### PR TITLE
Port to Zig 0.16.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 zig-cache/
 zig-out/
 .zig-cache/
+zig-pkg/
 
 # Build artifacts
 build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Outboxx is a lightweight PostgreSQL Change Data Capture (CDC) tool written in Zi
 - ✅ **Kafka Integration**: Producer implementation with at-least-once delivery
 - ✅ **Comprehensive Testing**: Unit, integration, and E2E tests with real services
 - ✅ **Development Environment**: Docker Compose setup with PostgreSQL and Kafka
-- ✅ **Nix Environment**: Isolated, reproducible development environment with Zig 0.15.1
+- ✅ **Nix Environment**: Isolated, reproducible development environment with Zig 0.16.0
 - ✅ **Performance Validated**: High-throughput benchmarks completed, significantly lower memory footprint than JVM alternatives
 
 ## Development Workflow
@@ -487,11 +487,13 @@ outboxx --config config.toml > output.log
 const print = std.debug.print;
 print("Outboxx - PostgreSQL CDC\n", .{});
 
-// ✅ CORRECT: Use stdout for user messages (Zig 0.15.1)
+// ✅ CORRECT: Use stdout for user messages (Zig 0.16.0)
+// `io` comes from the `std.process.Init` parameter of `main`.
 var buf: [4096]u8 = undefined;
-const formatted = try std.fmt.bufPrint(&buf, "Outboxx - PostgreSQL CDC\n", .{});
-const stdout_file = std.fs.File.stdout();
-try stdout_file.writeAll(formatted);
+var stdout_writer = std.Io.File.stdout().writer(io, &buf);
+const w = &stdout_writer.interface;
+try w.print("Outboxx - PostgreSQL CDC\n", .{});
+try w.flush();
 ```
 
 **For logging (anywhere in codebase):**
@@ -503,18 +505,20 @@ std.log.warn("Connection retry...", .{});
 std.log.err("Fatal error", .{});
 ```
 
