### PR TITLE
ci: run component benchmarks on PRs and post results as a comment

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,12 +41,12 @@ jobs:
       # is compared against the committed baseline; the comparison is purely
       # informational and never fails the build.
       - name: Run benchmarks and compare with baseline
-        run: make bench-ci BENCH_RUNS=7 BENCH_REPORT=benchmark-comment.md
+        run: make bench-ci BENCH_RUNS=7 BENCH_REPORT=tests/benchmarks/results/benchmark-comment.md
 
+      # Only runs if the step above succeeded, so the report file is present.
       - name: Post benchmark comment on PR
-        if: always()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ github.event.pull_request.number }}
-          path: benchmark-comment.md
+          path: tests/benchmarks/results/benchmark-comment.md
           header: benchmark-results

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
       # is compared against the committed baseline; the comparison is purely
       # informational and never fails the build.
       - name: Run benchmarks and compare with baseline
-        run: make bench-ci BENCH_RUNS=7 BENCH_REPORT=tests/benchmarks/results/benchmark-comment.md
+        run: make bench-ci BENCH_RUNS=3 BENCH_REPORT=tests/benchmarks/results/benchmark-comment.md
 
       # Only runs if the step above succeeded, so the report file is present.
       - name: Post benchmark comment on PR

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
       # is compared against the committed baseline; the comparison is purely
       # informational and never fails the build.
       - name: Run benchmarks and compare with baseline
-        run: make bench-ci BENCH_RUNS=3 BENCH_REPORT=tests/benchmarks/results/benchmark-comment.md
+        run: make bench-ci BENCH_RUNS=1 BENCH_REPORT=tests/benchmarks/results/benchmark-comment.md
 
       # Only runs if the step above succeeded, so the report file is present.
       - name: Post benchmark comment on PR

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
       # is compared against the committed baseline; the comparison is purely
       # informational and never fails the build.
       - name: Run benchmarks and compare with baseline
-        run: make bench-ci BENCH_RUNS=1 BENCH_REPORT=tests/benchmarks/results/benchmark-comment.md
+        run: make bench-ci BENCH_RUNS=3 BENCH_REPORT=tests/benchmarks/results/benchmark-comment.md
 
       # Only runs if the step above succeeded, so the report file is present.
       - name: Post benchmark comment on PR

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,9 +21,20 @@ jobs:
       contents: read
       pull-requests: write
 
+    # GitHub-hosted runners don't guarantee identical hardware between runs, so
+    # absolute timings aren't comparable across runs and a committed wall-clock
+    # baseline is meaningless on CI. Instead we benchmark BOTH the PR and its
+    # base branch on this same runner and compare the delta — the hardware
+    # cancels out. On one runner intra-run jitter is the only noise left, so a
+    # couple of passes (the minimum is kept) is enough.
+    env:
+      BENCH_RUNS: 2
+
     steps:
-      - name: Checkout code
+      - name: Checkout PR
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # need the base commit to benchmark it on the same runner
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -35,18 +46,36 @@ jobs:
         with:
           name: devenv
 
-      # Run the suite several times and keep the minimum per benchmark. CI
-      # runners are noisy (one-sided: scheduling/cold cache only add time), so
-      # the min over N passes is far more stable than a single run. The result
-      # is compared against the committed baseline; the comparison is purely
-      # informational and never fails the build.
-      - name: Run benchmarks and compare with baseline
-        run: make bench-ci BENCH_RUNS=3 BENCH_REPORT=tests/benchmarks/results/benchmark-comment.md
+      - name: Benchmark PR head
+        run: |
+          make bench-collect
+          cp tests/benchmarks/results/current.json "$RUNNER_TEMP/pr.json"
 
-      # Only runs if the step above succeeded, so the report file is present.
+      # Build and run the base branch in a separate worktree on the same runner.
+      - name: Benchmark base branch
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git worktree add "$RUNNER_TEMP/base" "$BASE_SHA"
+          make -C "$RUNNER_TEMP/base" bench-collect
+          cp "$RUNNER_TEMP/base/tests/benchmarks/results/current.json" "$RUNNER_TEMP/base.json"
+
+      # Compare PR (current) against base (baseline) and render the report.
+      # Informational only — this step never fails the build.
+      - name: Compare PR against base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          cp "$RUNNER_TEMP/base.json" tests/benchmarks/baseline/components.json
+          cp "$RUNNER_TEMP/pr.json" tests/benchmarks/results/current.json
+          make bench-report \
+            BENCH_REPORT="$RUNNER_TEMP/benchmark-comment.md" \
+            BASELINE_LABEL="the base branch (\`$BASE_REF\` @ \`${BASE_SHA:0:7}\`), built on the same runner"
+
       - name: Post benchmark comment on PR
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ github.event.pull_request.number }}
-          path: tests/benchmarks/results/benchmark-comment.md
+          path: ${{ runner.temp }}/benchmark-comment.md
           header: benchmark-results

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -52,12 +52,16 @@ jobs:
           cp tests/benchmarks/results/current.json "$RUNNER_TEMP/pr.json"
 
       # Build and run the base branch in a separate worktree on the same runner.
