### PR TITLE
Stabilize benchmark baseline: min over N runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@
 SHELL := $(CURDIR)/.make-shell
 .SHELLFLAGS :=
 
+# Number of passes for bench-save / bench-compare (the minimum time/run is
+# kept). Override e.g. `make bench-save BENCH_RUNS=9`.
+export BENCH_RUNS ?= 5
+
 # Helper function for running commands with spinner
 # Captures both stdout and stderr, shows full output on failure
 define run_with_spinner
@@ -61,8 +65,8 @@ help:
 	@echo ""
 	@echo "Component Benchmarks:"
 	@echo "  make bench         - Run component benchmarks (view results in terminal)"
-	@echo "  make bench-compare - Compare current run with baseline"
-	@echo "  make bench-save    - Save current results as new baseline"
+	@echo "  make bench-compare - Compare current run with baseline (min of BENCH_RUNS passes)"
+	@echo "  make bench-save    - Save current results as new baseline (BENCH_RUNS=N, default 5)"
 	@echo ""
 	@echo "Dependencies:"
 	@echo "  make check-deps    - Check system dependencies"

--- a/tests/benchmarks/baseline/components.json
+++ b/tests/benchmarks/baseline/components.json
@@ -1,93 +1,82 @@
 {
-  "timestamp": "2026-06-27T20:30:41Z",
+  "timestamp": "2026-06-28T06:17:58Z",
+  "runs": 5,
+  "aggregate": "min",
   "benchmarks": {
     "JsonSerializer": {
-      "time_avg_us": 27.142,
-      "time_stddev_us": 3.192,
+      "time_avg_us": 26.364,
       "memory_bytes": 505,
       "allocations": 3
     }
 ,
     "PgOutputDecoder": {
-      "time_avg_us": 49.849,
-      "time_stddev_us": 4.286,
+      "time_avg_us": 49.392,
       "memory_bytes": 243,
       "allocations": 6
     }
 ,
     "matchStreams found": {
-      "time_avg_us": 10.051,
-      "time_stddev_us": 1.092,
+      "time_avg_us": 9.904,
       "memory_bytes": 96,
       "allocations": 1
     }
 ,
     "matchStreams not found": {
-      "time_avg_us": .029,
-      "time_stddev_us": .043,
+      "time_avg_us": .0280,
       "memory_bytes": 0,
       "allocations": 0
     }
 ,
     "getPartitionKeyValue integer": {
-      "time_avg_us": 29.896,
-      "time_stddev_us": 1.952,
+      "time_avg_us": 29.709,
       "memory_bytes": 137,
       "allocations": 3
     }
 ,
     "getPartitionKeyValue string": {
-      "time_avg_us": 10.012,
-      "time_stddev_us": .982,
+      "time_avg_us": 9.983,
       "memory_bytes": 36,
       "allocations": 1
     }
 ,
     "getPartitionKeyValue boolean": {
-      "time_avg_us": 9.025,
-      "time_stddev_us": .943,
+      "time_avg_us": 9.053,
       "memory_bytes": 4,
       "allocations": 1
     }
 ,
     "getPartitionKeyValue not found": {
-      "time_avg_us": .022,
-      "time_stddev_us": .066,
+      "time_avg_us": .0200,
       "memory_bytes": 0,
       "allocations": 0
     }
 ,
     "KafkaProducer sendMessage": {
-      "time_avg_us": 211.668,
-      "time_stddev_us": 151.408,
+      "time_avg_us": 340.726,
       "memory_bytes": 0,
       "allocations": 0
     }
 ,
     "KafkaProducer produce": {
-      "time_avg_us": 147.725,
-      "time_stddev_us": 61.334,
+      "time_avg_us": 116.072,
       "memory_bytes": 0,
       "allocations": 1
     }
 ,
     "MessageProcessor INSERT": {
-      "time_avg_us": 131.898,
-      "time_stddev_us": 4.432,
+      "time_avg_us": 131.665,
       "memory_bytes": 643,
       "allocations": 15
     }
 ,
     "MessageProcessor UPDATE": {
-      "time_avg_us": 231.433,
-      "time_stddev_us": 6.5,
+      "time_avg_us": 230.735,
       "memory_bytes": 976,
       "allocations": 27
     }
 ,
     "MessageProcessor DELETE": {
-      "time_avg_us": 132.233,
-      "time_stddev_us": 4.163,
+      "time_avg_us": 131.48,
       "memory_bytes": 643,
       "allocations": 15
     }

--- a/tests/benchmarks/scripts/collect_results.sh
+++ b/tests/benchmarks/scripts/collect_results.sh
@@ -6,124 +6,113 @@ BENCH_DIR="$(dirname "$SCRIPT_DIR")"
 RESULTS_DIR="$BENCH_DIR/results"
 BIN_DIR="$BENCH_DIR/../../zig-out/bin"
 
+# Number of full passes over the whole suite. Each benchmark's time/run is then
+# reduced to its *minimum* across passes (see below). Override:
+#   BENCH_RUNS=9 make bench-save
+BENCH_RUNS="${BENCH_RUNS:-5}"
+
+BENCHES=(serializer_bench decoder_bench match_streams_bench partition_key_bench kafka_bench message_processor_bench)
+
 # Colors
-RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-echo "Collecting benchmark results..."
+echo "Collecting benchmark results (${BENCH_RUNS} passes over the suite, keeping min)..."
 echo ""
 
-# Create results directory if it doesn't exist
 mkdir -p "$RESULTS_DIR"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
 
-# Output file
+# --- Run the whole suite BENCH_RUNS times -----------------------------------
+# Running the full suite each pass (rather than one binary N times in a row)
+# keeps cache conditions realistic between repeated runs of the same binary.
+for ((pass = 1; pass <= BENCH_RUNS; pass++)); do
+    echo -e "${YELLOW}Pass ${pass}/${BENCH_RUNS}...${NC}"
+    for bench in "${BENCHES[@]}"; do
+        "$BIN_DIR/$bench" 2>&1 | sed 's/\x1b\[[0-9;]*m//g' > "$TMP/${bench}.${pass}"
+    done
+done
+echo ""
+
 OUTPUT_FILE="$RESULTS_DIR/current.json"
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-# Start JSON output
 cat > "$OUTPUT_FILE" << EOF
 {
   "timestamp": "$TIMESTAMP",
+  "runs": $BENCH_RUNS,
+  "aggregate": "min",
   "benchmarks": {
 EOF
 
 FIRST=true
 
-# Function to parse all benchmarks from a single file
-parse_benchmark_file() {
-    local bench_file="$1"
+# Timing lines (one per sub-benchmark, in order) from a captured-output file.
+timing_lines_of() {
+    grep -E '^[A-Za-z].*[0-9]+(\.[0-9]+)?(us|ns)' "$1" | grep -v '\[MEMORY\]'
+}
 
-    echo -e "${YELLOW}Running $bench_file...${NC}"
+# First "<num>us|ns" on a line -> microseconds.
+time_us_of() {
+    local twu unit val
+    twu=$(echo "$1" | grep -oE '[0-9]+(\.[0-9]+)?(us|ns)' | head -1)
+    unit=$(echo "$twu" | grep -oE '(us|ns)')
+    val=$(echo "$twu" | sed 's/us//;s/ns//')
+    val=${val:-0}
+    [ "$unit" = "ns" ] && val=$(echo "scale=4; $val / 1000" | bc)
+    echo "$val"
+}
 
-    # Run benchmark and capture output, strip ANSI color codes
-    local output=$("$BIN_DIR/$bench_file" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')
+# --- Aggregate: minimum time/run per sub-benchmark across passes -------------
+# Why min: benchmark noise is one-sided (scheduling / cold cache / load only
+# *add* time), so the minimum is the cleanest, least-noisy sample — far more
+# stable than the average for a regression baseline. Memory and allocation
+# counts are deterministic, so they come from the first pass.
+for bench in "${BENCHES[@]}"; do
+    local_first="$TMP/${bench}.1"
 
-    # Extract full benchmark names from test runner lines (format: "N/M file.test.benchmark NAME...")
-    local bench_names=$(echo "$output" | grep "\.test\.benchmark " | sed -E 's/^[0-9]+\/[0-9]+ [^ ]+\.test\.benchmark ([^.]+)\.\.\..*/\1/')
+    bench_names=$(grep "\.test\.benchmark " "$local_first" | sed -E 's/^[0-9]+\/[0-9]+ [^ ]+\.test\.benchmark ([^.]+)\.\.\..*/\1/')
+    allocations_list=$(grep "Allocations per operation:" "$local_first" | grep -oE '[0-9]+$')
+    memory_lines=$(grep '\[MEMORY\]' "$local_first" || true)
 
-    # Extract "Allocations per operation:" values
-    local allocations_list=$(echo "$output" | grep "Allocations per operation:" | grep -oE '[0-9]+$')
-
-    # Extract timing and memory lines (non-[MEMORY] lines with time units)
-    local timing_lines=$(echo "$output" | grep -E '^[A-Za-z].*[0-9]+(\.[0-9]+)?(us|ns)' | grep -v '\[MEMORY\]')
-    local memory_lines=$(echo "$output" | grep '\[MEMORY\]')
-
-    # Process each benchmark
-    local bench_index=0
+    bench_index=0
     while IFS= read -r bench_name; do
-        if [ -z "$bench_name" ]; then
-            continue
-        fi
-
+        [ -z "$bench_name" ] && continue
         bench_index=$((bench_index + 1))
 
-        # Get corresponding timing line
-        local time_line=$(echo "$timing_lines" | sed -n "${bench_index}p")
+        min_time=""
+        for ((pass = 1; pass <= BENCH_RUNS; pass++)); do
+            time_line=$(timing_lines_of "$TMP/${bench}.${pass}" | sed -n "${bench_index}p")
+            [ -z "$time_line" ] && continue
+            t=$(time_us_of "$time_line")
+            if [ -z "$min_time" ] || (( $(echo "$t < $min_time" | bc -l) )); then
+                min_time=$t
+            fi
+        done
+        min_time=${min_time:-0}
 
-        # Extract time average (first number with us/ns)
-        local time_with_unit=$(echo "$time_line" | grep -oE '[0-9]+(\.[0-9]+)?(us|ns)' | head -1)
-        local time_unit=$(echo "$time_with_unit" | grep -oE '(us|ns)')
-        local time_avg=$(echo "$time_with_unit" | sed 's/us//;s/ns//')
-
-        # Convert ns to us
-        if [ "$time_unit" = "ns" ]; then
-            time_avg=$(echo "scale=3; $time_avg / 1000" | bc)
-        fi
-
-        # Extract stddev (after ±)
-        local stddev_with_unit=$(echo "$time_line" | grep -oE '± [0-9]+(\.[0-9]+)?(us|ns)' | head -1 | sed 's/± //')
-        local stddev_unit=$(echo "$stddev_with_unit" | grep -oE '(us|ns)')
-        local time_stddev=$(echo "$stddev_with_unit" | sed 's/us//;s/ns//')
-
-        # Convert stddev ns to us
-        if [ "$stddev_unit" = "ns" ]; then
-            time_stddev=$(echo "scale=3; $time_stddev / 1000" | bc)
-        fi
-
-        # Get corresponding memory line
-        local memory_line=$(echo "$memory_lines" | sed -n "${bench_index}p")
-        local memory=$(echo "$memory_line" | grep -oE '[0-9]+B' | head -1 | sed 's/B//')
-
-        # Get corresponding allocation count
-        local allocations=$(echo "$allocations_list" | sed -n "${bench_index}p")
-
-        # Default to 0 if not found
-        time_avg=${time_avg:-0}
-        time_stddev=${time_stddev:-0}
+        memory=$(echo "$memory_lines" | sed -n "${bench_index}p" | grep -oE '[0-9]+B' | head -1 | sed 's/B//')
         memory=${memory:-0}
+        allocations=$(echo "$allocations_list" | sed -n "${bench_index}p")
         allocations=${allocations:-0}
 
-        # Add comma if not first entry
         if [ "$FIRST" = false ]; then
             echo "," >> "$OUTPUT_FILE"
         fi
         FIRST=false
 
-        # Write JSON entry
         cat >> "$OUTPUT_FILE" << EOF
     "$bench_name": {
-      "time_avg_us": $time_avg,
-      "time_stddev_us": $time_stddev,
+      "time_avg_us": $min_time,
       "memory_bytes": $memory,
       "allocations": $allocations
     }
 EOF
-
-        echo -e "${GREEN}✓ $bench_name: ${time_avg}us, ${memory}B, ${allocations} allocs${NC}"
+        echo -e "${GREEN}✓ $bench_name: ${min_time}us (min of ${BENCH_RUNS}), ${memory}B, ${allocations} allocs${NC}"
     done <<< "$bench_names"
-}
+done
 
-# Parse all benchmark files
-parse_benchmark_file "serializer_bench"
-parse_benchmark_file "decoder_bench"
-parse_benchmark_file "match_streams_bench"
-parse_benchmark_file "partition_key_bench"
-parse_benchmark_file "kafka_bench"
-parse_benchmark_file "message_processor_bench"
-
-# Close JSON
 cat >> "$OUTPUT_FILE" << EOF
 
   }


### PR DESCRIPTION
Closes #25

## Why

The benchmark baseline (and `bench-compare`) was a **single-shot** measurement, so one noisy run (background load / cold cache) could swing a number 2–4×. We saw `JsonSerializer` "regress +91%" on a single run while it was actually faster — pure measurement artifact.

Benchmark noise is **one-sided** (scheduling / cache / load only *add* time), so the cleanest sample is the **minimum** across several runs.

## What

- **`collect_results.sh`**: run the whole suite `BENCH_RUNS` times and keep the **min** `time/run` per benchmark (memory/allocations are deterministic → taken from the first pass). Drops the now-meaningless `time_stddev_us` field.
- **`Makefile`**: `export BENCH_RUNS ?= 5` (override: `make bench-save BENCH_RUNS=9`); help updated.
- **`baseline/components.json`**: regenerated with min-of-5 (Zig 0.15.2 / zbench 0.12).

Stays on Zig 0.15.2 — pure bench tooling, version-independent (bash).
