### PR TITLE
release: v0.2.0 (Zig 0.16.0)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .outboxx,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zbench = .{

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -1,6 +1,6 @@
 const builtin = @import("builtin");
 
-pub const VERSION = "0.1.0";
+pub const VERSION = "0.2.0";
 pub const APP_NAME = "Outboxx";
 pub const DESCRIPTION = "PostgreSQL Change Data Capture with Kafka";
 


### PR DESCRIPTION
Bumps Outboxx to **0.2.0**, the first release built on **Zig 0.16.0** (the previous release targeted Zig 0.15.2). Semver stays decoupled from the toolchain; the release tag will be `v0.2.0-zig0.16`.

- `build.zig.zon` / `src/constants.zig` VERSION: `0.1.0` → `0.2.0`.
- `minimum_zig_version` is already `0.16.0` (set by the port, #22).

After merge: tag `v0.2.0-zig0.16` on `main` and publish a draft release.