+      # Drive it with version-stable primitives (zig build + the collect script)
+      # rather than this PR's make targets — the base checkout predates them.
+      # BENCH_RUNS is inherited from the job env by the collect script.
       - name: Benchmark base branch
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           git worktree add "$RUNNER_TEMP/base" "$BASE_SHA"
-          make -C "$RUNNER_TEMP/base" bench-collect
+          ( cd "$RUNNER_TEMP/base" \
+            && nix develop --command bash -c 'zig build bench && tests/benchmarks/scripts/collect_results.sh' )
           cp "$RUNNER_TEMP/base/tests/benchmarks/results/current.json" "$RUNNER_TEMP/base.json"
 
       # Compare PR (current) against base (baseline) and render the report.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,52 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+# Cancel superseded runs on the same PR — only the latest push matters.
+concurrency:
+  group: benchmarks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Component Benchmarks
+    runs-on: ubuntu-latest
+
+    if: github.event.pull_request.draft == false
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Setup Nix cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: devenv
+
+      # Run the suite several times and keep the minimum per benchmark. CI
+      # runners are noisy (one-sided: scheduling/cold cache only add time), so
+      # the min over N passes is far more stable than a single run. The result
+      # is compared against the committed baseline; the comparison is purely
+      # informational and never fails the build.
+      - name: Run benchmarks and compare with baseline
+        run: make bench-ci BENCH_RUNS=7 BENCH_REPORT=benchmark-comment.md
+
+      - name: Post benchmark comment on PR
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.pull_request.number }}
+          path: benchmark-comment.md
+          header: benchmark-results

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build run test test-integration test-unit clean fmt lint dev install-deps check-deps env-up env-down env-restart env-logs env-status coverage load-up load-down load-switch load-test-steady load-test-burst load-test-ramp load-test-mixed load-status bench bench-compare bench-save bench-ci
+.PHONY: help build run test test-integration test-unit clean fmt lint dev install-deps check-deps env-up env-down env-restart env-logs env-status coverage load-up load-down load-switch load-test-steady load-test-burst load-test-ramp load-test-mixed load-status bench bench-collect bench-report bench-compare bench-save bench-ci
 
 # Use direnv to auto-load Nix environment for local development
 # This allows commands to work without 'nix develop' wrapper
@@ -226,35 +226,38 @@ bench:
 	@echo ""
 	@./zig-out/bin/message_processor_bench
 
-# Benchmark comparison (local development)
-bench-compare:
+# Build the benchmark binaries and collect one set of results into
+# tests/benchmarks/results/current.json (min of BENCH_RUNS passes). This is the
+# reusable unit: the CI workflow runs it once on the PR and once on the base
+# branch (in a separate worktree) to compare both on identical hardware.
+bench-collect:
 	@echo "Building benchmarks..."
 	@zig build bench >/dev/null 2>&1
 	@echo "Collecting benchmark results..."
 	@tests/benchmarks/scripts/collect_results.sh
-	@echo ""
-	@tests/benchmarks/scripts/compare_results.sh
 
-# CI entrypoint: run the suite (min of BENCH_RUNS passes) against the committed
-# baseline and emit both a terminal report (for the Actions log) and a markdown
-# report at BENCH_REPORT (posted as a PR comment). Informational only, never
-# fails the build.
+# Compare the collected results against the baseline, writing a terminal report
+# (for the Actions log) and a markdown report at BENCH_REPORT (for a PR
+# comment). Reads tests/benchmarks/{baseline/components.json,results/current.json}
+# as prepared by the caller. Informational only, never fails the build.
+# BASELINE_LABEL describes what the baseline represents in the report header.
 BENCH_REPORT ?= tests/benchmarks/results/benchmark-comment.md
-bench-ci:
-	@echo "Building benchmarks..."
-	@zig build bench >/dev/null 2>&1
-	@echo "Collecting benchmark results..."
-	@tests/benchmarks/scripts/collect_results.sh
-	@echo ""
+export BASELINE_LABEL ?=
+bench-report:
 	@tests/benchmarks/scripts/compare_results.sh
 	@tests/benchmarks/scripts/compare_results.sh --markdown > "$(BENCH_REPORT)"
 	@echo "Markdown report written to $(BENCH_REPORT)"
 
