### PR TITLE
Update benchmark baseline (zbench 0.12.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 zig-cache/
 zig-out/
 .zig-cache/
+zig-pkg/
 
 # Build artifacts
 build/

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
             .hash = "toml-0.3.0-bV14BfV7AQD8DkuQI7skP8ekQTaBYKTO0MY_35Cw_EXo",
         },
         .zbench = .{
-            .url = "https://github.com/hendriknielaender/zbench/archive/463f8d5349daf72430697c9fe42cfe0a68729859.tar.gz",
-            .hash = "zbench-0.11.1-YTdc7zgmAQDtDcHPFwsLeawui27WjMLWmUwrfz7pIlB2",
+            .url = "https://github.com/hendriknielaender/zbench/archive/refs/tags/v0.12.0.tar.gz",
+            .hash = "zbench-0.11.1-YTdc7zkmAQBWI99esNFueJc9GuzK-KaU6Nfr1ZXhNGmc",
         },
     },
     .paths = .{""},

--- a/tests/benchmarks/baseline/components.json
+++ b/tests/benchmarks/baseline/components.json
@@ -1,93 +1,93 @@
 {
-  "timestamp": "2025-11-25T20:18:10Z",
+  "timestamp": "2026-06-27T20:30:41Z",
   "benchmarks": {
     "JsonSerializer": {
-      "time_avg_us": 23.065,
-      "time_stddev_us": 11.591,
+      "time_avg_us": 27.142,
+      "time_stddev_us": 3.192,
       "memory_bytes": 505,
       "allocations": 3
     }
 ,
     "PgOutputDecoder": {
-      "time_avg_us": 33.231,
-      "time_stddev_us": 9.252,
+      "time_avg_us": 49.849,
+      "time_stddev_us": 4.286,
       "memory_bytes": 243,
       "allocations": 6
     }
 ,
     "matchStreams found": {
-      "time_avg_us": 8.63,
-      "time_stddev_us": 4.874,
+      "time_avg_us": 10.051,
+      "time_stddev_us": 1.092,
       "memory_bytes": 96,
       "allocations": 1
     }
 ,
     "matchStreams not found": {
-      "time_avg_us": .016,
-      "time_stddev_us": .021,
+      "time_avg_us": .029,
+      "time_stddev_us": .043,
       "memory_bytes": 0,
       "allocations": 0
     }
 ,
     "getPartitionKeyValue integer": {
-      "time_avg_us": 21.642,
-      "time_stddev_us": 4.868,
+      "time_avg_us": 29.896,
+      "time_stddev_us": 1.952,
       "memory_bytes": 137,
       "allocations": 3
     }
 ,
     "getPartitionKeyValue string": {
-      "time_avg_us": 8.45,
-      "time_stddev_us": 2.68,
+      "time_avg_us": 10.012,
+      "time_stddev_us": .982,
       "memory_bytes": 36,
       "allocations": 1
     }
 ,
     "getPartitionKeyValue boolean": {
-      "time_avg_us": 7.814,
-      "time_stddev_us": 1.851,
+      "time_avg_us": 9.025,
+      "time_stddev_us": .943,
       "memory_bytes": 4,
       "allocations": 1
     }
 ,
     "getPartitionKeyValue not found": {
-      "time_avg_us": .013,
-      "time_stddev_us": .031,
+      "time_avg_us": .022,
+      "time_stddev_us": .066,
       "memory_bytes": 0,
       "allocations": 0
     }
 ,
     "KafkaProducer sendMessage": {
-      "time_avg_us": 318.025,
-      "time_stddev_us": 131.984,
+      "time_avg_us": 211.668,
+      "time_stddev_us": 151.408,
       "memory_bytes": 0,
       "allocations": 0
     }
 ,
     "KafkaProducer produce": {
-      "time_avg_us": 98.885,
-      "time_stddev_us": 37.246,
+      "time_avg_us": 147.725,
+      "time_stddev_us": 61.334,
       "memory_bytes": 0,
       "allocations": 1
     }
 ,
     "MessageProcessor INSERT": {
-      "time_avg_us": 84.839,
-      "time_stddev_us": 10.232,
+      "time_avg_us": 131.898,
+      "time_stddev_us": 4.432,
       "memory_bytes": 643,
       "allocations": 15
     }
 ,
     "MessageProcessor UPDATE": {
-      "time_avg_us": 148.302,
-      "time_stddev_us": 13.454,
+      "time_avg_us": 231.433,
+      "time_stddev_us": 6.5,
       "memory_bytes": 976,
       "allocations": 27
     }
 ,
     "MessageProcessor DELETE": {
-      "time_avg_us": 85.884,
-      "time_stddev_us": 8.029,
+      "time_avg_us": 132.233,
+      "time_stddev_us": 4.163,
       "memory_bytes": 643,
       "allocations": 15
     }

--- a/tests/benchmarks/components/decoder_bench.zig
+++ b/tests/benchmarks/components/decoder_bench.zig
@@ -63,7 +63,7 @@ fn buildInsertMessage(allocator: std.mem.Allocator) ![]u8 {
 const BenchDecoderInsert = struct {
     golden_data: []const u8,
 
-    pub fn run(self: BenchDecoderInsert, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchDecoderInsert, allocator: std.mem.Allocator) void {
         var decoder = PgOutputDecoder.init(allocator);
         var msg = decoder.decode(self.golden_data) catch unreachable;
         defer msg.deinit(allocator);

--- a/tests/benchmarks/components/kafka_bench.zig
+++ b/tests/benchmarks/components/kafka_bench.zig
@@ -75,7 +75,7 @@ const MockCluster = struct {
 const BenchKafkaSend = struct {
     producer: *KafkaProducer,
 
-    pub fn run(self: BenchKafkaSend, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchKafkaSend, allocator: std.mem.Allocator) void {
         _ = allocator;
         for (0..batch_size) |_| {
             self.producer.sendMessage("bench_topic", "key_123", payload) catch unreachable;
@@ -88,7 +88,7 @@ const BenchKafkaProduce = struct {
     producer: *KafkaProducer,
     messages: []kafka_producer.Message,
 
-    pub fn run(self: BenchKafkaProduce, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchKafkaProduce, allocator: std.mem.Allocator) void {
         _ = allocator;
         self.producer.produce("bench_topic", self.messages) catch unreachable;
         self.producer.poll();

--- a/tests/benchmarks/components/match_streams_bench.zig
+++ b/tests/benchmarks/components/match_streams_bench.zig
@@ -122,7 +122,7 @@ fn createTestStreams(allocator: std.mem.Allocator) ![]Stream {
 const BenchMatchFound = struct {
     streams: []const Stream,
 
-    pub fn run(self: BenchMatchFound, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchMatchFound, allocator: std.mem.Allocator) void {
         var matched = processor_mod.matchStreams(allocator, self.streams, "users", "INSERT") catch unreachable;
         defer matched.deinit(allocator);
     }
@@ -131,7 +131,7 @@ const BenchMatchFound = struct {
 const BenchMatchNotFound = struct {
     streams: []const Stream,
 
-    pub fn run(self: BenchMatchNotFound, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchMatchNotFound, allocator: std.mem.Allocator) void {
         var matched = processor_mod.matchStreams(allocator, self.streams, "nonexistent_table", "INSERT") catch unreachable;
         defer matched.deinit(allocator);
     }

--- a/tests/benchmarks/components/message_processor_bench.zig
+++ b/tests/benchmarks/components/message_processor_bench.zig
@@ -92,7 +92,7 @@ const BenchProcessInsert = struct {
     registry: *RelationRegistry,
     message: PgOutputMessage,
 
-    pub fn run(self: BenchProcessInsert, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchProcessInsert, allocator: std.mem.Allocator) void {
         var processor = MessageProcessor.init();
         var event = processor.processMessage(allocator, self.message, self.registry) catch unreachable;
         if (event) |*e| {
@@ -153,7 +153,7 @@ const BenchProcessUpdate = struct {
     registry: *RelationRegistry,
     message: PgOutputMessage,
 
-    pub fn run(self: BenchProcessUpdate, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchProcessUpdate, allocator: std.mem.Allocator) void {
         var processor = MessageProcessor.init();
         var event = processor.processMessage(allocator, self.message, self.registry) catch unreachable;
         if (event) |*e| {
@@ -194,7 +194,7 @@ const BenchProcessDelete = struct {
     registry: *RelationRegistry,
     message: PgOutputMessage,
 
-    pub fn run(self: BenchProcessDelete, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchProcessDelete, allocator: std.mem.Allocator) void {
         var processor = MessageProcessor.init();
         var event = processor.processMessage(allocator, self.message, self.registry) catch unreachable;
         if (event) |*e| {

--- a/tests/benchmarks/components/partition_key_bench.zig
+++ b/tests/benchmarks/components/partition_key_bench.zig
@@ -59,7 +59,7 @@ fn createEventWithStringKey(allocator: std.mem.Allocator) !ChangeEvent {
 const BenchPartitionKeyInteger = struct {
     event: ChangeEvent,
 
-    pub fn run(self: BenchPartitionKeyInteger, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchPartitionKeyInteger, allocator: std.mem.Allocator) void {
         const key = self.event.getPartitionKeyValue(allocator, "id") catch unreachable;
         if (key) |k| {
             allocator.free(k);
@@ -70,7 +70,7 @@ const BenchPartitionKeyInteger = struct {
 const BenchPartitionKeyString = struct {
     event: ChangeEvent,
 
-    pub fn run(self: BenchPartitionKeyString, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchPartitionKeyString, allocator: std.mem.Allocator) void {
         const key = self.event.getPartitionKeyValue(allocator, "uuid") catch unreachable;
         if (key) |k| {
             allocator.free(k);
@@ -81,7 +81,7 @@ const BenchPartitionKeyString = struct {
 const BenchPartitionKeyBoolean = struct {
     event: ChangeEvent,
 
-    pub fn run(self: BenchPartitionKeyBoolean, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchPartitionKeyBoolean, allocator: std.mem.Allocator) void {
         const key = self.event.getPartitionKeyValue(allocator, "active") catch unreachable;
         if (key) |k| {
             allocator.free(k);
@@ -92,7 +92,7 @@ const BenchPartitionKeyBoolean = struct {
 const BenchPartitionKeyNotFound = struct {
     event: ChangeEvent,
 
-    pub fn run(self: BenchPartitionKeyNotFound, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchPartitionKeyNotFound, allocator: std.mem.Allocator) void {
         const key = self.event.getPartitionKeyValue(allocator, "nonexistent_field") catch unreachable;
         if (key) |k| {
             allocator.free(k);

--- a/tests/benchmarks/components/serializer_bench.zig
+++ b/tests/benchmarks/components/serializer_bench.zig
@@ -40,7 +40,7 @@ fn buildChangeEvent(allocator: std.mem.Allocator) !ChangeEvent {
 const BenchSerializeInsert = struct {
     event: ChangeEvent,
 
-    pub fn run(self: BenchSerializeInsert, allocator: std.mem.Allocator) void {
+    pub fn run(self: *BenchSerializeInsert, allocator: std.mem.Allocator) void {
         const serializer = JsonSerializer.init();
         const json = serializer.serialize(self.event, allocator) catch unreachable;
         allocator.free(json);


### PR DESCRIPTION
## Why

To have a fresh, committed benchmark baseline on `main` (for `make bench-compare`) on up-to-date tooling, **before** the Zig 0.16 port lands. Stays on **Zig 0.15.2** — only the bench tooling and baseline change.

## What

- Bump **zbench 0.11.1 → 0.12.0** (newest release still compatible with Zig 0.15; 0.13+ requires 0.16).
- Adapt benchmark objects to zbench 0.12's API: `run` now needs a **pointer receiver** (`fn(*T, allocator)`). `bench.run(writer)` is unchanged.
- Refresh `tests/benchmarks/baseline/components.json` via `make bench-save` (warm run, no system load).
- Ignore `zig-pkg/` (local package cache).

## Baseline (Zig 0.15.2)

MessageProcessor INSERT 131.9µs / 15 allocs · UPDATE 231.4µs / 27 · DELETE 132.2µs / 15 · JsonSerializer 27.1µs / 3 · PgOutputDecoder 49.8µs / 6 · matchStreams 10.1µs.