-**Simple wrapper for error handling (Zig 0.15.1):**
+**Simple wrapper for error handling (Zig 0.16.0):**
 
 ```zig
+// `stdout_io` is a file-scope `std.Io` captured from main's `std.process.Init`.
 fn printStatus(comptime fmt: []const u8, args: anytype) void {
     var buf: [4096]u8 = undefined;
-    const formatted = std.fmt.bufPrint(&buf, fmt, args) catch |err| {
-        std.log.warn("Failed to format message: {}", .{err});
+    var stdout_writer = std.Io.File.stdout().writer(stdout_io, &buf);
+    const w = &stdout_writer.interface;
+    w.print(fmt, args) catch |err| {
+        std.log.warn("Failed to write to stdout: {}", .{err});
         return;
     };
-    const stdout_file = std.fs.File.stdout();
-    stdout_file.writeAll(formatted) catch |err| {
-        std.log.warn("Failed to write to stdout: {}", .{err});
+    w.flush() catch |err| {
+        std.log.warn("Failed to flush stdout: {}", .{err});
     };
 }
 

--- a/build.zig
+++ b/build.zig
@@ -56,6 +56,17 @@ pub fn build(b: *std.Build) void {
     addCHeadersT(b, c_rdkafka);
     const c_rdkafka_module = c_rdkafka.createModule();
 
+    // Shared libpq bindings via build-system C translation (Zig 0.16),
+    // imported as "c" by every module that uses libpq.
+    const c_pq = b.addTranslateC(.{
+        .root_source_file = b.path("src/c/pq.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+    addCHeadersT(b, c_pq);
+    const c_pq_module = c_pq.createModule();
+    postgres_source_module.addImport("c", c_pq_module);
+
     // Kafka producer module
     const kafka_producer_module = b.createModule(.{
         .root_source_file = b.path("src/kafka/producer.zig"),
@@ -96,6 +107,7 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addImport("config", config_module);
     exe.root_module.addImport("postgres_source", postgres_source_module);
     exe.root_module.addImport("constants", constants_module);
+    exe.root_module.addImport("c", c_pq_module);
 
     // Link libc for PostgreSQL and Kafka C libraries
     exe.root_module.link_libc = true;
@@ -105,11 +117,6 @@ pub fn build(b: *std.Build) void {
 
     // Add Kafka library (librdkafka)
     exe.root_module.linkSystemLibrary("rdkafka", .{});
-
-    // C headers (libpq / librdkafka) are needed by every module that performs a
-    // @cImport. In Zig 0.16 include paths are per-module, so apply them to each.
-    addCHeaders(b, exe.root_module);
-    addCHeaders(b, postgres_source_module);
 
     b.installArtifact(exe);
 
@@ -170,9 +177,9 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    replication_protocol_tests.root_module.addImport("c", c_pq_module);
     replication_protocol_tests.root_module.link_libc = true;
     replication_protocol_tests.root_module.linkSystemLibrary("pq", .{});
-    addCHeaders(b, replication_protocol_tests.root_module);
 
     // PgOutputDecoder tests
     const pg_output_decoder_tests = b.addTest(.{
@@ -202,9 +209,9 @@ pub fn build(b: *std.Build) void {
     });
     streaming_source_tests.root_module.addImport("domain", domain_module);
     streaming_source_tests.root_module.addImport("constants", constants_module);
+    streaming_source_tests.root_module.addImport("c", c_pq_module);
     streaming_source_tests.root_module.link_libc = true;
     streaming_source_tests.root_module.linkSystemLibrary("pq", .{});
-    addCHeaders(b, streaming_source_tests.root_module);
 
     // Streaming replication integration tests
     const streaming_integration_tests = b.addTest(.{
@@ -216,9 +223,9 @@ pub fn build(b: *std.Build) void {
     });
     streaming_integration_tests.root_module.addImport("domain", domain_module);
     streaming_integration_tests.root_module.addImport("constants", constants_module);
+    streaming_integration_tests.root_module.addImport("c", c_pq_module);
     streaming_integration_tests.root_module.link_libc = true;
     streaming_integration_tests.root_module.linkSystemLibrary("pq", .{});
-    addCHeaders(b, streaming_integration_tests.root_module);
 
     // Validator tests
     const validator_tests = b.addTest(.{
@@ -228,9 +235,9 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    validator_tests.root_module.addImport("c", c_pq_module);
     validator_tests.root_module.link_libc = true;
     validator_tests.root_module.linkSystemLibrary("pq", .{});
-    addCHeaders(b, validator_tests.root_module);
 
     // Test helpers module (shared utilities for all tests)
     const test_helpers_module = b.createModule(.{

--- a/build.zig
+++ b/build.zig
@@ -45,6 +45,17 @@ pub fn build(b: *std.Build) void {
     postgres_source_module.addImport("domain", domain_module);
     postgres_source_module.addImport("constants", constants_module);
 
+    // Shared librdkafka bindings via build-system C translation (Zig 0.16).
+    // One translation, imported as "c" by every module that uses librdkafka,
+    // so the generated C types are identical across modules.
+    const c_rdkafka = b.addTranslateC(.{
+        .root_source_file = b.path("src/c/rdkafka.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+    addCHeadersT(b, c_rdkafka);
+    const c_rdkafka_module = c_rdkafka.createModule();
+
     // Kafka producer module
     const kafka_producer_module = b.createModule(.{
         .root_source_file = b.path("src/kafka/producer.zig"),
@@ -52,6 +63,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     kafka_producer_module.addImport("constants", constants_module);
+    kafka_producer_module.addImport("c", c_rdkafka_module);
 
     // Processor module with all dependencies
     const cdc_processor_module = b.createModule(.{
@@ -98,7 +110,6 @@ pub fn build(b: *std.Build) void {
     // @cImport. In Zig 0.16 include paths are per-module, so apply them to each.
     addCHeaders(b, exe.root_module);
     addCHeaders(b, postgres_source_module);
-    addCHeaders(b, kafka_producer_module);
 
     b.installArtifact(exe);
 
@@ -147,9 +158,9 @@ pub fn build(b: *std.Build) void {
         }),
     });
     kafka_producer_tests.root_module.addImport("constants", constants_module);
+    kafka_producer_tests.root_module.addImport("c", c_rdkafka_module);
     kafka_producer_tests.root_module.link_libc = true;
     kafka_producer_tests.root_module.linkSystemLibrary("rdkafka", .{});
-    addCHeaders(b, kafka_producer_tests.root_module);
 
     // ReplicationProtocol tests
     const replication_protocol_tests = b.addTest(.{
@@ -284,6 +295,7 @@ pub fn build(b: *std.Build) void {
         }),
     });
     kafka_integration_tests.root_module.addImport("constants", constants_module);
+    kafka_integration_tests.root_module.addImport("c", c_rdkafka_module);
     kafka_integration_tests.root_module.link_libc = true;
     kafka_integration_tests.root_module.linkSystemLibrary("rdkafka", .{});
     addCHeaders(b, kafka_integration_tests.root_module);
@@ -494,5 +506,20 @@ fn addCHeaders(b: *std.Build, module: *std.Build.Module) void {
     } else {
         // Fallback to standard system paths
         module.addIncludePath(.{ .cwd_relative = "/usr/include/postgresql" });
+    }
+}
+
+/// Same as `addCHeaders`, but for a translate-c step (used so the C translation
+/// can locate libpq / librdkafka system headers).
+fn addCHeadersT(b: *std.Build, translate_c: *std.Build.Step.TranslateC) void {
+    if (b.graph.environ_map.get("C_INCLUDE_PATH")) |include_path| {
+        var it = std.mem.splitScalar(u8, include_path, ':');
+        while (it.next()) |path| {
+            if (path.len > 0) {
+                translate_c.addIncludePath(.{ .cwd_relative = path });
+            }
+        }
+    } else {
+        translate_c.addIncludePath(.{ .cwd_relative = "/usr/include/postgresql" });
     }
 }

--- a/build.zig
+++ b/build.zig
@@ -7,11 +7,6 @@ pub fn build(b: *std.Build) void {
     // Standard optimization options allow the person running zig build to pick the optimization level
     const optimize = b.standardOptimizeOption(.{});
 
-    // Add TOML dependency, sadly it was not working with 0.15.1 zig version
-    // TODO: Check it later again
-    const toml_dep = b.dependency("toml", .{});
-    const toml_module = toml_dep.module("toml");
-
     // Constants module (application-wide constants)
     const constants_module = b.createModule(.{
         .root_source_file = b.path("src/constants.zig"),
@@ -83,7 +78,6 @@ pub fn build(b: *std.Build) void {
     });
 
     // Dependencies for the main executable
-    exe.root_module.addImport("toml", toml_module);
     exe.root_module.addImport("domain", domain_module);
     exe.root_module.addImport("json_serialization", json_serialization_module);
     exe.root_module.addImport("kafka_producer", kafka_producer_module);
@@ -92,27 +86,19 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addImport("constants", constants_module);
 
     // Link libc for PostgreSQL and Kafka C libraries
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     // Add PostgreSQL library (libpq)
-    exe.linkSystemLibrary("pq");
+    exe.root_module.linkSystemLibrary("pq", .{});
 
     // Add Kafka library (librdkafka)
-    exe.linkSystemLibrary("rdkafka");
+    exe.root_module.linkSystemLibrary("rdkafka", .{});
 
-    // Add include paths from environment (useful for Nix and custom installs)
-    if (std.process.getEnvVarOwned(b.allocator, "C_INCLUDE_PATH")) |include_path| {
-        defer b.allocator.free(include_path);
-        var it = std.mem.splitScalar(u8, include_path, ':');
-        while (it.next()) |path| {
-            if (path.len > 0) {
-                exe.addIncludePath(.{ .cwd_relative = path });
-            }
-        }
-    } else |_| {
-        // Fallback to standard system paths
-        exe.addIncludePath(.{ .cwd_relative = "/usr/include/postgresql" });
-    }
+    // C headers (libpq / librdkafka) are needed by every module that performs a
+    // @cImport. In Zig 0.16 include paths are per-module, so apply them to each.
+    addCHeaders(b, exe.root_module);
+    addCHeaders(b, postgres_source_module);
+    addCHeaders(b, kafka_producer_module);
 
     b.installArtifact(exe);
 
@@ -136,7 +122,6 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    config_tests.root_module.addImport("toml", toml_module);
 
     // Domain layer tests (new)
     const domain_tests = b.addTest(.{
@@ -162,8 +147,9 @@ pub fn build(b: *std.Build) void {
         }),
     });
     kafka_producer_tests.root_module.addImport("constants", constants_module);
-    kafka_producer_tests.linkLibC();
-    kafka_producer_tests.linkSystemLibrary("rdkafka");
+    kafka_producer_tests.root_module.link_libc = true;
+    kafka_producer_tests.root_module.linkSystemLibrary("rdkafka", .{});
+    addCHeaders(b, kafka_producer_tests.root_module);
 
     // ReplicationProtocol tests
     const replication_protocol_tests = b.addTest(.{
@@ -173,8 +159,9 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    replication_protocol_tests.linkLibC();
-    replication_protocol_tests.linkSystemLibrary("pq");
+    replication_protocol_tests.root_module.link_libc = true;
+    replication_protocol_tests.root_module.linkSystemLibrary("pq", .{});
+    addCHeaders(b, replication_protocol_tests.root_module);
 
     // PgOutputDecoder tests
     const pg_output_decoder_tests = b.addTest(.{
@@ -204,8 +191,9 @@ pub fn build(b: *std.Build) void {
     });
     streaming_source_tests.root_module.addImport("domain", domain_module);
     streaming_source_tests.root_module.addImport("constants", constants_module);
-    streaming_source_tests.linkLibC();
-    streaming_source_tests.linkSystemLibrary("pq");
+    streaming_source_tests.root_module.link_libc = true;
+    streaming_source_tests.root_module.linkSystemLibrary("pq", .{});
+    addCHeaders(b, streaming_source_tests.root_module);
 
     // Streaming replication integration tests
     const streaming_integration_tests = b.addTest(.{
@@ -217,8 +205,9 @@ pub fn build(b: *std.Build) void {
     });
     streaming_integration_tests.root_module.addImport("domain", domain_module);
     streaming_integration_tests.root_module.addImport("constants", constants_module);
-    streaming_integration_tests.linkLibC();
-    streaming_integration_tests.linkSystemLibrary("pq");
+    streaming_integration_tests.root_module.link_libc = true;
+    streaming_integration_tests.root_module.linkSystemLibrary("pq", .{});
+    addCHeaders(b, streaming_integration_tests.root_module);
 
     // Validator tests
     const validator_tests = b.addTest(.{
@@ -228,8 +217,9 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    validator_tests.linkLibC();
-    validator_tests.linkSystemLibrary("pq");
+    validator_tests.root_module.link_libc = true;
+    validator_tests.root_module.linkSystemLibrary("pq", .{});
+    addCHeaders(b, validator_tests.root_module);
 
     // Test helpers module (shared utilities for all tests)
     const test_helpers_module = b.createModule(.{
@@ -238,6 +228,8 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     test_helpers_module.addImport("config", config_module);
+    test_helpers_module.link_libc = true;
+    addCHeaders(b, test_helpers_module);
 
     // Add test_helpers to integration tests
     replication_protocol_tests.root_module.addImport("test_helpers", test_helpers_module);
@@ -276,9 +268,10 @@ pub fn build(b: *std.Build) void {
     e2e_streaming_test.root_module.addImport("cdc_processor", cdc_processor_module);
     e2e_streaming_test.root_module.addImport("config", config_module);
     e2e_streaming_test.root_module.addImport("postgres_source", postgres_source_module);
-    e2e_streaming_test.linkLibC();
-    e2e_streaming_test.linkSystemLibrary("pq");
-    e2e_streaming_test.linkSystemLibrary("rdkafka");
+    e2e_streaming_test.root_module.link_libc = true;
+    e2e_streaming_test.root_module.linkSystemLibrary("pq", .{});
+    e2e_streaming_test.root_module.linkSystemLibrary("rdkafka", .{});
+    addCHeaders(b, e2e_streaming_test.root_module);
 
     const run_e2e_streaming_test = b.addRunArtifact(e2e_streaming_test);
 
@@ -291,8 +284,9 @@ pub fn build(b: *std.Build) void {
         }),
     });
     kafka_integration_tests.root_module.addImport("constants", constants_module);
-    kafka_integration_tests.linkLibC();
-    kafka_integration_tests.linkSystemLibrary("rdkafka");
+    kafka_integration_tests.root_module.link_libc = true;
+    kafka_integration_tests.root_module.linkSystemLibrary("rdkafka", .{});
+    addCHeaders(b, kafka_integration_tests.root_module);
 
     const run_kafka_integration_tests = b.addRunArtifact(kafka_integration_tests);
     const run_streaming_integration_tests = b.addRunArtifact(streaming_integration_tests);
@@ -317,8 +311,8 @@ pub fn build(b: *std.Build) void {
             .optimize = .Debug,
         }),
     });
-    debug_exe.linkLibC();
-    debug_exe.linkSystemLibrary("pq");
+    debug_exe.root_module.link_libc = true;
+    debug_exe.root_module.linkSystemLibrary("pq", .{});
 
     const debug_install = b.addInstallArtifact(debug_exe, .{});
     const debug_step = b.step("debug", "Build debug version");
@@ -333,8 +327,8 @@ pub fn build(b: *std.Build) void {
             .optimize = .ReleaseSmall,
         }),
     });
-    release_small_exe.linkLibC();
-    release_small_exe.linkSystemLibrary("pq");
+    release_small_exe.root_module.link_libc = true;
+    release_small_exe.root_module.linkSystemLibrary("pq", .{});
 
     const release_small_install = b.addInstallArtifact(release_small_exe, .{});
     const release_small_step = b.step("release-small", "Build release version optimized for size");
@@ -356,11 +350,10 @@ pub fn build(b: *std.Build) void {
     fmt_fix_step.dependOn(&fmt.step);
 
     // Clean build artifacts
+    // Note: Zig 0.16 removed Build.addRemoveDirTree; use a system command instead.
     const clean_step = b.step("clean", "Clean build artifacts");
-    const remove_zig_out = b.addRemoveDirTree(b.path("zig-out"));
-    const remove_zig_cache = b.addRemoveDirTree(b.path(".zig-cache"));
-    clean_step.dependOn(&remove_zig_out.step);
-    clean_step.dependOn(&remove_zig_cache.step);
+    const remove_artifacts = b.addSystemCommand(&.{ "rm", "-rf", "zig-out", ".zig-cache" });
+    clean_step.dependOn(&remove_artifacts.step);
 
     // Development workflow: format, test, and build
     const dev_step = b.step("dev", "Development workflow: format, test, and build");
@@ -386,7 +379,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = .ReleaseFast,
     });
-
 
     const serializer_bench = b.addTest(.{
         .name = "serializer_bench",
@@ -457,8 +449,9 @@ pub fn build(b: *std.Build) void {
     kafka_bench.root_module.addImport("zbench", zbench_module);
     kafka_bench.root_module.addImport("kafka_producer", kafka_producer_module);
     kafka_bench.root_module.addImport("bench_helpers", bench_helpers_module);
-    kafka_bench.linkLibC();
-    kafka_bench.linkSystemLibrary("rdkafka");
+    kafka_bench.root_module.link_libc = true;
+    kafka_bench.root_module.linkSystemLibrary("rdkafka", .{});
+    addCHeaders(b, kafka_bench.root_module);
 
     const install_kafka_bench = b.addInstallArtifact(kafka_bench, .{});
 
@@ -484,4 +477,22 @@ pub fn build(b: *std.Build) void {
     bench_step.dependOn(&install_partition_key_bench.step);
     bench_step.dependOn(&install_kafka_bench.step);
     bench_step.dependOn(&install_message_processor_bench.step);
+}
+
+/// Add C include paths (libpq / librdkafka headers) to a module.
+/// In Zig 0.16, @cImport resolves include paths per-module, so this must be
+/// applied to every module that performs a @cImport. Paths come from
+/// C_INCLUDE_PATH (set by the Nix dev shell) with a system fallback.
+fn addCHeaders(b: *std.Build, module: *std.Build.Module) void {
+    if (b.graph.environ_map.get("C_INCLUDE_PATH")) |include_path| {
+        var it = std.mem.splitScalar(u8, include_path, ':');
+        while (it.next()) |path| {
+            if (path.len > 0) {
+                module.addIncludePath(.{ .cwd_relative = path });
+            }
+        }
+    } else {
+        // Fallback to standard system paths
+        module.addIncludePath(.{ .cwd_relative = "/usr/include/postgresql" });
+    }
 }

--- a/build.zig
+++ b/build.zig
@@ -67,6 +67,16 @@ pub fn build(b: *std.Build) void {
     const c_pq_module = c_pq.createModule();
     postgres_source_module.addImport("c", c_pq_module);
 
+    // Combined libpq + librdkafka bindings, imported as "c" by the shared test
+    // helpers (which touch both PostgreSQL and Kafka).
+    const c_pqrdkafka = b.addTranslateC(.{
+        .root_source_file = b.path("src/c/pq_rdkafka.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+    addCHeadersT(b, c_pqrdkafka);
+    const c_pqrdkafka_module = c_pqrdkafka.createModule();
+
     // Kafka producer module
     const kafka_producer_module = b.createModule(.{
         .root_source_file = b.path("src/kafka/producer.zig"),
@@ -246,8 +256,8 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     test_helpers_module.addImport("config", config_module);
+    test_helpers_module.addImport("c", c_pqrdkafka_module);
     test_helpers_module.link_libc = true;
-    addCHeaders(b, test_helpers_module);
 
     // Add test_helpers to integration tests
     replication_protocol_tests.root_module.addImport("test_helpers", test_helpers_module);
@@ -289,7 +299,6 @@ pub fn build(b: *std.Build) void {
     e2e_streaming_test.root_module.link_libc = true;
     e2e_streaming_test.root_module.linkSystemLibrary("pq", .{});
     e2e_streaming_test.root_module.linkSystemLibrary("rdkafka", .{});
-    addCHeaders(b, e2e_streaming_test.root_module);
 
     const run_e2e_streaming_test = b.addRunArtifact(e2e_streaming_test);
 
@@ -305,7 +314,6 @@ pub fn build(b: *std.Build) void {
     kafka_integration_tests.root_module.addImport("c", c_rdkafka_module);
     kafka_integration_tests.root_module.link_libc = true;
     kafka_integration_tests.root_module.linkSystemLibrary("rdkafka", .{});
-    addCHeaders(b, kafka_integration_tests.root_module);
 
     const run_kafka_integration_tests = b.addRunArtifact(kafka_integration_tests);
     const run_streaming_integration_tests = b.addRunArtifact(streaming_integration_tests);
@@ -468,9 +476,9 @@ pub fn build(b: *std.Build) void {
     kafka_bench.root_module.addImport("zbench", zbench_module);
     kafka_bench.root_module.addImport("kafka_producer", kafka_producer_module);
     kafka_bench.root_module.addImport("bench_helpers", bench_helpers_module);
+    kafka_bench.root_module.addImport("c", c_rdkafka_module);
     kafka_bench.root_module.link_libc = true;
     kafka_bench.root_module.linkSystemLibrary("rdkafka", .{});
-    addCHeaders(b, kafka_bench.root_module);
 
     const install_kafka_bench = b.addInstallArtifact(kafka_bench, .{});
 
@@ -498,26 +506,9 @@ pub fn build(b: *std.Build) void {
     bench_step.dependOn(&install_message_processor_bench.step);
 }
 
-/// Add C include paths (libpq / librdkafka headers) to a module.
-/// In Zig 0.16, @cImport resolves include paths per-module, so this must be
-/// applied to every module that performs a @cImport. Paths come from
+/// Add C include paths (libpq / librdkafka headers) to a translate-c step, so
+/// the C translation can locate the system headers. Paths come from
 /// C_INCLUDE_PATH (set by the Nix dev shell) with a system fallback.
-fn addCHeaders(b: *std.Build, module: *std.Build.Module) void {
-    if (b.graph.environ_map.get("C_INCLUDE_PATH")) |include_path| {
-        var it = std.mem.splitScalar(u8, include_path, ':');
-        while (it.next()) |path| {
-            if (path.len > 0) {
-                module.addIncludePath(.{ .cwd_relative = path });
-            }
-        }
-    } else {
-        // Fallback to standard system paths
-        module.addIncludePath(.{ .cwd_relative = "/usr/include/postgresql" });
-    }
-}
-
-/// Same as `addCHeaders`, but for a translate-c step (used so the C translation
-/// can locate libpq / librdkafka system headers).
 fn addCHeadersT(b: *std.Build, translate_c: *std.Build.Step.TranslateC) void {
     if (b.graph.environ_map.get("C_INCLUDE_PATH")) |include_path| {
         var it = std.mem.splitScalar(u8, include_path, ':');

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,14 +1,11 @@
 .{
     .name = .outboxx,
     .version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
-        .toml = .{
-            .url = "git+https://github.com/sam701/zig-toml?ref=zig-0.15#475b03c630c802f8b6bd3e239d8fc2279b4fadb8",
-            .hash = "toml-0.3.0-bV14BfV7AQD8DkuQI7skP8ekQTaBYKTO0MY_35Cw_EXo",
-        },
         .zbench = .{
-            .url = "https://github.com/hendriknielaender/zbench/archive/463f8d5349daf72430697c9fe42cfe0a68729859.tar.gz",
-            .hash = "zbench-0.11.1-YTdc7zgmAQDtDcHPFwsLeawui27WjMLWmUwrfz7pIlB2",
+            .url = "https://github.com/hendriknielaender/zbench/archive/refs/tags/v0.13.0.tar.gz",
+            .hash = "zbench-0.13.0-YTdc7xVBAQCCMC-IdLLuotBeiNNNm8k9Pi2V4VYqrwfI",
         },
     },
     .paths = .{""},

--- a/docs/zig-0.16-migration-plan.md
+++ b/docs/zig-0.16-migration-plan.md
@@ -1,0 +1,96 @@
+# Port Outboxx from Zig 0.15.1 → Zig 0.16.0
+
+## Context
+
+The project is written against **Zig 0.15.1** (see `build.zig.zon` comment pinning the `toml` dep to a `zig-0.15` branch, and `CLAUDE.md`). The active toolchain is now **Zig 0.16.0** (`zig version` → `0.16.0`), and `zig build` fails immediately:
+
+```
+build.zig:95:8: error: no field or member function named 'linkLibC' in 'Build.Step.Compile'
+```
+
+Goal: port to **0.16.0**, doing the smallest mechanical changes first to get a **green, working build + tests**, then a **full idiomatic modernization** that embraces what 0.16 introduced. Scope is **everything**: app + unit/integration/e2e tests + benchmarks + tooling/docs. Each phase must end at a green `zig build` target.
+
+### Why this port is smaller than a typical Zig version bump
+The codebase is already on bleeding-edge 0.15.1 idioms that happen to match 0.16:
+- Unmanaged containers already: `std.ArrayList(T).empty`, `.append(allocator, …)`, `.deinit(allocator)`, `.toOwnedSlice(allocator)`, `std.AutoHashMap`, `std.StringHashMap`. **No change needed.**
+- `callconv(.c)` (lowercase) already used. `posix.Sigaction` / `posix.sigaction` / `posix.SIG.INT` signatures still match. `std.json.Value` / `parseFromSlice` / `validate` unchanged. `std.mem.indexOf`/`indexOfScalar`/`lastIndexOf` are now **aliases** to `find*` (present, not removed). `splitSequence`/`splitScalar` present.
+
+### What actually breaks (grounded against the installed 0.16.0 stdlib)
+1. **Build system** — `linkLibC` / `linkSystemLibrary` / `addIncludePath` moved off `*Step.Compile` onto `*Build.Module`. Every `addExecutable`/`addTest` in `build.zig` calls these → must move to `.root_module` (or set on the created modules). *Blocks all compilation.*
+2. **"Juicy Main" + non-global IO/env/args** — `std.process.argsAlloc/argsFree` and `std.process.getEnvVarOwned` are **gone**. The supported way to get args/env/io is `pub fn main(init: std.process.Init) !void`, where `init` provides `io`, `gpa`, `arena`, `minimal.args`, `environ_map`.
+3. **IO-as-an-interface / fs reorg** — `std.fs.File` → `std.Io.File`; file writers/readers now take an `io` arg: `Io.File.stdout().writer(io, &buf)`, `dir.readFileAlloc(io, …)`. `File.readToEndAlloc` removed.
+4. **Writer** — `ArrayList.writer(allocator)` removed → `std.Io.Writer.Allocating` (has `.fromArrayList`, `.toArrayList`, interface at `&aw.writer`). The serializer helpers already take `writer: anytype` and use `.writeAll/.print/.writeByte`, which exist on `*std.Io.Writer` — so only the writer *construction* changes.
+5. **`@cImport` deprecated** (still compiles in 0.16, emits deprecation) — keep for "make it work", migrate to `b.addTranslateC` during modernization.
+6. **`toml` dependency is unused** — `@import("toml")` appears nowhere in `src/`; config uses its own `ConfigParser`. Dropping it removes the `zig-0.15`-pinned blocker.
+
+---
+
+## Part A — Make it work (each phase ends green)
+
+### Phase 1 — Toolchain pin + build system + app + unit tests green
+**Milestone:** `zig build` (exe) **and** `zig build test` (all unit tests) pass.
+
+- **Pin toolchain:** add `.zigversion` / mise pin `0.16.0`; set `minimum_zig_version = "0.16.0"` in `build.zig.zon`.
+- **`build.zig`:** move `linkLibC()` / `linkSystemLibrary("pq"|"rdkafka")` / `addIncludePath()` from each compile step onto its `.root_module` (e.g. `exe.root_module.linkLibC()`), for the exe and the unit-test steps (`config_tests`, `domain_tests`, `json_serialization_tests`, `pg_output_decoder_tests`, `relation_registry_tests`, `streaming_source_tests`, plus `debug_exe`/`release_small_exe`). **Drop the `toml` dependency** from `build.zig.zon` and its two `addImport("toml", …)` uses in `build.zig`.
+- **`src/main.zig`:** adopt `pub fn main(init: std.process.Init) !void` (replaces current `main() void` + `run()`). Source `io` from `init.io`; replace `std.process.argsAlloc` (in `parseConfigPath`) with `init.minimal.args`; replace `std.fs.File.stdout()` + `writeAll` (in `printStatus`) with `std.Io.File.stdout().writer(io, &buf)` + `&w.interface`. Minimal approach: stash `io` in a file-scope `var` (like the existing `shutdown_requested`) so `printStatus`/`printBanner` need no signature change — proper threading is Phase 6. Keep the leak-checking GPA (or use `init.gpa`).
+- **`src/config/config.zig`:** the file-read path (`parseFile` → `readToEndAlloc`, line ~529) and `loadPasswords` (`getEnvVarOwned`, lines ~147/159) need `io`/env. Thread `io` into `loadFromTomlFile`/`parseFile` and use `std.Io.Dir.readFileAlloc(io, …)`; change `getEnvVarOwned` to an `init.environ_map` lookup (pass the map or `io`). Note: most of `config_test.zig` exercises `parseToml(content)` (pure string, no io) and is unaffected; only file-read / password tests need the new args.
+- **`src/serialization/json.zig`:** replace `var output = std.ArrayList(u8).empty; const writer = output.writer(allocator);` with `std.Io.Writer.Allocating` (init with allocator), pass `&aw.writer` to the existing `serialize*` helpers, then `aw.toArrayList()` / take the owned slice. Helper fns (`serializeDataSection`/`serializeRow`/`serializeValue`) are unchanged.
+- Confirm `domain/change_event.zig`, `pg_output_decoder.zig`, `relation_registry.zig`, `source/postgres/source.zig` compile as-is (expected: only the build.zig link moves were needed).
+
+### Phase 2 — Integration + E2E green
+**Milestone:** `zig build test-integration` and `zig build test-e2e` compile; pass with `make env-up` services running.
+
+- **`build.zig`:** apply the same `.root_module` link move to the integration/e2e steps: `kafka_producer_tests`, `kafka_integration_tests`, `streaming_integration_tests`, `replication_protocol_tests`, `validator_tests`, `e2e_streaming_test`.
+- Fix any `io`/file/writer/stdout usage in `tests/test_helpers.zig`, `src/source/postgres/integration_test.zig`, `replication_protocol_test.zig`, `validator_test.zig`, `source_test.zig`, `src/kafka/producer_test.zig`, `tests/e2e/cdc_test.zig`. Most are libpq/librdkafka C calls + `std.fmt.allocPrint` (unaffected); the likely touch-points are any `std.fs.File`/stdout usage and test `main`/io plumbing.
+
+### Phase 3 — Benchmarks green
+**Milestone:** `zig build bench` compiles; `./zig-out/bin/*_bench` run.
+
+- **`build.zig`:** `.root_module` link move for `kafka_bench`; verify the `zbench` dependency builds under 0.16 and **bump its ref if needed** (it's pinned to a specific commit).
+- **`tests/benchmarks/components/*.zig`:** replace `std.fs.File.stdout().writer(&buf)` with `std.Io.File.stdout().writer(io, &buf)` and give each bench `main` access to `io` (juicy main). Check `tests/benchmarks/bench_helpers.zig`.
+
+### Phase 4 — Tooling & docs
+**Milestone:** CI and dev environment target 0.16; docs consistent.
+
+- `flake.nix`: ensure the `zig` package resolves to 0.16.x (nixpkgs-unstable likely already provides it; pin if necessary).
+- `.github/workflows/*.yml`: bump the Zig setup/version.
+- `Makefile`: any version assertions/messages.
+- `CLAUDE.md`: update all `0.15.1` references to `0.16.0`; fix the stdout example (currently shows `std.fs.File.stdout()`).
+
+---
+
+## Part B — Modernize (idiomatic 0.16, each an independently green refactor)
+
+### Phase 5 — Replace deprecated `@cImport` with `b.addTranslateC`
+Create a single `src/c.h` (`#include <libpq-fe.h>` + `<librdkafka/rdkafka.h>` + `rdkafka_mock.h` for benches), add `b.addTranslateC(...)` modules in `build.zig`, and `const c = @import("c")` in the 5+ files currently doing file-scope `@cImport`. Removes the deprecation and centralizes C config.
+
+### Phase 6 — Idiomatic IO threading
+Replace the Phase-1 file-scope `io` shim with an explicit application context (carry `io`, allocator) threaded through `main` → config → (only the layers that touch std IO; postgres/kafka stay on C libs). Use `init.arena` for process-lifetime allocations where it simplifies cleanup. Introduce a single buffered stdout `std.Io.File.Writer` reused across `printStatus`/`printBanner` instead of per-call `bufPrint`.
+
+### Phase 7 — Serializer & stdlib idioms polish
+Finalize `json.zig` around `std.Io.Writer.Allocating` (or a pre-sized `Writer.fixed` fast path). Optionally adopt the new `std.mem.find`/`findScalar` names over the `indexOf` aliases for consistency with 0.16. Re-run benchmarks to confirm no regression vs the committed baseline.
+
+---
+
+## Verification
+
+Per phase, run the matching target (auto-loads the Nix env via the Makefile wrappers):
+
+```bash
+# Phase 1
+zig build && zig build test
+# Phase 2 (needs services)
+make env-up && zig build test-integration && zig build test-e2e
+# Phase 3
+zig build bench && ./zig-out/bin/serializer_bench
+# Whole pipeline regression
+make test            # unit + integration + e2e
+zig build fmt-check  # formatting gate used in CI
+```
+
+End-to-end smoke test of the built binary (real CDC path): `make env-up`, then run `./zig-out/bin/outboxx --config dev/config.toml`, perform an `INSERT` in PostgreSQL, and confirm a message arrives via `kafka-console-consumer`/`kcat` on the mapped topic.
+
+## Risks / watch-items
+- **`zbench` 0.16 compatibility** (Phase 3) is the most likely external blocker — may need a newer commit/fork.
+- **`std.Io.Dir.readFileAlloc` exact signature** and how `init.environ_map` exposes lookups: confirm against installed stdlib while editing `config.zig` (both verified to exist; only the precise call shape needs pinning down at implementation time).
+- Keep `@cImport` working through Phase 1–4 (it only warns); don't let Phase 5 block the green build.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761672384,
-        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -51,8 +51,11 @@
           ];
 
           shellHook = ''
-            # Only set C_INCLUDE_PATH for header files (used by build.zig)
-            export C_INCLUDE_PATH="${pkgs.postgresql}/include:${rdkafka-latest}/include:''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+            # Only set C_INCLUDE_PATH for header files (used by build.zig).
+            # Use the `dev` outputs: the default (`out`) outputs contain no headers,
+            # which breaks the build-system translate-c step (it only honors -I,
+            # unlike @cImport which also reads NIX_CFLAGS_COMPILE).
+            export C_INCLUDE_PATH="${pkgs.postgresql.dev}/include:${rdkafka-latest.dev}/include:''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
 
             echo "Outboxx development environment ready"
           '';

--- a/src/c/pq.h
+++ b/src/c/pq.h
@@ -1,0 +1,4 @@
+/* Wrapper header for translate-c (Zig 0.16 build-system C translation).
+ * Shared across all modules that use libpq so the generated C types
+ * are identical everywhere. */
+#include <libpq-fe.h>