-bench-save:
-	@echo "Building benchmarks..."
-	@zig build bench >/dev/null 2>&1
-	@echo "Collecting benchmark results..."
-	@tests/benchmarks/scripts/collect_results.sh
+# Local development: collect + terminal comparison against the committed baseline.
+bench-compare: bench-collect
+	@echo ""
+	@tests/benchmarks/scripts/compare_results.sh
+
+# CI entrypoint: collect + terminal & markdown report.
+bench-ci: bench-collect bench-report
+
+# Save the current results as the new committed baseline.
+bench-save: bench-collect
 	@echo ""
 	@echo "Updating baseline from current results..."
 	@cp tests/benchmarks/results/current.json tests/benchmarks/baseline/components.json

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ bench-compare:
 # baseline and emit both a terminal report (for the Actions log) and a markdown
 # report at BENCH_REPORT (posted as a PR comment). Informational only, never
 # fails the build.
-BENCH_REPORT ?= benchmark-comment.md
+BENCH_REPORT ?= tests/benchmarks/results/benchmark-comment.md
 bench-ci:
 	@echo "Building benchmarks..."
 	@zig build bench >/dev/null 2>&1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build run test test-integration test-unit clean fmt lint dev install-deps check-deps env-up env-down env-restart env-logs env-status coverage load-up load-down load-switch load-test-steady load-test-burst load-test-ramp load-test-mixed load-status bench
+.PHONY: help build run test test-integration test-unit clean fmt lint dev install-deps check-deps env-up env-down env-restart env-logs env-status coverage load-up load-down load-switch load-test-steady load-test-burst load-test-ramp load-test-mixed load-status bench bench-compare bench-save bench-ci
 
 # Use direnv to auto-load Nix environment for local development
 # This allows commands to work without 'nix develop' wrapper
@@ -66,6 +66,7 @@ help:
 	@echo "Component Benchmarks:"
 	@echo "  make bench         - Run component benchmarks (view results in terminal)"
 	@echo "  make bench-compare - Compare current run with baseline (min of BENCH_RUNS passes)"
+	@echo "  make bench-ci      - Compare + write markdown report (used by CI for PR comments)"
 	@echo "  make bench-save    - Save current results as new baseline (BENCH_RUNS=N, default 5)"
 	@echo ""
 	@echo "Dependencies:"
@@ -233,6 +234,21 @@ bench-compare:
 	@tests/benchmarks/scripts/collect_results.sh
 	@echo ""
 	@tests/benchmarks/scripts/compare_results.sh
+
+# CI entrypoint: run the suite (min of BENCH_RUNS passes) against the committed
+# baseline and emit both a terminal report (for the Actions log) and a markdown
+# report at BENCH_REPORT (posted as a PR comment). Informational only, never
+# fails the build.
+BENCH_REPORT ?= benchmark-comment.md
+bench-ci:
+	@echo "Building benchmarks..."
+	@zig build bench >/dev/null 2>&1
+	@echo "Collecting benchmark results..."
+	@tests/benchmarks/scripts/collect_results.sh
+	@echo ""
+	@tests/benchmarks/scripts/compare_results.sh
+	@tests/benchmarks/scripts/compare_results.sh --markdown > "$(BENCH_REPORT)"
+	@echo "Markdown report written to $(BENCH_REPORT)"
 
 bench-save:
 	@echo "Building benchmarks..."

