### PR TITLE
Fix benchmark collector misreading avg times of 1ms or more

### DIFF
--- a/tests/benchmarks/scripts/collect_results.sh
+++ b/tests/benchmarks/scripts/collect_results.sh
@@ -53,14 +53,19 @@ timing_lines_of() {
     grep -E '^[A-Za-z].*[0-9]+(\.[0-9]+)?(us|ns)' "$1" | grep -v '\[MEMORY\]'
 }
 
-# First "<num>us|ns" on a line -> microseconds.
+# Average time/run -> microseconds: take the token before "±" and convert its
+# unit (zbench scales ns/us/ms/s by magnitude).
 time_us_of() {
     local twu unit val
-    twu=$(echo "$1" | grep -oE '[0-9]+(\.[0-9]+)?(us|ns)' | head -1)
-    unit=$(echo "$twu" | grep -oE '(us|ns)')
-    val=$(echo "$twu" | sed 's/us//;s/ns//')
+    twu=$(echo "$1" | grep -oE '[0-9]+(\.[0-9]+)?(ns|us|ms|s) *±' | head -1 | grep -oE '[0-9]+(\.[0-9]+)?(ns|us|ms|s)')
+    unit=$(echo "$twu" | grep -oE '(ns|us|ms|s)$')
+    val=$(echo "$twu" | sed -E 's/(ns|us|ms|s)$//')
     val=${val:-0}
-    [ "$unit" = "ns" ] && val=$(echo "scale=4; $val / 1000" | bc)
+    case "$unit" in
+        ns) val=$(echo "scale=6; $val / 1000" | bc) ;;
+        ms) val=$(echo "scale=6; $val * 1000" | bc) ;;
+        s) val=$(echo "scale=6; $val * 1000000" | bc) ;;
+    esac
     echo "$val"
 }
 


### PR DESCRIPTION
## Why

`collect_results.sh` read each benchmark's avg time/run by grabbing the first `us`/`ns` token on the zbench line. zbench scales the unit by magnitude, so when an avg is ≥ 1ms it prints `ms` — which the parser skipped, then picked up the next `us` token instead: the per-iteration **min** from `(min … max)`. A slow benchmark therefore collapsed to a tiny value.

On a loaded CI runner this hit `MessageProcessor UPDATE` (the heaviest of the three), reported as `29.68μs` against a real ~230μs, which surfaced as a fake `+461%` regression in the PR comparison. The other ops stayed under 1ms and parsed correctly, so only UPDATE flipped.

## What

- `time_us_of`: anchor on the avg token (the one before `±`) and convert its unit, handling `ns`/`us`/`ms`/`s`.

Verified: UPDATE now collects as 232μs locally, matching raw zbench and the committed baseline (230.7μs); synthetic ns/us/ms/s lines convert as expected.