--- a/src/c/pq_rdkafka.h
+++ b/src/c/pq_rdkafka.h
@@ -1,0 +1,5 @@
+/* Wrapper header for translate-c (Zig 0.16 build-system C translation).
+ * Combined libpq + librdkafka bindings, used by the shared test helpers which
+ * touch both PostgreSQL and Kafka. */
+#include <libpq-fe.h>
+#include <librdkafka/rdkafka.h>

--- a/src/c/rdkafka.h
+++ b/src/c/rdkafka.h
@@ -1,0 +1,4 @@
+/* Wrapper header for translate-c (Zig 0.16 build-system C translation).
+ * Shared across all modules that use librdkafka so the generated C types
+ * are identical everywhere. */
+#include <librdkafka/rdkafka.h>

--- a/src/c/rdkafka.h
+++ b/src/c/rdkafka.h
@@ -1,4 +1,5 @@
 /* Wrapper header for translate-c (Zig 0.16 build-system C translation).
  * Shared across all modules that use librdkafka so the generated C types
- * are identical everywhere. */
+ * are identical everywhere. Includes the mock API used by benchmarks. */
 #include <librdkafka/rdkafka.h>
+#include <librdkafka/rdkafka_mock.h>

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -141,28 +141,24 @@ pub const Config = struct {
     }
 
     /// Load passwords from environment variables based on config