--- a/tests/benchmarks/.gitignore
+++ b/tests/benchmarks/.gitignore
@@ -1,6 +1,7 @@
 # Ignore temporary benchmark results
 results/*.json
 results/*.txt
+results/*.md
 
 # Keep baseline in Git
 !baseline/

--- a/tests/benchmarks/scripts/compare_results.sh
+++ b/tests/benchmarks/scripts/compare_results.sh
@@ -63,6 +63,21 @@ get_threshold() {
     fi
 }
 
+# Percentage change of current vs baseline. Multiply before dividing so bc's
+# fixed scale keeps precision for small deltas (otherwise e.g. +0.7% truncates
+# to +0.0%). Returns 0 when the baseline is 0: there's no meaningful ratio, and
+# it avoids a platform-dependent bc divide-by-zero that produces an empty string
+# and aborts the script under set -e (GNU bc) or fails the assignment (BSD bc).
+# The bc comparison handles both float times and integer allocation counts.
+pct_change() {
+    local current=$1 baseline=$2
+    if [ "$(echo "$baseline == 0" | bc -l)" = "1" ]; then
+        echo "0"
+    else
+        echo "scale=2; (($current - $baseline) * 100) / $baseline" | bc
+    fi
+}
+
 baseline_ts=$(jq -r '.timestamp' "$BASELINE_FILE")
 current_ts=$(jq -r '.timestamp' "$CURRENT_FILE")
 current_runs=$(jq -r '.runs // "?"' "$CURRENT_FILE")
@@ -92,13 +107,15 @@ ignored=0
 
 # Compare each benchmark (use process substitution to preserve variables)
 while read -r bench_name; do
-    # Extract baseline metrics
-    baseline_time=$(jq -r ".benchmarks[\"$bench_name\"].time_avg_us" "$BASELINE_FILE")
-    baseline_allocs=$(jq -r ".benchmarks[\"$bench_name\"].allocations" "$BASELINE_FILE")
+    # Extract baseline metrics (default missing/null fields to 0 so the
+    # arithmetic below never sees the string "null").
+    baseline_time=$(jq -r ".benchmarks[\"$bench_name\"].time_avg_us // 0" "$BASELINE_FILE")
+    baseline_allocs=$(jq -r ".benchmarks[\"$bench_name\"].allocations // 0" "$BASELINE_FILE")
 
-    # Extract current metrics
+    # Extract current metrics. A missing time means the benchmark is absent from
+    # the current results (handled below); a missing alloc count defaults to 0.
     current_time=$(jq -r ".benchmarks[\"$bench_name\"].time_avg_us // \"N/A\"" "$CURRENT_FILE")
-    current_allocs=$(jq -r ".benchmarks[\"$bench_name\"].allocations // \"N/A\"" "$CURRENT_FILE")
+    current_allocs=$(jq -r ".benchmarks[\"$bench_name\"].allocations // 0" "$CURRENT_FILE")
 
     if [ "$current_time" = "N/A" ]; then
         if [ "$MODE" = "markdown" ]; then
@@ -109,9 +126,7 @@ while read -r bench_name; do
         continue
     fi
 
-    # Percentage change. Multiply before dividing so bc's fixed scale keeps
-    # precision for small deltas (otherwise e.g. +0.7% truncates to +0.0%).
-    time_change=$(echo "scale=2; (($current_time - $baseline_time) * 100) / $baseline_time" | bc)
+    time_change=$(pct_change "$current_time" "$baseline_time")
 
     # Classify the change against the time-dependent threshold.
     threshold=$(get_threshold "$baseline_time")
@@ -146,14 +161,7 @@ while read -r bench_name; do
             ignored)   color="$CYAN";  icon="~" ;;
             *)         color="$NC";    icon="→" ;;
         esac
-        # Guard against a zero baseline: bc's divide-by-zero behaviour differs
-        # across platforms (GNU bc prints nothing and still exits 0), which
-        # would feed printf an empty string and abort the script under set -e.
-        if [ "$baseline_allocs" -ne 0 ]; then
-            alloc_change=$(echo "scale=2; (($current_allocs - $baseline_allocs) * 100) / $baseline_allocs" | bc)
-        else
-            alloc_change=0
-        fi
+        alloc_change=$(pct_change "$current_allocs" "$baseline_allocs")
         printf "${color}%-40s${NC} " "$bench_name"
         printf "Time: %8.2fμs → %8.2fμs (%+6.1f%%) %s\n" "$baseline_time" "$current_time" "$time_change" "$icon"
         printf "                                         Allocs: %5d → %5d (%+6.1f%%)\n" "$baseline_allocs" "$current_allocs" "$alloc_change"

--- a/tests/benchmarks/scripts/compare_results.sh
+++ b/tests/benchmarks/scripts/compare_results.sh
@@ -142,7 +142,14 @@ while read -r bench_name; do
             ignored)   color="$CYAN";  icon="~" ;;
             *)         color="$NC";    icon="→" ;;
         esac
-        alloc_change=$(echo "scale=2; (($current_allocs - $baseline_allocs) * 100) / $baseline_allocs" | bc 2>/dev/null || echo "0")
+        # Guard against a zero baseline: bc's divide-by-zero behaviour differs
+        # across platforms (GNU bc prints nothing and still exits 0), which
+        # would feed printf an empty string and abort the script under set -e.
+        if [ "$baseline_allocs" -ne 0 ]; then
+            alloc_change=$(echo "scale=2; (($current_allocs - $baseline_allocs) * 100) / $baseline_allocs" | bc)
+        else
+            alloc_change=0
+        fi
         printf "${color}%-40s${NC} " "$bench_name"
         printf "Time: %8.2fμs → %8.2fμs (%+6.1f%%) %s\n" "$baseline_time" "$current_time" "$time_change" "$icon"
         printf "                                         Allocs: %5d → %5d (%+6.1f%%)\n" "$baseline_allocs" "$current_allocs" "$alloc_change"

--- a/tests/benchmarks/scripts/compare_results.sh
+++ b/tests/benchmarks/scripts/compare_results.sh
@@ -6,7 +6,14 @@ BENCH_DIR="$(dirname "$SCRIPT_DIR")"
 BASELINE_FILE="$BENCH_DIR/baseline/components.json"
 CURRENT_FILE="$BENCH_DIR/results/current.json"
 
-# Colors
+# Output mode: "terminal" (default, colored human output) or "markdown"
+# (GitHub-flavored table for posting as a PR comment). Pick with --markdown.
+MODE="terminal"
+if [ "${1:-}" = "--markdown" ]; then
+    MODE="markdown"
+fi
+
+# Colors (terminal mode only)
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -15,37 +22,23 @@ NC='\033[0m'
 
 # Check if files exist
 if [ ! -f "$BASELINE_FILE" ]; then
-    echo -e "${RED}Error: Baseline file not found: $BASELINE_FILE${NC}"
-    echo "Run 'make bench-save' to create initial baseline"
+    echo -e "${RED}Error: Baseline file not found: $BASELINE_FILE${NC}" >&2
+    echo "Run 'make bench-save' to create initial baseline" >&2
     exit 1
 fi
 
 if [ ! -f "$CURRENT_FILE" ]; then
-    echo -e "${RED}Error: Current results not found: $CURRENT_FILE${NC}"
-    echo "This is an internal error - current results should be generated automatically"
+    echo -e "${RED}Error: Current results not found: $CURRENT_FILE${NC}" >&2
+    echo "This is an internal error - current results should be generated automatically" >&2
     exit 1
 fi
 
 # Check if jq is available
 if ! command -v jq &> /dev/null; then
-    echo -e "${RED}Error: jq is not installed${NC}"
-    echo "Install with: brew install jq (macOS) or apt-get install jq (Linux)"
+    echo -e "${RED}Error: jq is not installed${NC}" >&2
+    echo "Install with: brew install jq (macOS) or apt-get install jq (Linux)" >&2
     exit 1
 fi
-
-# Print header
-echo -e "${CYAN}Benchmark Comparison Report${NC}"
-echo "=================================="
-echo ""
-echo -e "Baseline: $(jq -r '.timestamp' "$BASELINE_FILE")"
-echo -e "Current:  $(jq -r '.timestamp' "$CURRENT_FILE")"
-echo ""
-
-# Counters
-improved=0
-regressed=0
-neutral=0
-ignored=0
 
 # Progressive threshold based on operation time:
 # - < 1μs:    IGNORE (too fast for stable measurements)
@@ -66,20 +59,49 @@ get_threshold() {
     fi
 }
 
+baseline_ts=$(jq -r '.timestamp' "$BASELINE_FILE")
+current_ts=$(jq -r '.timestamp' "$CURRENT_FILE")
+current_runs=$(jq -r '.runs // "?"' "$CURRENT_FILE")
+
+# Header
+if [ "$MODE" = "markdown" ]; then
+    echo "## 📊 Benchmark Results"
+    echo ""
+    echo "Current run is the **minimum over ${current_runs} passes**, compared against the committed baseline (\`tests/benchmarks/baseline/components.json\`)."
+    echo ""
+    echo "| Benchmark | Baseline | Current | Δ Time | Allocs | |"
+    echo "|---|--:|--:|--:|--:|:--:|"
+else
+    echo -e "${CYAN}Benchmark Comparison Report${NC}"
+    echo "=================================="
+    echo ""
+    echo -e "Baseline: $baseline_ts"
+    echo -e "Current:  $current_ts (min of ${current_runs} passes)"
+    echo ""
+fi
+
+# Counters
+improved=0
+regressed=0
+neutral=0
+ignored=0
+
 # Compare each benchmark (use process substitution to preserve variables)
 while read -r bench_name; do
     # Extract baseline metrics
     baseline_time=$(jq -r ".benchmarks[\"$bench_name\"].time_avg_us" "$BASELINE_FILE")
-    baseline_memory=$(jq -r ".benchmarks[\"$bench_name\"].memory_bytes" "$BASELINE_FILE")
     baseline_allocs=$(jq -r ".benchmarks[\"$bench_name\"].allocations" "$BASELINE_FILE")
 
     # Extract current metrics
     current_time=$(jq -r ".benchmarks[\"$bench_name\"].time_avg_us // \"N/A\"" "$CURRENT_FILE")
-    current_memory=$(jq -r ".benchmarks[\"$bench_name\"].memory_bytes // \"N/A\"" "$CURRENT_FILE")
     current_allocs=$(jq -r ".benchmarks[\"$bench_name\"].allocations // \"N/A\"" "$CURRENT_FILE")
 
     if [ "$current_time" = "N/A" ]; then
-        echo -e "${YELLOW}⚠ $bench_name: Not found in current results${NC}"
+        if [ "$MODE" = "markdown" ]; then
+            echo "| \`$bench_name\` | — | — | — | — | ⚠️ missing |"
+        else
+            echo -e "${YELLOW}⚠ $bench_name: Not found in current results${NC}"
+        fi
         continue
     fi
 
@@ -91,24 +113,20 @@ while read -r bench_name; do
     THRESHOLD=$(get_threshold "$baseline_time")
 
     # Determine status
-    status="neutral"
     status_icon="→"
     status_color="$NC"
 
     # Special handling for sub-microsecond operations (ignore changes)
     if [ "$THRESHOLD" = "0" ]; then
-        status="ignored"
         status_icon="~"
         status_color="${CYAN}"
         ignored=$((ignored + 1))
     # Check time regression/improvement
     elif (( $(echo "$time_change > $THRESHOLD" | bc -l) )); then
-        status="regressed"
         status_icon="↑"
         status_color="$RED"
         regressed=$((regressed + 1))
     elif (( $(echo "$time_change < -$THRESHOLD" | bc -l) )); then
-        status="improved"
         status_icon="↓"
         status_color="$GREEN"
         improved=$((improved + 1))
@@ -116,29 +134,48 @@ while read -r bench_name; do
         neutral=$((neutral + 1))
     fi
 
-    # Terminal colored output
-    printf "${status_color}%-40s${NC} " "$bench_name"
-    printf "Time: %8.2fμs → %8.2fμs (%+6.1f%%) %s\n" "$baseline_time" "$current_time" "$time_change" "$status_icon"
-    printf "                                         Allocs: %5d → %5d (%+6.1f%%)\n" "$baseline_allocs" "$current_allocs" "$alloc_change"
-    echo ""
+    if [ "$MODE" = "markdown" ]; then
+        # Map terminal icons to emoji for the table
+        case "$status_icon" in
+            "↑") md_icon="🔴 slower" ;;
+            "↓") md_icon="🟢 faster" ;;
+            "~") md_icon="⚪ noise" ;;
+            *)   md_icon="➡️" ;;
+        esac
+        printf "| \`%s\` | %.2fμs | %.2fμs | %+.1f%% | %d → %d | %s |\n" \
+            "$bench_name" "$baseline_time" "$current_time" "$time_change" \
+            "$baseline_allocs" "$current_allocs" "$md_icon"
+    else
+        printf "${status_color}%-40s${NC} " "$bench_name"
+        printf "Time: %8.2fμs → %8.2fμs (%+6.1f%%) %s\n" "$baseline_time" "$current_time" "$time_change" "$status_icon"
+        printf "                                         Allocs: %5d → %5d (%+6.1f%%)\n" "$baseline_allocs" "$current_allocs" "$alloc_change"
+        echo ""
+    fi
 done < <(jq -r '.benchmarks | keys[]' "$BASELINE_FILE")
 
 # Summary
-echo "=================================="
-echo -e "${GREEN}✓ Improved:  $improved${NC}"
-echo -e "${YELLOW}→ Neutral:   $neutral${NC}"
-echo -e "${RED}✗ Regressed: $regressed${NC}"
-if [ "$ignored" -gt 0 ]; then
-    echo -e "${CYAN}~ Ignored:   $ignored (sub-microsecond operations)${NC}"
-fi
-echo ""
-echo -e "${CYAN}Progressive thresholds: <1μs=ignore, 1-20μs=15%, 20-50μs=10%, ≥50μs=5%${NC}"
-echo ""
-
-# Informational message (no exit 1)
-if [ "$regressed" -gt 0 ]; then
-    echo -e "${YELLOW}Note: Performance regressions detected${NC}"
-    echo -e "${YELLOW}Review the results above to determine if changes are expected${NC}"
+if [ "$MODE" = "markdown" ]; then
+    echo ""
+    echo "**Summary:** 🟢 ${improved} faster · ➡️ ${neutral} neutral · 🔴 ${regressed} slower · ⚪ ${ignored} ignored (sub-μs)"
+    echo ""
+    echo "<sub>Thresholds: <1μs ignore · 1–20μs 15% · 20–50μs 10% · ≥50μs 5%. Measured on a shared CI runner — treat small deltas as noise. Informational only; this check never fails the build.</sub>"
 else
-    echo -e "${GREEN}All benchmarks within acceptable range${NC}"
+    echo "=================================="
+    echo -e "${GREEN}✓ Improved:  $improved${NC}"
+    echo -e "${YELLOW}→ Neutral:   $neutral${NC}"
+    echo -e "${RED}✗ Regressed: $regressed${NC}"
+    if [ "$ignored" -gt 0 ]; then
+        echo -e "${CYAN}~ Ignored:   $ignored (sub-microsecond operations)${NC}"
+    fi
+    echo ""
+    echo -e "${CYAN}Progressive thresholds: <1μs=ignore, 1-20μs=15%, 20-50μs=10%, ≥50μs=5%${NC}"
+    echo ""
+
+    # Informational message (no exit 1)
+    if [ "$regressed" -gt 0 ]; then
+        echo -e "${YELLOW}Note: Performance regressions detected${NC}"
+        echo -e "${YELLOW}Review the results above to determine if changes are expected${NC}"
+    else
+        echo -e "${GREEN}All benchmarks within acceptable range${NC}"
+    fi
 fi

--- a/tests/benchmarks/scripts/compare_results.sh
+++ b/tests/benchmarks/scripts/compare_results.sh
@@ -163,8 +163,22 @@ done < <(jq -r '.benchmarks | keys[]' "$BASELINE_FILE")
 
 # Summary
 if [ "$MODE" = "markdown" ]; then
+    # Only list non-empty buckets so an empty "🔴 0 slower" doesn't draw the eye
+    # when nothing regressed.
+    parts=()
+    [ "$improved" -gt 0 ]  && parts+=("🟢 ${improved} faster")
+    [ "$neutral" -gt 0 ]   && parts+=("➡️ ${neutral} neutral")
+    [ "$regressed" -gt 0 ] && parts+=("🔴 ${regressed} slower")
+    [ "$ignored" -gt 0 ]   && parts+=("⚪ ${ignored} ignored (sub-μs)")
+    summary=""
+    if [ "${#parts[@]}" -gt 0 ]; then
+        for part in "${parts[@]}"; do
+            [ -n "$summary" ] && summary="$summary · "
+            summary="$summary$part"
+        done
+    fi
     echo ""
-    echo "**Summary:** 🟢 ${improved} faster · ➡️ ${neutral} neutral · 🔴 ${regressed} slower · ⚪ ${ignored} ignored (sub-μs)"
+    echo "**Summary:** ${summary:-no benchmarks compared}"
     echo ""
     echo "<sub>Thresholds: <1μs ignore · 1–20μs 15% · 20–50μs 10% · ≥50μs 5%. Measured on a shared CI runner — treat small deltas as noise. Informational only; this check never fails the build.</sub>"
 else

--- a/tests/benchmarks/scripts/compare_results.sh
+++ b/tests/benchmarks/scripts/compare_results.sh
@@ -13,6 +13,10 @@ if [ "${1:-}" = "--markdown" ]; then
     MODE="markdown"
 fi
 
+# What the baseline represents, shown in the markdown report header. Defaults to
+# the committed baseline; the CI workflow overrides it (base branch, same runner).
+BASELINE_LABEL="${BASELINE_LABEL:-the committed baseline (\`tests/benchmarks/baseline/components.json\`)}"
+
 # Colors (terminal mode only)
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -67,7 +71,7 @@ current_runs=$(jq -r '.runs // "?"' "$CURRENT_FILE")
 if [ "$MODE" = "markdown" ]; then
     echo "## 📊 Benchmark Results"
     echo ""
-    echo "Current run is the **minimum over ${current_runs} passes**, compared against the committed baseline (\`tests/benchmarks/baseline/components.json\`)."
+    echo "Current run is the **minimum over ${current_runs} passes**, compared against ${BASELINE_LABEL}."
     echo ""
     echo "| Benchmark | Baseline | Current | Δ Time | Allocs | Status |"
     echo "|---|--:|--:|--:|--:|:--:|"

--- a/tests/benchmarks/scripts/compare_results.sh
+++ b/tests/benchmarks/scripts/compare_results.sh
@@ -69,7 +69,7 @@ if [ "$MODE" = "markdown" ]; then
     echo ""
     echo "Current run is the **minimum over ${current_runs} passes**, compared against the committed baseline (\`tests/benchmarks/baseline/components.json\`)."
     echo ""
-    echo "| Benchmark | Baseline | Current | Δ Time | Allocs | |"
+    echo "| Benchmark | Baseline | Current | Δ Time | Allocs | Status |"
     echo "|---|--:|--:|--:|--:|:--:|"
 else
     echo -e "${CYAN}Benchmark Comparison Report${NC}"
@@ -105,49 +105,46 @@ while read -r bench_name; do
         continue
     fi
 
-    # Calculate percentage change
-    time_change=$(echo "scale=2; (($current_time - $baseline_time) / $baseline_time) * 100" | bc)
-    alloc_change=$(echo "scale=2; (($current_allocs - $baseline_allocs) / $baseline_allocs) * 100" | bc 2>/dev/null || echo "0")
+    # Percentage change. Multiply before dividing so bc's fixed scale keeps
+    # precision for small deltas (otherwise e.g. +0.7% truncates to +0.0%).
+    time_change=$(echo "scale=2; (($current_time - $baseline_time) * 100) / $baseline_time" | bc)
 
-    # Get dynamic threshold based on baseline time
-    THRESHOLD=$(get_threshold "$baseline_time")
-
-    # Determine status
-    status_icon="→"
-    status_color="$NC"
-
-    # Special handling for sub-microsecond operations (ignore changes)
-    if [ "$THRESHOLD" = "0" ]; then
-        status_icon="~"
-        status_color="${CYAN}"
+    # Classify the change against the time-dependent threshold.
+    threshold=$(get_threshold "$baseline_time")
+    if [ "$threshold" = "0" ]; then
+        status="ignored"   # sub-microsecond: too fast to measure reliably
         ignored=$((ignored + 1))
-    # Check time regression/improvement
-    elif (( $(echo "$time_change > $THRESHOLD" | bc -l) )); then
-        status_icon="↑"
-        status_color="$RED"
+    elif (( $(echo "$time_change > $threshold" | bc -l) )); then
+        status="regressed"
         regressed=$((regressed + 1))
-    elif (( $(echo "$time_change < -$THRESHOLD" | bc -l) )); then
-        status_icon="↓"
-        status_color="$GREEN"
+    elif (( $(echo "$time_change < -$threshold" | bc -l) )); then
+        status="improved"
         improved=$((improved + 1))
     else
+        status="neutral"
         neutral=$((neutral + 1))
     fi
 
     if [ "$MODE" = "markdown" ]; then
-        # Map terminal icons to emoji for the table
-        case "$status_icon" in
-            "↑") md_icon="🔴 slower" ;;
-            "↓") md_icon="🟢 faster" ;;
-            "~") md_icon="⚪ noise" ;;
-            *)   md_icon="➡️" ;;
+        case "$status" in
+            regressed) badge="🔴 slower" ;;
+            improved)  badge="🟢 faster" ;;
+            ignored)   badge="⚪ noise" ;;
+            *)         badge="➡️" ;;
         esac
         printf "| \`%s\` | %.2fμs | %.2fμs | %+.1f%% | %d → %d | %s |\n" \
             "$bench_name" "$baseline_time" "$current_time" "$time_change" \
-            "$baseline_allocs" "$current_allocs" "$md_icon"
+            "$baseline_allocs" "$current_allocs" "$badge"
     else
-        printf "${status_color}%-40s${NC} " "$bench_name"
-        printf "Time: %8.2fμs → %8.2fμs (%+6.1f%%) %s\n" "$baseline_time" "$current_time" "$time_change" "$status_icon"
+        case "$status" in
+            regressed) color="$RED";   icon="↑" ;;
+            improved)  color="$GREEN"; icon="↓" ;;
+            ignored)   color="$CYAN";  icon="~" ;;
+            *)         color="$NC";    icon="→" ;;
+        esac
+        alloc_change=$(echo "scale=2; (($current_allocs - $baseline_allocs) * 100) / $baseline_allocs" | bc 2>/dev/null || echo "0")
+        printf "${color}%-40s${NC} " "$bench_name"
+        printf "Time: %8.2fμs → %8.2fμs (%+6.1f%%) %s\n" "$baseline_time" "$current_time" "$time_change" "$icon"
         printf "                                         Allocs: %5d → %5d (%+6.1f%%)\n" "$baseline_allocs" "$current_allocs" "$alloc_change"
         echo ""
     fi


### PR DESCRIPTION
Closes #28.

Runs the component benchmarks on every PR and surfaces the results as a sticky comment, so reviewers can see performance impact without running anything locally.

## Why now
A previous attempt at CI benchmarks was removed (54b056f) because GitHub Actions runners are too noisy for single-run comparisons (6–8x variance → false regressions). Since #26 the baseline is collected as the **minimum over N passes**, which is stable enough to compare in CI. This PR applies the same min-over-N trick to the CI run itself.

## What's here
- **`.github/workflows/benchmarks.yml`** — on non-draft PRs: build the suite, run it `BENCH_RUNS=7` times keeping the per-benchmark minimum, compare against the committed baseline, and post a sticky comment (`marocchino/sticky-pull-request-comment`). Concurrency-cancels superseded runs. No Postgres/Kafka services needed — `kafka_bench` uses librdkafka's mock cluster.
- **`tests/benchmarks/scripts/compare_results.sh`** — new `--markdown` mode that emits a GitHub-flavored table with per-benchmark status (🟢 faster / 🔴 slower / ➡️ neutral / ⚪ sub-μs noise). Terminal mode unchanged.
- **`Makefile`** — new `bench-ci` target: collect (min of `BENCH_RUNS`) + compare + write the markdown report.

## Notes
- **Informational only** — the check never fails the build. The existing progressive thresholds (<1μs ignore, 1–20μs 15%, 20–50μs 10%, ≥50μs 5%) classify deltas; the comment carries a disclaimer that small deltas on shared runners are noise.
- Baseline stays the committed `tests/benchmarks/baseline/components.json`; this PR does not add any automated baseline-update flow.

## Example comment
| Benchmark | Baseline | Current | Δ Time | Allocs | |
|---|--:|--:|--:|--:|:--:|
| \`JsonSerializer\` | 26.36μs | 26.54μs | +0.0% | 3 → 3 | ➡️ |
| \`PgOutputDecoder\` | 49.39μs | 49.65μs | +0.0% | 6 → 6 | ➡️ |

**Summary:** 🟢 0 faster · ➡️ 11 neutral · 🔴 0 slower · ⚪ 2 ignored (sub-μs)