### PR TITLE
Fix secret scanner flagging a non-literal password assignment

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -62,8 +62,11 @@ jobs:
           # Check for common secret patterns
           echo "Scanning for potential secrets..."
 
-          # Database credentials (exclude test configs, format strings, default values, and env var names)
-          if grep -r -i "password.*=" src/ --include="*.zig" | grep -v "_test" | grep -v "// " | grep -v "password.*=.*\"password\"" | grep -v "\.password.*=.*\"password\"" | grep -v "password={s}" | grep -v "password_env" | grep -v "runtime_passwords" | grep -v "getPassword"; then
+          # Database credentials: only a string-literal assignment is a hardcoded
+          # secret, so require a quote after "=" (a bare `const password = expr;`
+          # is a runtime value, not a secret). Exclude test configs, the "password"
+          # default, format strings, and env-var-name fields.
+          if grep -r -i "password.*=.*\"" src/ --include="*.zig" | grep -v "_test" | grep -v "// " | grep -v "password.*=.*\"password\"" | grep -v "\.password.*=.*\"password\"" | grep -v "password={s}" | grep -v "password_env" | grep -v "runtime_passwords" | grep -v "getPassword"; then
             echo "FAIL: Found potential hardcoded passwords"
             exit 1
           fi


### PR DESCRIPTION
## Why

The `Security` workflow (secret detection) fails on `main` after the 0.16 port. Its password check greps `src/` for `password.*=`, which now matches `src/config/config.zig`:

```zig
const password = try allocator.dupe(u8, value);
```

This is a runtime value, not a hardcoded secret. It slips past the existing `grep -v` excludes (it has no `password_env` / `"password"` / etc. on the line). The pre-port code kept this on one line with `password_env`, which was excluded — so the false positive is new with the port's `loadPasswords` refactor.

## What

- Tighten the password pattern to `password.*=.*"` — only a string-literal assignment counts as a hardcoded secret. A bare `const password = <expr>;` no longer matches; a real `password = "secret"` still does. Existing excludes are kept.

Verified locally: the full secret-detection script now prints `PASS` (exit 0).