-    pub fn loadPasswords(self: *Config, allocator: std.mem.Allocator) !void {
+    pub fn loadPasswords(self: *Config, allocator: std.mem.Allocator, environ_map: *std.process.Environ.Map) !void {
         // Load PostgreSQL password if configured
         if (self.source.postgres) |postgres| {
-            const password = std.process.getEnvVarOwned(allocator, postgres.password_env) catch |err| switch (err) {
-                error.EnvironmentVariableNotFound => {
-                    std.log.warn("Environment variable '{s}' not found", .{postgres.password_env});
-                    return err;
-                },
-                else => return err,
+            const value = environ_map.get(postgres.password_env) orelse {
+                std.log.warn("Environment variable '{s}' not found", .{postgres.password_env});
+                return error.EnvironmentVariableNotFound;
             };
+            const password = try allocator.dupe(u8, value);
             try self.runtime_passwords.put("postgres", password);
         }
 
         // Load MySQL password if configured
         if (self.source.mysql) |mysql| {
-            const password = std.process.getEnvVarOwned(allocator, mysql.password_env) catch |err| switch (err) {
-                error.EnvironmentVariableNotFound => {
-                    std.log.warn("Environment variable '{s}' not found", .{mysql.password_env});
-                    return err;
-                },
-                else => return err,
+            const value = environ_map.get(mysql.password_env) orelse {
+                std.log.warn("Environment variable '{s}' not found", .{mysql.password_env});
+                return error.EnvironmentVariableNotFound;
             };
+            const password = try allocator.dupe(u8, value);
             try self.runtime_passwords.put("mysql", password);
         }
     }
@@ -503,9 +499,9 @@ pub const Config = struct {
     }
 
     /// Load configuration from TOML file
-    pub fn loadFromTomlFile(allocator: std.mem.Allocator, file_path: []const u8) !Config {
+    pub fn loadFromTomlFile(io: std.Io, allocator: std.mem.Allocator, file_path: []const u8) !Config {
         var parser = ConfigParser.init(allocator);
-        return parser.parseFile(file_path);
+        return parser.parseFile(io, file_path);
     }
 };
 
@@ -520,13 +516,8 @@ pub const ConfigParser = struct {
     }
 
     /// Parse TOML config file
-    pub fn parseFile(self: *ConfigParser, file_path: []const u8) !Config {
-        const file = std.fs.cwd().openFile(file_path, .{}) catch |err| {
-            return err;
-        };
-        defer file.close();
-
-        const file_content = file.readToEndAlloc(self.allocator, 1024 * 1024) catch |err| {
+    pub fn parseFile(self: *ConfigParser, io: std.Io, file_path: []const u8) !Config {
+        const file_content = std.Io.Dir.cwd().readFileAlloc(io, file_path, self.allocator, .limited(1024 * 1024)) catch |err| {
             std.log.warn("Failed to read config file: {}", .{err});
             return err;
         };

--- a/src/config/config_test.zig
+++ b/src/config/config_test.zig
@@ -106,7 +106,7 @@ test "parse basic TOML config - file not found should fail" {
     const allocator = testing.allocator;
 
     // This should fail with FileNotFound error (fail fast)
-    const result = Config.loadFromTomlFile(allocator, "dummy_path");
+    const result = Config.loadFromTomlFile(testing.io, allocator, "dummy_path");
     try testing.expectError(error.FileNotFound, result);
 }
 
@@ -138,16 +138,12 @@ test "parse basic TOML config - real file" {
     ;
 
     // Write to temporary file
-    const temp_file = try std.fs.cwd().createFile("test_config.toml", .{});
-    defer {
-        temp_file.close();
-        std.fs.cwd().deleteFile("test_config.toml") catch {};
-    }
-
-    try temp_file.writeAll(temp_content);
+    const io = testing.io;
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = "test_config.toml", .data = temp_content });
+    defer std.Io.Dir.cwd().deleteFile(io, "test_config.toml") catch {};
 
     // Now parse the real file
-    var parsed_config = try Config.loadFromTomlFile(allocator, "test_config.toml");
+    var parsed_config = try Config.loadFromTomlFile(io, allocator, "test_config.toml");
     defer parsed_config.deinit(allocator);
 
     // Verify it was parsed correctly

--- a/src/domain/change_event.zig
+++ b/src/domain/change_event.zig
@@ -43,7 +43,7 @@ pub const RowData = []FieldData;
 pub const RowDataHelpers = struct {
     pub fn createBuilder(allocator: std.mem.Allocator) std.ArrayList(FieldData) {
         _ = allocator;
-        return std.ArrayList(FieldData){};
+        return std.ArrayList(FieldData).empty;
     }
 
     pub fn put(builder: *std.ArrayList(FieldData), allocator: std.mem.Allocator, field_name: []const u8, value: std.json.Value) !void {
@@ -188,7 +188,7 @@ pub const ChangeEvent = struct {
 test "ChangeEvent creation and memory management" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {
@@ -222,7 +222,7 @@ test "ChangeEvent creation and memory management" {
 test "RowDataHelpers field access" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {
@@ -251,7 +251,7 @@ test "RowDataHelpers field access" {
 test "UPDATE event with old and new data" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {
@@ -299,7 +299,7 @@ test "UPDATE event with old and new data" {
 test "getPartitionKeyValue extracts field values" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {

--- a/src/kafka/producer.zig
+++ b/src/kafka/producer.zig
@@ -1,7 +1,5 @@
 const std = @import("std");
-const c = @cImport({
-    @cInclude("librdkafka/rdkafka.h");
-});
+const c = @import("c"); // shared librdkafka bindings (build-system translate-c)
 const constants = @import("constants");
 
 const KafkaError = error{

--- a/src/kafka/producer_test.zig
+++ b/src/kafka/producer_test.zig
@@ -1,9 +1,7 @@
 const std = @import("std");
 const testing = std.testing;
 const KafkaProducer = @import("producer.zig").KafkaProducer;
-const c = @cImport({
-    @cInclude("librdkafka/rdkafka.h");
-});
+const c = @import("c"); // shared librdkafka bindings (build-system translate-c)
 
 // Simple function to verify message was written to Kafka
 fn verifyMessageWritten(allocator: std.mem.Allocator, brokers: []const u8, topic: []const u8, expected_payload: []const u8) !bool {

--- a/src/kafka/producer_test.zig
+++ b/src/kafka/producer_test.zig
@@ -68,7 +68,7 @@ test "Kafka integration tests" {
 }
 
 test "KafkaProducer can initialize and connect to Kafka" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {
@@ -85,7 +85,7 @@ test "KafkaProducer can initialize and connect to Kafka" {
 }
 
 test "KafkaProducer can send message to topic" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {
@@ -117,7 +117,7 @@ test "KafkaProducer can send message to topic" {
 }
 
 test "KafkaProducer can send messages to multiple topics" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {
@@ -158,7 +158,7 @@ test "KafkaProducer can send messages to multiple topics" {
 }
 
 test "KafkaProducer handles invalid broker gracefully" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {
@@ -184,7 +184,7 @@ test "KafkaProducer handles invalid broker gracefully" {
 }
 
 test "KafkaProducer memory management" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,16 +15,22 @@ pub const CliError = error{
 
 var shutdown_requested = std.atomic.Value(bool).init(false);
 
-pub fn main() void {
-    run() catch |err| {
+// Writing to stdout requires an Io instance in Zig 0.16. Stored here so the
+// printStatus/printBanner helpers can stay parameterless for now.
+// TODO(phase 6): thread `io` through an explicit app context instead of a global.
+var stdout_io: std.Io = undefined;
+
+pub fn main(init: std.process.Init) void {
+    stdout_io = init.io;
+    run(init) catch |err| {
         std.log.err("Fatal error: {}", .{err});
         std.process.exit(1);
     };
     std.process.exit(0);
 }
 
-fn run() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{
+fn run(init: std.process.Init) !void {
+    var gpa = std.heap.DebugAllocator(.{
         .safety = true,
         .retain_metadata = true,
     }){};
@@ -40,18 +46,18 @@ fn run() !void {
 
     printBanner();
 
-    const config_file_path = try parseConfigPath(allocator) orelse {
+    const config_file_path = try parseConfigPath(init.minimal.args, allocator) orelse {
         std.log.warn("config file is required. Use --config <path>", .{});
         return CliError.NoConfigPath;
     };
     defer allocator.free(config_file_path);
 
     printStatus("Loading configuration from: {s}\n", .{config_file_path});
-    var config = try Config.loadFromTomlFile(allocator, config_file_path);
+    var config = try Config.loadFromTomlFile(init.io, allocator, config_file_path);
     defer config.deinit(allocator);
 
     try config.validate(allocator);
-    try config.loadPasswords(allocator);
+    try config.loadPasswords(allocator, init.environ_map);
 
     printConfigInfo(config);
 
@@ -96,17 +102,18 @@ fn run() !void {
 /// For logs and diagnostics, use std.log.* (writes to stderr)
 fn printStatus(comptime fmt: []const u8, args: anytype) void {
     var buf: [4096]u8 = undefined;
-    const formatted = std.fmt.bufPrint(&buf, fmt, args) catch |err| {
-        std.log.warn("Failed to format message: {}", .{err});
+    var stdout_writer = std.Io.File.stdout().writer(stdout_io, &buf);
+    const w = &stdout_writer.interface;
+    w.print(fmt, args) catch |err| {
+        std.log.warn("Failed to write to stdout: {}", .{err});
         return;
     };
-    const stdout_file = std.fs.File.stdout();
-    stdout_file.writeAll(formatted) catch |err| {
-        std.log.warn("Failed to write to stdout: {}", .{err});
+    w.flush() catch |err| {
+        std.log.warn("Failed to flush stdout: {}", .{err});
     };
 }
 
-fn handleShutdownSignal(_: c_int) callconv(.c) void {
+fn handleShutdownSignal(_: posix.SIG) callconv(.c) void {
     shutdown_requested.store(true, .seq_cst);
     std.log.info("Shutdown signal received, initiating graceful shutdown...", .{});
 }
@@ -130,14 +137,16 @@ fn printBanner() void {
     printStatus("Build: {s}\n\n", .{@tagName(constants.BUILD_MODE)});
 }
 
-fn parseConfigPath(allocator: std.mem.Allocator) !?[]const u8 {
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+fn parseConfigPath(args: std.process.Args, allocator: std.mem.Allocator) !?[]const u8 {
+    var it = args.iterate();
+    defer it.deinit();
 
-    var i: usize = 1;
-    while (i < args.len) : (i += 1) {
-        if (std.mem.eql(u8, args[i], "--config") and i + 1 < args.len) {
-            return try allocator.dupe(u8, args[i + 1]);
+    _ = it.next(); // skip executable name (argv[0])
+    while (it.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--config")) {
+            if (it.next()) |path| {
+                return try allocator.dupe(u8, path);
+            }
         }
     }
 

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -50,7 +50,11 @@ fn flushCommitWorker(
     const flush_interval_iterations: u32 = @intCast(constants.CDC.KAFKA_FLUSH_INTERVAL_SEC);
 
     while (!stop_signal.load(.monotonic)) {
-        std.Thread.sleep(1 * std.time.ns_per_s);
+        // Zig 0.16 removed std.Thread.sleep (sleeping now goes through the Io
+        // interface); use libc nanosleep to avoid threading `io` into the flush
+        // thread. TODO(phase 6): replace with io.sleep once `io` is threaded.
+        var sleep_req: std.c.timespec = .{ .sec = 1, .nsec = 0 };
+        _ = std.c.nanosleep(&sleep_req, null);
         iterations += 1;
 
         if (iterations < flush_interval_iterations) {

--- a/src/serialization/json.zig
+++ b/src/serialization/json.zig
@@ -18,10 +18,10 @@ pub const JsonSerializer = struct {
         _ = self;
 
         // Use custom JSON writer for proper formatting
-        var output = std.ArrayList(u8).empty;
-        errdefer output.deinit(allocator);
+        var output: std.Io.Writer.Allocating = .init(allocator);
+        errdefer output.deinit();
 
-        const writer = output.writer(allocator);
+        const writer = &output.writer;
 
         try writer.writeAll("{\"op\":\"");
         try writer.writeAll(event.op);
@@ -50,7 +50,7 @@ pub const JsonSerializer = struct {
 
         try writer.writeAll("}}");
 
-        return output.toOwnedSlice(allocator);
+        return output.toOwnedSlice();
     }
 
     fn serializeDataSection(data: DataSection, writer: anytype) !void {
@@ -143,7 +143,7 @@ const FieldValueHelpers = domain.FieldValueHelpers;
 test "JsonSerializer serialize INSERT event" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {
@@ -188,7 +188,7 @@ test "JsonSerializer serialize INSERT event" {
 test "JsonSerializer serialize UPDATE event" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {
@@ -234,7 +234,7 @@ test "JsonSerializer serialize UPDATE event" {
 test "JsonSerializer validate JSON output is parseable" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {
@@ -279,7 +279,7 @@ test "JsonSerializer validate JSON output is parseable" {
 test "JsonSerializer string escaping" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer {
         const deinit_status = gpa.deinit();
         if (deinit_status == .leak) {

--- a/src/source/postgres/integration_test.zig
+++ b/src/source/postgres/integration_test.zig
@@ -84,9 +84,9 @@ test "Streaming source: receive and convert INSERT messages to ChangeEvents" {
     const allocator = testing.allocator;
 
     // Generate unique names for this test (timestamp + random to avoid collisions)
-    var prng = std.Random.DefaultPrng.init(@intCast(std.time.microTimestamp()));
+    var prng = std.Random.DefaultPrng.init(@intCast(test_helpers.nowMicros()));
     const random_suffix = prng.random().int(u32);
-    const timestamp = std.time.timestamp();
+    const timestamp = test_helpers.nowSeconds();
     const table_name = try std.fmt.allocPrint(allocator, "stream_test_{d}_{d}", .{ timestamp, random_suffix });
     defer allocator.free(table_name);
 
@@ -187,9 +187,9 @@ test "Streaming source: UPDATE operation E2E with old and new tuples" {
     const allocator = testing.allocator;
 
     // Generate unique names for this test (timestamp + random to avoid collisions)
-    var prng = std.Random.DefaultPrng.init(@intCast(std.time.microTimestamp()));
+    var prng = std.Random.DefaultPrng.init(@intCast(test_helpers.nowMicros()));
     const random_suffix = prng.random().int(u32);
-    const timestamp = std.time.timestamp();
+    const timestamp = test_helpers.nowSeconds();
     const table_name = try std.fmt.allocPrint(allocator, "stream_update_test_{d}_{d}", .{ timestamp, random_suffix });
     defer allocator.free(table_name);
 
@@ -329,9 +329,9 @@ test "Streaming source: DELETE operation E2E" {
     const allocator = testing.allocator;
 
     // Generate unique names for this test (timestamp + random to avoid collisions)
-    var prng = std.Random.DefaultPrng.init(@intCast(std.time.microTimestamp()));
+    var prng = std.Random.DefaultPrng.init(@intCast(test_helpers.nowMicros()));
     const random_suffix = prng.random().int(u32);
-    const timestamp = std.time.timestamp();
+    const timestamp = test_helpers.nowSeconds();
     const table_name = try std.fmt.allocPrint(allocator, "stream_delete_test_{d}_{d}", .{ timestamp, random_suffix });
     defer allocator.free(table_name);
 
@@ -459,9 +459,9 @@ test "Streaming source: Multiple batches with limit parameter" {
     const allocator = testing.allocator;
 
     // Generate unique names for this test (timestamp + random to avoid collisions)
-    var prng = std.Random.DefaultPrng.init(@intCast(std.time.microTimestamp()));
+    var prng = std.Random.DefaultPrng.init(@intCast(test_helpers.nowMicros()));
     const random_suffix = prng.random().int(u32);
-    const timestamp = std.time.timestamp();
+    const timestamp = test_helpers.nowSeconds();
     const table_name = try std.fmt.allocPrint(allocator, "stream_batch_test_{d}_{d}", .{ timestamp, random_suffix });
     defer allocator.free(table_name);
 
@@ -566,9 +566,9 @@ test "Streaming source: Timeout behavior with no data" {
     const allocator = testing.allocator;
 
     // Generate unique names for this test (timestamp + random to avoid collisions)
-    var prng = std.Random.DefaultPrng.init(@intCast(std.time.microTimestamp()));
+    var prng = std.Random.DefaultPrng.init(@intCast(test_helpers.nowMicros()));
     const random_suffix = prng.random().int(u32);
-    const timestamp = std.time.timestamp();
+    const timestamp = test_helpers.nowSeconds();
     const table_name = try std.fmt.allocPrint(allocator, "stream_timeout_test_{d}_{d}", .{ timestamp, random_suffix });
     defer allocator.free(table_name);
 
@@ -626,7 +626,7 @@ test "Streaming source: Timeout behavior with no data" {
 
     std.log.info("Waiting for timeout with no data (1 second)...", .{});
 
-    const start_time = std.time.milliTimestamp();
+    const start_time = test_helpers.nowMillis();
 
     const batch = try source.receiveBatchWithWaitTime(allocator, 10, 1000);
     defer {
@@ -634,7 +634,7 @@ test "Streaming source: Timeout behavior with no data" {
         mut_batch.deinit();
     }
 
-    const elapsed = std.time.milliTimestamp() - start_time;
+    const elapsed = test_helpers.nowMillis() - start_time;
 
     std.log.info("Timeout test: received {} changes in {}ms", .{ batch.changes.len, elapsed });
 

--- a/src/source/postgres/integration_test.zig
+++ b/src/source/postgres/integration_test.zig
@@ -10,9 +10,7 @@ const ChangeOperation = domain.ChangeOperation;
 const source_mod = @import("source.zig");
 const PostgresSource = source_mod.PostgresSource;
 
-const c = @cImport({
-    @cInclude("libpq-fe.h");
-});
+const c = @import("c"); // shared libpq bindings (build-system translate-c)
 
 // Helper to create setup connection (non-replication)
 fn createSetupConnection(allocator: std.mem.Allocator) !*c.PGconn {

--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -1,7 +1,5 @@
 const std = @import("std");
-const c = @cImport({
-    @cInclude("libpq-fe.h");
-});
+const c = @import("c"); // shared libpq bindings (build-system translate-c)
 
 pub const ReplicationError = error{
     ConnectionFailed,

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -20,6 +20,16 @@ const DecoderError = pg_output_decoder.DecoderError;
 const relation_registry = @import("relation_registry.zig");
 const RelationRegistryError = relation_registry.RelationRegistryError;
 
+// Wall-clock time in milliseconds. Zig 0.16 removed std.time.milliTimestamp
+// (time now goes through the Io interface); libc gettimeofday is used here to
+// avoid threading `io` into the receive loop.
+// TODO(phase 6): replace with the Io clock once `io` is threaded through.
+fn nowMillis() i64 {
+    var tv: std.c.timeval = undefined;
+    _ = std.c.gettimeofday(&tv, null);
+    return @as(i64, @intCast(tv.sec)) * 1000 + @divTrunc(@as(i64, @intCast(tv.usec)), 1000);
+}
+
 // Re-export types for benchmarks (public API)
 pub const PgOutputMessage = pg_output_decoder.PgOutputMessage;
 pub const InsertMessage = pg_output_decoder.InsertMessage;
@@ -82,7 +92,7 @@ pub const MessageProcessor = struct {
             .source = try batch_allocator.dupe(u8, "postgres"),
             .resource = try batch_allocator.dupe(u8, rel_info.relation_name),
             .schema = try batch_allocator.dupe(u8, rel_info.namespace),
-            .timestamp = std.time.timestamp(),
+            .timestamp = @divTrunc(nowMillis(), 1000),
             .lsn = null,
         };
 
@@ -101,7 +111,7 @@ pub const MessageProcessor = struct {
             .source = try batch_allocator.dupe(u8, "postgres"),
             .resource = try batch_allocator.dupe(u8, rel_info.relation_name),
             .schema = try batch_allocator.dupe(u8, rel_info.namespace),
-            .timestamp = std.time.timestamp(),
+            .timestamp = @divTrunc(nowMillis(), 1000),
             .lsn = null,
         };
 
@@ -125,7 +135,7 @@ pub const MessageProcessor = struct {
             .source = try batch_allocator.dupe(u8, "postgres"),
             .resource = try batch_allocator.dupe(u8, rel_info.relation_name),
             .schema = try batch_allocator.dupe(u8, rel_info.namespace),
-            .timestamp = std.time.timestamp(),
+            .timestamp = @divTrunc(nowMillis(), 1000),
             .lsn = null,
         };
 
@@ -276,11 +286,11 @@ pub const PostgresSource = struct {
 
         var last_confirmed_lsn: u64 = self.last_lsn; // Track LSN locally
 
-        const start_time = std.time.milliTimestamp();
+        const start_time = nowMillis();
         const deadline = start_time + wait_time_ms;
 
-        while (changes.items.len < limit and std.time.milliTimestamp() < deadline) {
-            const remaining_time = @max(deadline - std.time.milliTimestamp(), 0);
+        while (changes.items.len < limit and nowMillis() < deadline) {
+            const remaining_time = @max(deadline - nowMillis(), 0);
             const wait_time: i32 = @intCast(remaining_time);
 
             // Step 1: Blocking receive (poll() inside)
@@ -387,7 +397,7 @@ pub const PostgresSource = struct {
             .wal_write_position = lsn,
             .wal_flush_position = lsn,
             .wal_apply_position = lsn,
-            .client_time = std.time.timestamp(),
+            .client_time = @divTrunc(nowMillis(), 1000),
             .reply_requested = false,
         };
 

--- a/src/source/postgres/validator.zig
+++ b/src/source/postgres/validator.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 const print = std.debug.print;
-const c = @cImport({
-    @cInclude("libpq-fe.h");
-});
+const c = @import("c"); // shared libpq bindings (build-system translate-c)
 
 pub const ValidationError = error{
     ConnectionFailed,

--- a/tests/benchmarks/components/decoder_bench.zig
+++ b/tests/benchmarks/components/decoder_bench.zig
@@ -63,7 +63,7 @@ fn buildInsertMessage(allocator: std.mem.Allocator) ![]u8 {
 const BenchDecoderInsert = struct {
     golden_data: []const u8,
 
-    pub fn run(self: BenchDecoderInsert, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchDecoderInsert, allocator: std.mem.Allocator) void {
         var decoder = PgOutputDecoder.init(allocator);
         var msg = decoder.decode(self.golden_data) catch unreachable;
         defer msg.deinit(allocator);
@@ -90,11 +90,7 @@ test "benchmark PgOutputDecoder" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});

--- a/tests/benchmarks/components/kafka_bench.zig
+++ b/tests/benchmarks/components/kafka_bench.zig
@@ -75,7 +75,7 @@ const MockCluster = struct {
 const BenchKafkaSend = struct {
     producer: *KafkaProducer,
 
-    pub fn run(self: BenchKafkaSend, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchKafkaSend, allocator: std.mem.Allocator) void {
         _ = allocator;
         for (0..batch_size) |_| {
             self.producer.sendMessage("bench_topic", "key_123", payload) catch unreachable;
@@ -88,7 +88,7 @@ const BenchKafkaProduce = struct {
     producer: *KafkaProducer,
     messages: []kafka_producer.Message,
 
-    pub fn run(self: BenchKafkaProduce, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchKafkaProduce, allocator: std.mem.Allocator) void {
         _ = allocator;
         self.producer.produce("bench_topic", self.messages) catch unreachable;
         self.producer.poll();
@@ -123,11 +123,7 @@ test "benchmark KafkaProducer sendMessage" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / message_iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});
@@ -177,11 +173,7 @@ test "benchmark KafkaProducer produce" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / message_iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});

--- a/tests/benchmarks/components/kafka_bench.zig
+++ b/tests/benchmarks/components/kafka_bench.zig
@@ -10,10 +10,7 @@ const message_iterations = 100;
 const batch_size = 1000;
 const flush_iterations = message_iterations;
 
-const c = @cImport({
-    @cInclude("librdkafka/rdkafka.h");
-    @cInclude("librdkafka/rdkafka_mock.h");
-});
+const c = @import("c"); // shared librdkafka bindings incl. mock (translate-c)
 
 const payload =
     \\{

--- a/tests/benchmarks/components/match_streams_bench.zig
+++ b/tests/benchmarks/components/match_streams_bench.zig
@@ -122,7 +122,7 @@ fn createTestStreams(allocator: std.mem.Allocator) ![]Stream {
 const BenchMatchFound = struct {
     streams: []const Stream,
 
-    pub fn run(self: BenchMatchFound, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchMatchFound, allocator: std.mem.Allocator) void {
         var matched = processor_mod.matchStreams(allocator, self.streams, "users", "INSERT") catch unreachable;
         defer matched.deinit(allocator);
     }
@@ -131,7 +131,7 @@ const BenchMatchFound = struct {
 const BenchMatchNotFound = struct {
     streams: []const Stream,
 
-    pub fn run(self: BenchMatchNotFound, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchMatchNotFound, allocator: std.mem.Allocator) void {
         var matched = processor_mod.matchStreams(allocator, self.streams, "nonexistent_table", "INSERT") catch unreachable;
         defer matched.deinit(allocator);
     }
@@ -159,11 +159,7 @@ test "benchmark matchStreams found" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});
@@ -191,11 +187,7 @@ test "benchmark matchStreams not found" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});

--- a/tests/benchmarks/components/message_processor_bench.zig
+++ b/tests/benchmarks/components/message_processor_bench.zig
@@ -92,7 +92,7 @@ const BenchProcessInsert = struct {
     registry: *RelationRegistry,
     message: PgOutputMessage,
 
-    pub fn run(self: BenchProcessInsert, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchProcessInsert, allocator: std.mem.Allocator) void {
         var processor = MessageProcessor.init();
         var event = processor.processMessage(allocator, self.message, self.registry) catch unreachable;
         if (event) |*e| {
@@ -153,7 +153,7 @@ const BenchProcessUpdate = struct {
     registry: *RelationRegistry,
     message: PgOutputMessage,
 
-    pub fn run(self: BenchProcessUpdate, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchProcessUpdate, allocator: std.mem.Allocator) void {
         var processor = MessageProcessor.init();
         var event = processor.processMessage(allocator, self.message, self.registry) catch unreachable;
         if (event) |*e| {
@@ -194,7 +194,7 @@ const BenchProcessDelete = struct {
     registry: *RelationRegistry,
     message: PgOutputMessage,
 
-    pub fn run(self: BenchProcessDelete, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchProcessDelete, allocator: std.mem.Allocator) void {
         var processor = MessageProcessor.init();
         var event = processor.processMessage(allocator, self.message, self.registry) catch unreachable;
         if (event) |*e| {
@@ -233,11 +233,7 @@ test "benchmark MessageProcessor INSERT" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});
@@ -273,11 +269,7 @@ test "benchmark MessageProcessor UPDATE" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});
@@ -313,11 +305,7 @@ test "benchmark MessageProcessor DELETE" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});

--- a/tests/benchmarks/components/partition_key_bench.zig
+++ b/tests/benchmarks/components/partition_key_bench.zig
@@ -59,7 +59,7 @@ fn createEventWithStringKey(allocator: std.mem.Allocator) !ChangeEvent {
 const BenchPartitionKeyInteger = struct {
     event: ChangeEvent,
 
-    pub fn run(self: BenchPartitionKeyInteger, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchPartitionKeyInteger, allocator: std.mem.Allocator) void {
         const key = self.event.getPartitionKeyValue(allocator, "id") catch unreachable;
         if (key) |k| {
             allocator.free(k);
@@ -70,7 +70,7 @@ const BenchPartitionKeyInteger = struct {
 const BenchPartitionKeyString = struct {
     event: ChangeEvent,
 
-    pub fn run(self: BenchPartitionKeyString, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchPartitionKeyString, allocator: std.mem.Allocator) void {
         const key = self.event.getPartitionKeyValue(allocator, "uuid") catch unreachable;
         if (key) |k| {
             allocator.free(k);
@@ -81,7 +81,7 @@ const BenchPartitionKeyString = struct {
 const BenchPartitionKeyBoolean = struct {
     event: ChangeEvent,
 
-    pub fn run(self: BenchPartitionKeyBoolean, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchPartitionKeyBoolean, allocator: std.mem.Allocator) void {
         const key = self.event.getPartitionKeyValue(allocator, "active") catch unreachable;
         if (key) |k| {
             allocator.free(k);
@@ -92,7 +92,7 @@ const BenchPartitionKeyBoolean = struct {
 const BenchPartitionKeyNotFound = struct {
     event: ChangeEvent,
 
-    pub fn run(self: BenchPartitionKeyNotFound, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchPartitionKeyNotFound, allocator: std.mem.Allocator) void {
         const key = self.event.getPartitionKeyValue(allocator, "nonexistent_field") catch unreachable;
         if (key) |k| {
             allocator.free(k);
@@ -122,11 +122,7 @@ test "benchmark getPartitionKeyValue integer" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});
@@ -154,11 +150,7 @@ test "benchmark getPartitionKeyValue string" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});
@@ -186,11 +178,7 @@ test "benchmark getPartitionKeyValue boolean" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});
@@ -218,11 +206,7 @@ test "benchmark getPartitionKeyValue not found" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / iterations;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});

--- a/tests/benchmarks/components/serializer_bench.zig
+++ b/tests/benchmarks/components/serializer_bench.zig
@@ -40,7 +40,7 @@ fn buildChangeEvent(allocator: std.mem.Allocator) !ChangeEvent {
 const BenchSerializeInsert = struct {
     event: ChangeEvent,
 
-    pub fn run(self: BenchSerializeInsert, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchSerializeInsert, allocator: std.mem.Allocator) void {
         const serializer = JsonSerializer.init();
         const json = serializer.serialize(self.event, allocator) catch unreachable;
         allocator.free(json);
@@ -69,12 +69,7 @@ test "benchmark JsonSerializer" {
         .track_allocations = true,
     });
 
-    var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
-    const writer = &stdout.interface;
-
-    try bench.run(writer);
-    try writer.flush();
+    try bench.run(std.testing.io, std.Io.File.stdout());
 
     const allocations_per_iter = alloc_count / 1000;
     std.debug.print("\nAllocations per operation: {d}\n", .{allocations_per_iter});

--- a/tests/e2e/cdc_test.zig
+++ b/tests/e2e/cdc_test.zig
@@ -17,8 +17,8 @@ const c = test_helpers.c;
 // - Verification: Message count matches change count, JSON structure is correct
 
 // Enable debug logging for these tests
-pub const std_options = struct {
-    pub const log_level = .debug;
+pub const std_options: std.Options = .{
+    .log_level = .debug,
 };
 
 test "E2E: INSERT operation - full pipeline verification" {
@@ -40,7 +40,7 @@ test "E2E: INSERT operation - full pipeline verification" {
     }
 
     // Test configuration with unique names to avoid cross-test contamination
-    const timestamp = std.time.timestamp();
+    const timestamp = test_helpers.nowSeconds();
     const table_name = try std.fmt.allocPrint(allocator, "users_stream_insert_{d}", .{timestamp});
     defer allocator.free(table_name);
     const topic_name = try std.fmt.allocPrint(allocator, "topic.stream.insert.{d}", .{timestamp});
@@ -105,7 +105,7 @@ test "E2E: INSERT operation - full pipeline verification" {
     _ = c.PQexec(conn, insert1.ptr);
     _ = c.PQexec(conn, insert2.ptr);
     _ = c.PQexec(conn, insert3.ptr);
-    std.Thread.sleep(200_000_000); // 200ms
+    test_helpers.sleepNs(200_000_000); // 200ms
 
     // Process CDC pipeline
     std.debug.print("Step 2: Process CDC pipeline\n", .{});
@@ -184,7 +184,7 @@ test "E2E: UPDATE operation - full pipeline verification" {
     }
 
     // Test configuration with unique names
-    const timestamp = std.time.timestamp();
+    const timestamp = test_helpers.nowSeconds();
     const table_name = try std.fmt.allocPrint(allocator, "users_stream_update_{d}", .{timestamp});
     defer allocator.free(table_name);
     const topic_name = try std.fmt.allocPrint(allocator, "topic.stream.update.{d}", .{timestamp});
@@ -241,7 +241,7 @@ test "E2E: UPDATE operation - full pipeline verification" {
     const insert_sql = try test_helpers.formatSqlZ(allocator, "INSERT INTO {s} (name, value) VALUES ('Alice', 100);", .{table_name});
     defer allocator.free(insert_sql);
     _ = c.PQexec(conn, insert_sql.ptr);
-    std.Thread.sleep(200_000_000); // 200ms
+    test_helpers.sleepNs(200_000_000); // 200ms
 
     // Process initial INSERT
     {
@@ -258,7 +258,7 @@ test "E2E: UPDATE operation - full pipeline verification" {
     defer allocator.free(update2_sql);
     _ = c.PQexec(conn, update1_sql.ptr);
     _ = c.PQexec(conn, update2_sql.ptr);
-    std.Thread.sleep(200_000_000); // 200ms
+    test_helpers.sleepNs(200_000_000); // 200ms
 
     // Process UPDATE operations
     std.debug.print("Step 3: Process UPDATE operations\n", .{});
@@ -323,7 +323,7 @@ test "E2E: DELETE operation - full pipeline verification" {
     }
 
     // Test configuration with unique names
-    const timestamp = std.time.timestamp();
+    const timestamp = test_helpers.nowSeconds();
     const table_name = try std.fmt.allocPrint(allocator, "users_stream_delete_{d}", .{timestamp});
     defer allocator.free(table_name);
     const topic_name = try std.fmt.allocPrint(allocator, "topic.stream.delete.{d}", .{timestamp});
@@ -383,7 +383,7 @@ test "E2E: DELETE operation - full pipeline verification" {
     defer allocator.free(insert2_sql);
     _ = c.PQexec(conn, insert1_sql.ptr);
     _ = c.PQexec(conn, insert2_sql.ptr);
-    std.Thread.sleep(200_000_000); // 200ms
+    test_helpers.sleepNs(200_000_000); // 200ms
 
     // Process initial INSERTs
     {
@@ -400,7 +400,7 @@ test "E2E: DELETE operation - full pipeline verification" {
     defer allocator.free(delete2_sql);
     _ = c.PQexec(conn, delete1_sql.ptr);
     _ = c.PQexec(conn, delete2_sql.ptr);
-    std.Thread.sleep(200_000_000); // 200ms
+    test_helpers.sleepNs(200_000_000); // 200ms
 
     // Process DELETE operations
     std.debug.print("Step 3: Process DELETE operations\n", .{});

--- a/tests/test_helpers.zig
+++ b/tests/test_helpers.zig
@@ -5,11 +5,9 @@ const StreamSource = config_module.StreamSource;
 const StreamFlow = config_module.StreamFlow;
 const StreamSink = config_module.StreamSink;
 
-// Export C import so E2E tests use the same types
-pub const c = @cImport({
-    @cInclude("libpq-fe.h");
-    @cInclude("librdkafka/rdkafka.h");
-});
+// Combined libpq + librdkafka bindings (build-system translate-c), re-exported
+// so E2E tests use the same C types.
+pub const c = @import("c");
 
 // --- Time / sleep / env helpers ---
 // Zig 0.16 moved time and sleep behind the Io interface and removed the global

--- a/tests/test_helpers.zig
+++ b/tests/test_helpers.zig
@@ -11,6 +11,38 @@ pub const c = @cImport({
     @cInclude("librdkafka/rdkafka.h");
 });
 
+// --- Time / sleep / env helpers ---
+// Zig 0.16 moved time and sleep behind the Io interface and removed the global
+// env accessor. Test modules link libc, so use libc primitives directly here.
+
+/// Wall-clock milliseconds since the Unix epoch.
+pub fn nowMillis() i64 {
+    var tv: std.c.timeval = undefined;
+    _ = std.c.gettimeofday(&tv, null);
+    return @as(i64, @intCast(tv.sec)) * 1000 + @divTrunc(@as(i64, @intCast(tv.usec)), 1000);
+}
+
+/// Wall-clock seconds since the Unix epoch.
+pub fn nowSeconds() i64 {
+    return @divTrunc(nowMillis(), 1000);
+}
+
+/// Wall-clock microseconds since the Unix epoch.
+pub fn nowMicros() i64 {
+    var tv: std.c.timeval = undefined;
+    _ = std.c.gettimeofday(&tv, null);
+    return @as(i64, @intCast(tv.sec)) * 1_000_000 + @as(i64, @intCast(tv.usec));
+}
+
+/// Sleep for the given number of nanoseconds.
+pub fn sleepNs(ns: u64) void {
+    var req: std.c.timespec = .{
+        .sec = @intCast(ns / std.time.ns_per_s),
+        .nsec = @intCast(ns % std.time.ns_per_s),
+    };
+    _ = std.c.nanosleep(&req, null);
+}
+
 /// Helper to format SQL with null terminator for C APIs
 pub fn formatSqlZ(allocator: std.mem.Allocator, comptime fmt: []const u8, args: anytype) ![:0]const u8 {
     const sql = try std.fmt.allocPrint(allocator, fmt, args);
@@ -23,11 +55,11 @@ pub fn formatSqlZ(allocator: std.mem.Allocator, comptime fmt: []const u8, args: 
 /// Get PostgreSQL connection string for tests
 /// Uses POSTGRES_PASSWORD env var or defaults to "password"
 pub fn getTestConnectionString(allocator: std.mem.Allocator) ![]const u8 {
-    const password = std.process.getEnvVarOwned(allocator, "POSTGRES_PASSWORD") catch |err| switch (err) {
-        error.EnvironmentVariableNotFound => try allocator.dupe(u8, "password"),
-        else => return err,
-    };
-    defer allocator.free(password);
+    // std.process.getEnvVarOwned was removed in Zig 0.16; use libc getenv.
+    const password: []const u8 = if (std.c.getenv("POSTGRES_PASSWORD")) |p|
+        std.mem.span(p)
+    else
+        "password";
 
     return std.fmt.allocPrint(
         allocator,
@@ -101,7 +133,7 @@ pub fn consumeAllMessages(
     topic: []const u8,
     timeout_ms: i32,
 ) ![]std.json.Parsed(std.json.Value) {
-    var messages = std.ArrayList(std.json.Parsed(std.json.Value)){};
+    var messages: std.ArrayList(std.json.Parsed(std.json.Value)) = .empty;
     errdefer {
         for (messages.items) |msg| msg.deinit();
         messages.deinit(allocator);
@@ -110,7 +142,7 @@ pub fn consumeAllMessages(
     var errstr: [512]u8 = undefined;
 
     // Create consumer with unique group_id (to read from beginning)
-    const group_id = try std.fmt.allocPrint(allocator, "test-group-{d}", .{std.time.timestamp()});
+    const group_id = try std.fmt.allocPrint(allocator, "test-group-{d}", .{nowSeconds()});
     defer allocator.free(group_id);
 
     const conf = c.rd_kafka_conf_new();
@@ -148,13 +180,13 @@ pub fn consumeAllMessages(
 
     // Poll messages until timeout
     // Give consumer time to subscribe and rebalance
-    std.Thread.sleep(2_000_000_000); // 2 seconds for consumer to join and get assignments
+    sleepNs(2_000_000_000); // 2 seconds for consumer to join and get assignments
 
-    const start_time = std.time.milliTimestamp();
+    const start_time = nowMillis();
     var last_message_time = start_time;
 
     while (true) {
-        const elapsed = std.time.milliTimestamp() - start_time;
+        const elapsed = nowMillis() - start_time;
         if (elapsed >= timeout_ms) break;
 
         const message = c.rd_kafka_consumer_poll(consumer, 500);
@@ -167,13 +199,13 @@ pub fn consumeAllMessages(
             };
             try messages.append(allocator, parsed);
 
-            last_message_time = std.time.milliTimestamp();
+            last_message_time = nowMillis();
             c.rd_kafka_message_destroy(message);
         } else {
             if (message != null) c.rd_kafka_message_destroy(message);
 
             // Stop if no messages for 2 seconds after we got at least one
-            if (messages.items.len > 0 and (std.time.milliTimestamp() - last_message_time) > 2000) {
+            if (messages.items.len > 0 and (nowMillis() - last_message_time) > 2000) {
                 break;
             }
         }


### PR DESCRIPTION
## Why

The active toolchain moved to **Zig 0.16.0**, which breaks the 0.15.1 codebase (build fails immediately). This brings the project onto 0.16 and modernizes C interop along the way.

## What

- **Language/stdlib migration (0.15.1 → 0.16.0):** "Juicy Main" (`std.process.Init`), the new `Io` interface for stdout/file I/O, `std.Io.Writer.Allocating` for the JSON serializer, `DebugAllocator`, `posix.SIG` signal handler, `ArrayList(...).empty`, libc time/sleep where `std.time`/`std.Thread.sleep` were removed, plus build-system changes (per-module linking, etc.).
- **C interop modernization (Phase 5):** every `@cImport` replaced with build-system `translate-c` (shared, type-identical `c` modules for libpq / librdkafka / combined), since `@cImport` is deprecated. Removes the per-module include-path workaround.
- **Tooling:** flake provides Zig 0.16.0; `C_INCLUDE_PATH` points at the `.dev` outputs (fixes a latent header-resolution bug); zbench bumped to a 0.16-compatible release; docs updated.

## Verification

Green on Zig 0.16.0: `zig build`, `test` (55), `test-integration` (42), `test-e2e` (3), `bench` (6), `fmt-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)