### PR TITLE
release: v0.1.0 (Zig 0.15.2)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .outboxx,
-    .version = "0.15.1",
+    .version = "0.1.0",
     .dependencies = .{
         .toml = .{
             .url = "git+https://github.com/sam701/zig-toml?ref=zig-0.15#475b03c630c802f8b6bd3e239d8fc2279b4fadb8",

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -1,6 +1,6 @@
 const builtin = @import("builtin");
 
-pub const VERSION = "0.1.0-dev";
+pub const VERSION = "0.1.0";
 pub const APP_NAME = "Outboxx";
 pub const DESCRIPTION = "PostgreSQL Change Data Capture with Kafka";
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -127,6 +127,7 @@ fn setupSignalHandlers() void {
 fn printBanner() void {
     printStatus("{s} - {s}\n", .{ constants.APP_NAME, constants.DESCRIPTION });
     printStatus("Version: {s}\n", .{constants.VERSION});
+    printStatus("Zig: {s}\n", .{builtin.zig_version_string});
     printStatus("Build: {s}\n\n", .{@tagName(constants.BUILD_MODE)});
 }
 


### PR DESCRIPTION
Prepares the first public release of Outboxx.

- Introduces an independent Outboxx semver **0.1.0**, decoupled from the Zig toolchain version.
- The Zig version is now shown on its own line in the startup banner via `builtin.zig_version_string` (same idea as k8s -> kubectl: the tool keeps its own version, the toolchain version sits next to it).
- `build.zig.zon` / `constants.zig` VERSION: `0.15.1` -> `0.1.0`.

After merge, a draft release with tag `v0.1.0-zig0.15` will be published.