### PR TITLE
Replace hand-rolled TOML parser with library

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,12 +14,20 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    // TOML parser dependency (parses config straight into Zig structs)
+    const toml_dep = b.dependency("toml", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const toml_module = toml_dep.module("toml");
+
     // Config module (for type definitions like KafkaSink, Stream, etc.)
     const config_module = b.createModule(.{
         .root_source_file = b.path("src/config/config.zig"),
         .target = target,
         .optimize = optimize,
     });
+    config_module.addImport("toml", toml_module);
 
     // Domain module (new architecture) - must be defined before use
     const domain_module = b.createModule(.{
@@ -141,6 +149,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    config_tests.root_module.addImport("toml", toml_module);
 
     // Domain layer tests (new)
     const domain_tests = b.addTest(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,6 +7,10 @@
             .url = "https://github.com/hendriknielaender/zbench/archive/refs/tags/v0.13.0.tar.gz",
             .hash = "zbench-0.13.0-YTdc7xVBAQCCMC-IdLLuotBeiNNNm8k9Pi2V4VYqrwfI",
         },
+        .toml = .{
+            .url = "git+https://github.com/sam701/zig-toml?ref=zig-0.16#8685923e32e8b8a795eb2715684236975a70faed",
+            .hash = "toml-0.3.0-bV14BRmKAQAWR0FT0KUKFwVJTImaFhWjSe6HfSMtNZOH",
+        },
     },
     .paths = .{""},
     .fingerprint = 0xdcb3806ad7417129,

--- a/dev/config.toml
+++ b/dev/config.toml
@@ -43,7 +43,8 @@ format = "json" # Only "json" format is currently supported
 destination = "outboxx.users" # Kafka topic name
 routing_key = "id" # Field used for partitioning in Kafka
 
-[[streams]] # Second stream example
+# Second stream example
+[[streams]]
 name = "orders_dev_stream"
 
 [streams.source]

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const toml = @import("toml");
 
 // Configuration validation limits and constants
 pub const ValidationLimits = struct {
@@ -57,14 +58,11 @@ pub const SourceConfig = struct {
 
 pub const KafkaSink = struct {
     brokers: []const []const u8,
-    // Track if brokers array was dynamically allocated
-    brokers_allocated: bool = false,
 };
 
 pub const WebhookSink = struct {
     url: []const u8,
     method: []const u8,
-    headers: std.StringHashMap([]const u8),
 };
 
 pub const SinkConfig = struct {
@@ -99,128 +97,57 @@ pub const TableFilter = struct {
     exclude: []const []const u8,
 };
 
-pub const ParseError = error{
-    InvalidToml,
-    MissingSection,
-    InvalidType,
-    OutOfMemory,
-};
-
+// Configuration data, and the TOML parse target. Strings point into the arena of the
+// returned toml.Parsed(Config), so the caller keeps that value alive while using it.
 pub const Config = struct {
     metadata: Metadata,
     source: SourceConfig,
     sink: SinkConfig,
-    streams: []Stream,
-    tables: TableFilter,
+    streams: []const Stream = &.{},
+    tables: ?TableFilter = null,
 
-    // Runtime password storage (populated from ENV)
-    runtime_passwords: std.StringHashMap([]const u8),
-
-    // Track allocated strings for proper cleanup
-    allocated_strings: [][]const u8,
-    allocated_count: usize,
-    allocator: std.mem.Allocator,
-
-    pub fn init(allocator: std.mem.Allocator) Config {
-        return Config{
-            .metadata = Metadata{
-                .version = "", // Empty string, will be set by parser
-            },
-            .source = SourceConfig{ .type = "" }, // Empty, will be set by parser
-            .sink = SinkConfig{ .type = "" },
-            .streams = &.{},
-            .tables = TableFilter{
-                .include = &.{},
-                .exclude = &.{},
-            },
-            .runtime_passwords = std.StringHashMap([]const u8).init(allocator),
-            .allocated_strings = &[_][]const u8{},
-            .allocated_count = 0,
-            .allocator = allocator,
+    /// Parse a config file; caller owns and must deinit the returned result.
+    pub fn loadFromTomlFile(io: std.Io, allocator: std.mem.Allocator, file_path: []const u8) !toml.Parsed(Config) {
+        var parser = toml.Parser(Config).init(allocator);
+        defer parser.deinit();
+        return parser.parseFile(io, file_path) catch |err| {
+            std.log.warn("Failed to parse config file '{s}': {}", .{ file_path, err });
+            return err;
         };
     }
 
-    /// Load passwords from environment variables based on config
-    pub fn loadPasswords(self: *Config, allocator: std.mem.Allocator, environ_map: *std.process.Environ.Map) !void {
-        // Load PostgreSQL password if configured
-        if (self.source.postgres) |postgres| {
-            const value = environ_map.get(postgres.password_env) orelse {
-                std.log.warn("Environment variable '{s}' not found", .{postgres.password_env});
-                return error.EnvironmentVariableNotFound;
-            };
-            const pw = try allocator.dupe(u8, value);
-            try self.runtime_passwords.put("postgres", pw);
-        }
-
-        // Load MySQL password if configured
-        if (self.source.mysql) |mysql| {
-            const value = environ_map.get(mysql.password_env) orelse {
-                std.log.warn("Environment variable '{s}' not found", .{mysql.password_env});
-                return error.EnvironmentVariableNotFound;
-            };
-            const pw = try allocator.dupe(u8, value);
-            try self.runtime_passwords.put("mysql", pw);
-        }
+    /// Parse a config string; caller owns and must deinit the returned result.
+    pub fn loadFromTomlString(allocator: std.mem.Allocator, content: []const u8) !toml.Parsed(Config) {
+        var parser = toml.Parser(Config).init(allocator);
+        defer parser.deinit();
+        return parser.parseString(content);
     }
 
-    /// Get password for source type
-    pub fn getPassword(self: Config, source_type: []const u8) ?[]const u8 {
-        return self.runtime_passwords.get(source_type);
+    /// Read the configured source's password from the environment; caller owns the result.
+    pub fn loadPassword(self: Config, allocator: std.mem.Allocator, environ_map: *std.process.Environ.Map) ![]u8 {
+        const env_name = if (self.source.postgres) |postgres|
+            postgres.password_env
+        else if (self.source.mysql) |mysql|
+            mysql.password_env
+        else
+            return error.PasswordNotConfigured;
+
+        const value = environ_map.get(env_name) orelse {
+            std.log.warn("Environment variable '{s}' not found", .{env_name});
+            return error.EnvironmentVariableNotFound;
+        };
+        return allocator.dupe(u8, value);
     }
 
-    /// Generate PostgreSQL connection string
-    pub fn postgresConnectionString(self: Config, allocator: std.mem.Allocator) ![]u8 {
+    /// Build the libpq connection string for the configured PostgreSQL source.
+    pub fn postgresConnectionString(self: Config, allocator: std.mem.Allocator, password: []const u8) ![]u8 {
         const postgres = self.source.postgres orelse return error.PostgresNotConfigured;
-        const password = self.getPassword("postgres") orelse return error.PasswordNotLoaded;
 
         return std.fmt.allocPrint(
             allocator,
             "host={s} port={d} dbname={s} user={s} password={s} replication=database gssencmode=disable",
             .{ postgres.host, postgres.port, postgres.database, postgres.user, password },
         );
-    }
-
-    pub fn deinit(self: *Config, allocator: std.mem.Allocator) void {
-        // Free runtime passwords
-        var iterator = self.runtime_passwords.iterator();
-        while (iterator.next()) |entry| {
-            allocator.free(entry.value_ptr.*);
-        }
-        self.runtime_passwords.deinit();
-
-        // Free all allocated strings
-        for (self.allocated_strings[0..self.allocated_count]) |str| {
-            allocator.free(str);
-        }
-        if (self.allocated_strings.len > 0) {
-            allocator.free(self.allocated_strings);
-        }
-
-        // Free allocated arrays (only if they were dynamically allocated)
-        if (self.sink.kafka) |*kafka| {
-            if (kafka.brokers_allocated) {
-                // Free individual broker strings
-                for (kafka.brokers) |broker| {
-                    allocator.free(broker);
-                }
-                // Free the brokers array itself
-                allocator.free(kafka.brokers);
-            }
-        }
-
-        // Free streams array and individual stream operation arrays
-        if (self.streams.len > 0) {
-            for (self.streams) |stream| {
-                // Free operations array for each stream if it was allocated
-                if (stream.source.operations.len > 0) {
-                    for (stream.source.operations) |operation| {
-                        allocator.free(operation);
-                    }
-                    allocator.free(stream.source.operations);
-                }
-            }
-            allocator.free(self.streams);
-        }
     }
 
     // Helper validation functions
@@ -496,381 +423,5 @@ pub const Config = struct {
             return error.NoStreamsConfigured;
         }
         try validateStreams(allocator, self.streams);
-    }
-
-    /// Load configuration from TOML file
-    pub fn loadFromTomlFile(io: std.Io, allocator: std.mem.Allocator, file_path: []const u8) !Config {
-        var parser = ConfigParser.init(allocator);
-        return parser.parseFile(io, file_path);
-    }
-};
-
-// Internal configuration parser
-pub const ConfigParser = struct {
-    allocator: std.mem.Allocator,
-
-    pub fn init(allocator: std.mem.Allocator) ConfigParser {
-        return ConfigParser{
-            .allocator = allocator,
-        };
-    }
-
-    /// Parse TOML config file
-    pub fn parseFile(self: *ConfigParser, io: std.Io, file_path: []const u8) !Config {
-        const file_content = std.Io.Dir.cwd().readFileAlloc(io, file_path, self.allocator, .limited(1024 * 1024)) catch |err| {
-            std.log.warn("Failed to read config file: {}", .{err});
-            return err;
-        };
-        defer self.allocator.free(file_content);
-
-        return self.parseToml(file_content);
-    }
-
-    /// Parse TOML content string
-    pub fn parseToml(self: *ConfigParser, content: []const u8) !Config {
-        var result = Config.init(self.allocator);
-
-        // Simple line-by-line parser for our specific TOML structure
-        var lines = std.mem.splitSequence(u8, content, "\n");
-        var current_section: ?[]const u8 = null;
-        var current_subsection: ?[]const u8 = null;
-        var streams_list = std.ArrayList(Stream).empty;
-        defer streams_list.deinit(self.allocator);
-        var current_stream_index: ?usize = null;
-
-        while (lines.next()) |line| {
-            const trimmed = std.mem.trim(u8, line, " \t\r");
-
-            // Skip empty lines and comments
-            if (trimmed.len == 0 or trimmed[0] == '#') continue;
-
-            // Parse array of tables [[streams]]
-            if (trimmed.len >= 4 and std.mem.startsWith(u8, trimmed, "[[")) {
-                // Find closing ]] (may have comments after)
-                const closing_bracket = std.mem.find(u8, trimmed, "]]") orelse continue;
-                const array_section = trimmed[2..closing_bracket];
-
-                if (std.mem.eql(u8, array_section, "streams")) {
-                    // Create new stream entry
-                    try streams_list.append(self.allocator, Stream{
-                        .name = "",
-                        .source = StreamSource{
-                            .resource = "",
-                            .operations = &.{},
-                        },
-                        .flow = StreamFlow{
-                            .format = "",
-                        },
-                        .sink = StreamSink{
-                            .destination = "",
-                            .routing_key = null,
-                        },
-                    });
-                    current_stream_index = streams_list.items.len - 1;
-                    current_section = "streams";
-                    current_subsection = null;
-                }
-                continue;
-            }
-
-            // Parse sections [section]
-            if (trimmed[0] == '[' and trimmed[trimmed.len - 1] == ']') {
-                const section_name = trimmed[1 .. trimmed.len - 1];
-
-                if (std.mem.cut(u8, section_name, ".")) |parts| {
-                    current_section = parts[0];
-                    current_subsection = parts[1];
-                } else {
-                    current_section = section_name;
-                    current_subsection = null;
-                }
-                continue;
-            }
-
-            // Parse key-value pairs
-            if (std.mem.cut(u8, trimmed, "=")) |kv| {
-                const key = std.mem.trim(u8, kv[0], " \t");
-                const value_str = std.mem.trim(u8, kv[1], " \t");
-
-                const current_stream = if (current_stream_index) |idx| &streams_list.items[idx] else null;
-                try self.setConfigValue(&result, current_section, current_subsection, key, value_str, current_stream);
-            }
-        }
-
-        // Convert streams list to owned slice
-        if (streams_list.items.len > 0) {
-            result.streams = try self.allocator.dupe(Stream, streams_list.items);
-        }
-
-        return result;
-    }
-
-    fn setConfigValue(
-        self: *ConfigParser,
-        config: *Config,
-        section: ?[]const u8,
-        subsection: ?[]const u8,
-        key: []const u8,
-        value_str: []const u8,
-        current_stream: ?*Stream,
-    ) !void {
-        if (section == null) return;
-
-        if (std.mem.eql(u8, section.?, "metadata")) {
-            try self.parseMetadataValue(config, key, value_str);
-        } else if (std.mem.eql(u8, section.?, "source")) {
-            if (subsection == null) {
-                try self.parseSourceValue(config, key, value_str);
-            } else if (subsection != null) {
-                if (std.mem.eql(u8, subsection.?, "postgres")) {
-                    try self.parsePostgresValue(config, key, value_str);
-                } else if (std.mem.eql(u8, subsection.?, "mysql")) {
-                    try self.parseMysqlValue(config, key, value_str);
-                }
-            }
-        } else if (std.mem.eql(u8, section.?, "sink")) {
-            if (subsection == null) {
-                try self.parseSinkValue(config, key, value_str);
-            } else if (subsection != null) {
-                if (std.mem.eql(u8, subsection.?, "kafka")) {
-                    try self.parseKafkaValue(config, key, value_str);
-                }
-            }
-        } else if (std.mem.eql(u8, section.?, "streams")) {
-            if (current_stream) |stream| {
-                try self.parseStreamValue(stream, subsection, key, value_str, config);
-            }
-        }
-    }
-
-    fn parseMetadataValue(self: *ConfigParser, config: *Config, key: []const u8, value_str: []const u8) !void {
-        const value = try self.parseStringValue(config, value_str);
-
-        if (std.mem.eql(u8, key, "version")) {
-            config.metadata.version = value;
-        }
-    }
-
-    fn parseSourceValue(self: *ConfigParser, config: *Config, key: []const u8, value_str: []const u8) !void {
-        const value = try self.parseStringValue(config, value_str);
-
-        if (std.mem.eql(u8, key, "type")) {
-            config.source.type = value;
-        }
-    }
-
-    fn parseSinkValue(self: *ConfigParser, config: *Config, key: []const u8, value_str: []const u8) !void {
-        const value = try self.parseStringValue(config, value_str);
-
-        if (std.mem.eql(u8, key, "type")) {
-            config.sink.type = value;
-        }
-    }
-
-    fn parsePostgresValue(self: *ConfigParser, config: *Config, key: []const u8, value_str: []const u8) !void {
-        if (config.source.postgres == null) {
-            config.source.postgres = PostgresSource{
-                .host = "localhost",
-                .port = 5432,
-                .database = "outboxx_test",
-                .user = "postgres",
-                .password_env = "POSTGRES_PASSWORD",
-                .slot_name = "outboxx_slot",
-                .publication_name = "outboxx_publication",
-            };
-        }
-
-        var postgres = &config.source.postgres.?;
-
-        if (std.mem.eql(u8, key, "host")) {
-            postgres.host = try self.parseStringValue(config, value_str);
-        } else if (std.mem.eql(u8, key, "port")) {
-            postgres.port = self.parseIntValue(u16, value_str) catch |err| {
-                std.log.warn("Invalid postgres.port value '{s}': {}, using default 5432", .{ value_str, err });
-                return err;
-            };
-        } else if (std.mem.eql(u8, key, "database")) {
-            postgres.database = try self.parseStringValue(config, value_str);
-        } else if (std.mem.eql(u8, key, "user")) {
-            postgres.user = try self.parseStringValue(config, value_str);
-        } else if (std.mem.eql(u8, key, "password_env")) {
-            postgres.password_env = try self.parseStringValue(config, value_str);
-        } else if (std.mem.eql(u8, key, "slot_name")) {
-            postgres.slot_name = try self.parseStringValue(config, value_str);
-        } else if (std.mem.eql(u8, key, "publication_name")) {
-            postgres.publication_name = try self.parseStringValue(config, value_str);
-        }
-    }
-
-    fn parseMysqlValue(self: *ConfigParser, config: *Config, key: []const u8, value_str: []const u8) !void {
-        if (config.source.mysql == null) {
-            config.source.mysql = MysqlSource{
-                .host = "localhost",
-                .port = 3306,
-                .database = "myapp",
-                .user = "root",
-                .password_env = "MYSQL_PASSWORD",
-                .server_id = 1,
-                .binlog_format = "ROW",
-            };
-        }
-
-        var mysql = &config.source.mysql.?;
-
-        if (std.mem.eql(u8, key, "host")) {
-            mysql.host = try self.parseStringValue(config, value_str);
-        } else if (std.mem.eql(u8, key, "port")) {
-            mysql.port = self.parseIntValue(u16, value_str) catch |err| {
-                std.log.warn("Invalid mysql.port value '{s}': {}, using default 3306", .{ value_str, err });
-                return err;
-            };
-        } else if (std.mem.eql(u8, key, "database")) {
-            mysql.database = try self.parseStringValue(config, value_str);
-        } else if (std.mem.eql(u8, key, "user")) {
-            mysql.user = try self.parseStringValue(config, value_str);
-        } else if (std.mem.eql(u8, key, "password_env")) {
-            mysql.password_env = try self.parseStringValue(config, value_str);
-        } else if (std.mem.eql(u8, key, "server_id")) {
-            mysql.server_id = self.parseIntValue(u32, value_str) catch |err| {
-                std.log.warn("Invalid mysql.server_id value '{s}': {}, using default 1", .{ value_str, err });
-                return err;
-            };
-        } else if (std.mem.eql(u8, key, "binlog_format")) {
-            mysql.binlog_format = try self.parseStringValue(config, value_str);
-        }
-    }
-
-    fn parseKafkaValue(self: *ConfigParser, config: *Config, key: []const u8, value_str: []const u8) !void {
-        if (config.sink.kafka == null) {
-            config.sink.kafka = KafkaSink{
-                .brokers = &[_][]const u8{},
-                .brokers_allocated = false,
-            };
-        }
-
-        var kafka = &config.sink.kafka.?;
-
-        if (std.mem.eql(u8, key, "brokers")) {
-            kafka.brokers = try self.parseStringArray(value_str);
-            kafka.brokers_allocated = true;
-        }
-    }
-
-    fn parseIntValue(self: *ConfigParser, comptime T: type, value_str: []const u8) !T {
-        _ = self;
-
-        const clean_str = std.mem.trim(u8, value_str, " \t\"");
-        return std.fmt.parseInt(T, clean_str, 10);
-    }
-
-    fn parseStringArray(self: *ConfigParser, value_str: []const u8) ![]const []const u8 {
-        // Remove comments first
-        const value_without_comment = if (std.mem.cut(u8, value_str, "#")) |parts|
-            std.mem.trim(u8, parts[0], " \t")
-        else
-            value_str;
-
-        // Simple array parsing for ["item1", "item2"]
-        const clean_str = std.mem.trim(u8, value_without_comment, " \t");
-
-        if (clean_str.len < 2 or clean_str[0] != '[' or clean_str[clean_str.len - 1] != ']') {
-            return &[_][]const u8{};
-        }
-
-        const array_content = clean_str[1 .. clean_str.len - 1];
-
-        // Handle empty array
-        if (array_content.len == 0) {
-            return &[_][]const u8{};
-        }
-
-        // Count commas to estimate size
-        var count: usize = 1;
-        for (array_content) |c| {
-            if (c == ',') count += 1;
-        }
-
-        // Allocate array for items
-        const items = try self.allocator.alloc([]const u8, count);
-        var item_index: usize = 0;
-
-        var parts = std.mem.splitSequence(u8, array_content, ",");
-        while (parts.next()) |part| {
-            const trimmed_part = std.mem.trim(u8, part, " \t\"");
-            if (trimmed_part.len > 0 and item_index < items.len) {
-                // Duplicate the string so it stays valid
-                items[item_index] = try self.allocator.dupe(u8, trimmed_part);
-                item_index += 1;
-            }
-        }
-
-        // Resize to actual count
-        return self.allocator.realloc(items, item_index);
-    }
-
-    fn parseStreamValue(
-        self: *ConfigParser,
-        stream: *Stream,
-        subsection: ?[]const u8,
-        key: []const u8,
-        value_str: []const u8,
-        config: *Config,
-    ) !void {
-        if (subsection == null) {
-            // Direct stream properties
-            if (std.mem.eql(u8, key, "name")) {
-                stream.name = try self.parseStringValue(config, value_str);
-            }
-        } else if (std.mem.eql(u8, subsection.?, "source")) {
-            // Stream source properties
-            if (std.mem.eql(u8, key, "resource")) {
-                stream.source.resource = try self.parseStringValue(config, value_str);
-            } else if (std.mem.eql(u8, key, "operations")) {
-                stream.source.operations = try self.parseStringArray(value_str);
-            }
-        } else if (std.mem.eql(u8, subsection.?, "flow")) {
-            // Stream flow properties
-            if (std.mem.eql(u8, key, "format")) {
-                stream.flow.format = try self.parseStringValue(config, value_str);
-            }
-        } else if (std.mem.eql(u8, subsection.?, "sink")) {
-            // Stream sink properties
-            if (std.mem.eql(u8, key, "destination")) {
-                stream.sink.destination = try self.parseStringValue(config, value_str);
-            } else if (std.mem.eql(u8, key, "routing_key")) {
-                stream.sink.routing_key = try self.parseStringValue(config, value_str);
-            }
-        }
-    }
-
-    fn parseStringValue(self: *ConfigParser, target: anytype, value_str: []const u8) ![]const u8 {
-        // Remove comments first
-        const value_without_comment = if (std.mem.cut(u8, value_str, "#")) |parts|
-            std.mem.trim(u8, parts[0], " \t")
-        else
-            value_str;
-
-        // Remove quotes if present
-        const clean_value = if (value_without_comment.len >= 2 and value_without_comment[0] == '"' and value_without_comment[value_without_comment.len - 1] == '"')
-            value_without_comment[1 .. value_without_comment.len - 1]
-        else
-            value_without_comment;
-
-        // Make owned copy of the string
-        const owned_string = try self.allocator.dupe(u8, clean_value);
-
-        // Track for cleanup based on target type
-        if (@TypeOf(target) == *Config) {
-            const config = target;
-            // Track for cleanup - grow array if needed
-            if (config.allocated_count >= config.allocated_strings.len) {
-                const new_size = if (config.allocated_strings.len == 0) 10 else config.allocated_strings.len * 2;
-                config.allocated_strings = try config.allocator.realloc(config.allocated_strings, new_size);
-            }
-            config.allocated_strings[config.allocated_count] = owned_string;
-            config.allocated_count += 1;
-        }
-
-        return owned_string;
     }
 };

--- a/src/config/config_test.zig
+++ b/src/config/config_test.zig
@@ -4,205 +4,125 @@ const testing = std.testing;
 const config = @import("config.zig");
 const Config = config.Config;
 
-// Test helper function - creates valid config for testing
-fn createTestDefault(allocator: std.mem.Allocator) Config {
-    var test_config = Config.init(allocator);
-
-    // Set metadata for validation
-    test_config.metadata.version = "v0";
-
-    // Set source type and PostgreSQL configuration
-    test_config.source.type = "postgres";
-    test_config.source.postgres = config.PostgresSource{
-        .host = "localhost",
-        .port = 5432,
-        .database = "outboxx_test",
-        .user = "postgres",
-        .password_env = "POSTGRES_PASSWORD",
-        .slot_name = "outboxx_slot",
-        .publication_name = "outboxx_publication",
-    };
-
-    // Set sink type and Kafka configuration
-    test_config.sink.type = "kafka";
-    test_config.sink.kafka = config.KafkaSink{
-        .brokers = &[_][]const u8{"localhost:9092"},
-        .brokers_allocated = false, // This is a const array, not allocated
-    };
-
-    // Add a test stream for validation
-    // Allocate operations array dynamically so deinit can free it properly
-    const insert_op = allocator.dupe(u8, "insert") catch "insert";
-    const operations = allocator.dupe([]const u8, &[_][]const u8{insert_op}) catch &[_][]const u8{};
-
-    const stream = config.Stream{
-        .name = "test_stream",
-        .source = config.StreamSource{
-            .resource = "users",
-            .operations = operations,
+// Valid config built from static data. No allocations, so nothing to free.
+fn createTestDefault() Config {
+    return .{
+        .metadata = .{ .version = "v0" },
+        .source = .{
+            .type = "postgres",
+            .postgres = .{
+                .host = "localhost",
+                .port = 5432,
+                .database = "outboxx_test",
+                .user = "postgres",
+                .password_env = "POSTGRES_PASSWORD",
+                .slot_name = "outboxx_slot",
+                .publication_name = "outboxx_publication",
+            },
         },
-        .flow = config.StreamFlow{
-            .format = "json",
+        .sink = .{
+            .type = "kafka",
+            .kafka = .{ .brokers = &.{"localhost:9092"} },
         },
-        .sink = config.StreamSink{
-            .destination = "test_topic",
-            .routing_key = null,
+        .streams = &.{
+            .{
+                .name = "test_stream",
+                .source = .{ .resource = "users", .operations = &.{"insert"} },
+                .flow = .{ .format = "json" },
+                .sink = .{ .destination = "test_topic", .routing_key = null },
+            },
         },
     };
-
-    // Allocate streams array with one test stream
-    test_config.streams = allocator.dupe(config.Stream, &[_]config.Stream{stream}) catch &[_]config.Stream{};
-
-    return test_config;
 }
 
-// Basic Config tests
-test "Config.init" {
-    const allocator = testing.allocator;
-    var cfg = Config.init(allocator);
-    defer cfg.deinit(allocator);
-
-    // Config.init now creates empty config that needs to be filled by parser
-    try testing.expectEqualStrings("", cfg.metadata.version);
-    try testing.expectEqualStrings("", cfg.source.type);
-}
-
-test "Config basic functionality" {
-    const allocator = testing.allocator;
-    var cfg = Config.init(allocator);
-    defer cfg.deinit(allocator);
-
-    // Config.init now creates empty config - basic validation
-    try testing.expect(cfg.metadata.version.len == 0);
-    try testing.expect(cfg.source.type.len == 0);
-    try testing.expect(cfg.sink.type.len == 0);
-}
+// Complete, valid configuration used by parsing tests.
+const valid_config_toml =
+    \\[metadata]
+    \\version = "v0"
+    \\
+    \\[source]
+    \\type = "postgres"
+    \\
+    \\[source.postgres]
+    \\host = "pg.example.com"
+    \\port = 5433
+    \\database = "production_db"
+    \\user = "app_user"
+    \\password_env = "PROD_PASSWORD"
+    \\slot_name = "prod_slot"
+    \\publication_name = "prod_pub"
+    \\
+    \\[sink]
+    \\type = "kafka"
+    \\
+    \\[sink.kafka]
+    \\brokers = ["kafka1:9092"]
+    \\
+    \\[[streams]]
+    \\name = "users-stream"
+    \\
+    \\[streams.source]
+    \\resource = "users"
+    \\operations = ["insert", "update"]
+    \\
+    \\[streams.flow]
+    \\format = "json"
+    \\
+    \\[streams.sink]
+    \\destination = "outboxx.users"
+    \\routing_key = "id"
+;
 
 test "createTestDefault" {
-    const allocator = testing.allocator;
-    var cfg = createTestDefault(allocator);
-    defer cfg.deinit(allocator);
+    const cfg = createTestDefault();
 
-    // Test PostgreSQL defaults
     try testing.expect(cfg.source.postgres != null);
     const postgres = cfg.source.postgres.?;
     try testing.expectEqualStrings("localhost", postgres.host);
     try testing.expect(postgres.port == 5432);
     try testing.expectEqualStrings("outboxx_test", postgres.database);
-    try testing.expectEqualStrings("postgres", postgres.user);
-    try testing.expectEqualStrings("POSTGRES_PASSWORD", postgres.password_env);
-    try testing.expectEqualStrings("outboxx_slot", postgres.slot_name);
-    try testing.expectEqualStrings("outboxx_publication", postgres.publication_name);
 
-    // Test Kafka defaults
     try testing.expect(cfg.sink.kafka != null);
-    const kafka = cfg.sink.kafka.?;
-    try testing.expect(kafka.brokers.len == 1);
-    try testing.expectEqualStrings("localhost:9092", kafka.brokers[0]);
+    try testing.expect(cfg.sink.kafka.?.brokers.len == 1);
+    try testing.expectEqualStrings("localhost:9092", cfg.sink.kafka.?.brokers[0]);
 }
 
-// TOML Parser tests
-test "parse basic TOML config - file not found should fail" {
-    const allocator = testing.allocator;
-
-    // This should fail with FileNotFound error (fail fast)
-    const result = Config.loadFromTomlFile(testing.io, allocator, "dummy_path");
+// TOML parsing tests
+test "loadFromTomlFile - missing file fails fast" {
+    const result = Config.loadFromTomlFile(testing.io, testing.allocator, "dummy_path");
     try testing.expectError(error.FileNotFound, result);
 }
 
-test "parse basic TOML config - real file" {
+test "loadFromTomlFile - real file" {
     const allocator = testing.allocator;
-
-    // Create a temporary TOML file for testing
-    const temp_content =
-        \\[metadata]
-        \\version = "0"
-        \\
-        \\[source]
-        \\type = "postgres"
-        \\
-        \\[source.postgres]
-        \\host = "testhost"
-        \\port = 5433
-        \\database = "testdb"
-        \\user = "testuser"
-        \\password_env = "TEST_PASSWORD"
-        \\slot_name = "test_slot"
-        \\publication_name = "test_pub"
-        \\
-        \\[sink]
-        \\type = "kafka"
-        \\
-        \\[sink.kafka]
-        \\brokers = ["kafka1:9092"]
-    ;
-
-    // Write to temporary file
     const io = testing.io;
-    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = "test_config.toml", .data = temp_content });
+
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = "test_config.toml", .data = valid_config_toml });
     defer std.Io.Dir.cwd().deleteFile(io, "test_config.toml") catch {};
 
-    // Now parse the real file
-    var parsed_config = try Config.loadFromTomlFile(io, allocator, "test_config.toml");
-    defer parsed_config.deinit(allocator);
+    var parsed = try Config.loadFromTomlFile(io, allocator, "test_config.toml");
+    defer parsed.deinit();
+    const cfg = parsed.value;
 
-    // Verify it was parsed correctly
-    try testing.expectEqualStrings("0", parsed_config.metadata.version);
-
-    try testing.expect(parsed_config.source.postgres != null);
-    const postgres = parsed_config.source.postgres.?;
-    try testing.expectEqualStrings("testhost", postgres.host);
+    try testing.expectEqualStrings("v0", cfg.metadata.version);
+    try testing.expect(cfg.source.postgres != null);
+    const postgres = cfg.source.postgres.?;
+    try testing.expectEqualStrings("pg.example.com", postgres.host);
     try testing.expect(postgres.port == 5433);
-    try testing.expectEqualStrings("testdb", postgres.database);
-
-    // Validate the configuration (skip for now, parser needs improvement)
-    // try parsed_config.validate();
+    try testing.expectEqualStrings("production_db", postgres.database);
 }
 
-test "Config validation" {
-    const allocator = testing.allocator;
-
-    // Test valid default config
-    var valid_config = createTestDefault(allocator);
-    defer valid_config.deinit(allocator);
-    try valid_config.validate(allocator);
-
-    // Test invalid config - missing version
-    var invalid_config = Config.init(allocator);
-    defer invalid_config.deinit(allocator);
-    try testing.expectError(error.MissingConfigVersion, invalid_config.validate(allocator));
-}
-
-test "Config validation - unsupported version" {
-    const allocator = testing.allocator;
-
-    // Test config with unsupported version
-    var invalid_version_config = createTestDefault(allocator);
-    defer invalid_version_config.deinit(allocator);
-    invalid_version_config.metadata.version = "1"; // Unsupported version
-    try testing.expectError(error.UnsupportedConfigVersion, invalid_version_config.validate(allocator));
+test "loadFromTomlString - empty document fails" {
+    try testing.expectError(error.MissingRequiredField, Config.loadFromTomlString(testing.allocator, ""));
 }
 
 test "parse PostgreSQL config section" {
-    const allocator = testing.allocator;
+    var parsed = try Config.loadFromTomlString(testing.allocator, valid_config_toml);
+    defer parsed.deinit();
+    const cfg = parsed.value;
 
-    const toml_content =
-        \\[source.postgres]
-        \\host = "pg.example.com"
-        \\port = 5433
-        \\database = "production_db"
-        \\user = "app_user"
-        \\password_env = "PROD_PASSWORD"
-        \\slot_name = "prod_slot"
-        \\publication_name = "prod_pub"
-    ;
-
-    var parser = config.ConfigParser.init(allocator);
-    var parsed_config = try parser.parseToml(toml_content);
-    defer parsed_config.deinit(allocator);
-
-    try testing.expect(parsed_config.source.postgres != null);
-    const postgres = parsed_config.source.postgres.?;
+    try testing.expect(cfg.source.postgres != null);
+    const postgres = cfg.source.postgres.?;
     try testing.expectEqualStrings("pg.example.com", postgres.host);
     try testing.expect(postgres.port == 5433);
     try testing.expectEqualStrings("production_db", postgres.database);
@@ -212,178 +132,57 @@ test "parse PostgreSQL config section" {
     try testing.expectEqualStrings("prod_pub", postgres.publication_name);
 }
 
-test "parse Kafka config section" {
-    const allocator = testing.allocator;
-
-    const toml_content =
-        \\[sink.kafka]
-        \\brokers = ["kafka1:9092", "kafka2:9092", "kafka3:9092"]
-    ;
-
-    var parser = config.ConfigParser.init(allocator);
-    var parsed_config = try parser.parseToml(toml_content);
-    defer parsed_config.deinit(allocator);
-
-    try testing.expect(parsed_config.sink.kafka != null);
-    const kafka = parsed_config.sink.kafka.?;
-    try testing.expect(kafka.brokers.len == 3);
-    try testing.expectEqualStrings("kafka1:9092", kafka.brokers[0]);
-    try testing.expectEqualStrings("kafka2:9092", kafka.brokers[1]);
-    try testing.expectEqualStrings("kafka3:9092", kafka.brokers[2]);
-}
-
-test "parse complete TOML config" {
-    const allocator = testing.allocator;
-
+test "parse Kafka config section with multiple brokers" {
     const toml_content =
         \\[metadata]
-        \\version = "0"
+        \\version = "v0"
+        \\
+        \\[source]
+        \\type = "postgres"
         \\
         \\[source.postgres]
-        \\host = "prod-db.company.com"
+        \\host = "localhost"
         \\port = 5432
-        \\database = "main_app"
-        \\user = "cdc_user"
-        \\password_env = "CDC_PASSWORD"
-        \\slot_name = "main_slot"
-        \\publication_name = "all_tables"
+        \\database = "db"
+        \\user = "user"
+        \\password_env = "PWD"
+        \\slot_name = "slot"
+        \\publication_name = "pub"
         \\
-        \\[sink.kafka]
-        \\brokers = ["kafka.internal:9092"]
-    ;
-
-    var parser = config.ConfigParser.init(allocator);
-    var parsed_config = try parser.parseToml(toml_content);
-    defer parsed_config.deinit(allocator);
-
-    // Test metadata
-    try testing.expectEqualStrings("0", parsed_config.metadata.version);
-
-    // Test PostgreSQL config
-    try testing.expect(parsed_config.source.postgres != null);
-    const postgres = parsed_config.source.postgres.?;
-    try testing.expectEqualStrings("prod-db.company.com", postgres.host);
-    try testing.expectEqualStrings("main_app", postgres.database);
-    try testing.expectEqualStrings("cdc_user", postgres.user);
-    try testing.expectEqualStrings("CDC_PASSWORD", postgres.password_env);
-    try testing.expectEqualStrings("main_slot", postgres.slot_name);
-    try testing.expectEqualStrings("all_tables", postgres.publication_name);
-
-    // Test Kafka config
-    try testing.expect(parsed_config.sink.kafka != null);
-    const kafka = parsed_config.sink.kafka.?;
-    try testing.expect(kafka.brokers.len == 1);
-    try testing.expectEqualStrings("kafka.internal:9092", kafka.brokers[0]);
-}
-
-// Custom TOML parser compatibility tests
-test "Custom TOML parser can parse empty document" {
-    const allocator = testing.allocator;
-
-    const toml_content = "";
-
-    var parser = config.ConfigParser.init(allocator);
-    var result = parser.parseToml(toml_content) catch |err| {
-        // Empty document should fail gracefully
-        std.debug.print("Expected error for empty document: {}\n", .{err});
-        return;
-    };
-    defer result.deinit(allocator);
-}
-
-test "Custom TOML parser can parse simple string" {
-    const allocator = testing.allocator;
-
-    const toml_content =
-        \\[metadata]
-        \\version = "0"
-    ;
-
-    var parser = config.ConfigParser.init(allocator);
-    var result = try parser.parseToml(toml_content);
-    defer result.deinit(allocator);
-
-    try testing.expectEqualStrings("0", result.metadata.version);
-}
-
-test "Custom TOML parser can parse numbers" {
-    const allocator = testing.allocator;
-
-    const toml_content =
-        \\[source.postgres]
-        \\port = 8080
-    ;
-
-    var parser = config.ConfigParser.init(allocator);
-    var result = try parser.parseToml(toml_content);
-    defer result.deinit(allocator);
-
-    try testing.expect(result.source.postgres != null);
-    try testing.expect(result.source.postgres.?.port == 8080);
-}
-
-test "Custom TOML parser can parse boolean values" {
-    const allocator = testing.allocator;
-
-    const toml_content =
-        \\[sink.kafka]
-        \\enabled = true
-    ;
-
-    var parser = config.ConfigParser.init(allocator);
-    var result = try parser.parseToml(toml_content);
-    defer result.deinit(allocator);
-
-    // Note: Our parser doesn't support booleans yet, this test documents current limitations
-    // When we add boolean support, update this test
-}
-
-test "Custom TOML parser can parse arrays" {
-    const allocator = testing.allocator;
-
-    const toml_content =
+        \\[sink]
+        \\type = "kafka"
+        \\
         \\[sink.kafka]
         \\brokers = ["kafka1:9092", "kafka2:9092", "kafka3:9092"]
     ;
 
-    var parser = config.ConfigParser.init(allocator);
-    var result = try parser.parseToml(toml_content);
-    defer result.deinit(allocator);
+    var parsed = try Config.loadFromTomlString(testing.allocator, toml_content);
+    defer parsed.deinit();
+    const cfg = parsed.value;
 
-    try testing.expect(result.sink.kafka != null);
-    const kafka = result.sink.kafka.?;
+    try testing.expect(cfg.sink.kafka != null);
+    const kafka = cfg.sink.kafka.?;
     try testing.expect(kafka.brokers.len == 3);
     try testing.expectEqualStrings("kafka1:9092", kafka.brokers[0]);
     try testing.expectEqualStrings("kafka2:9092", kafka.brokers[1]);
     try testing.expectEqualStrings("kafka3:9092", kafka.brokers[2]);
 }
 
-test "Custom TOML parser can parse streams array" {
-    const allocator = testing.allocator;
+test "parse integer values" {
+    var parsed = try Config.loadFromTomlString(testing.allocator, valid_config_toml);
+    defer parsed.deinit();
 
-    const toml_content =
-        \\[[streams]]
-        \\name = "users-dev-stream"
-        \\
-        \\[streams.source]
-        \\resource = "users"
-        \\operations = ["insert", "update"]
-        \\
-        \\[streams.flow]
-        \\format = "json"
-        \\
-        \\[streams.sink]
-        \\destination = "outboxx.users"
-        \\routing_key = "id"
-    ;
+    try testing.expect(parsed.value.source.postgres.?.port == 5433);
+}
 
-    var parser = config.ConfigParser.init(allocator);
-    var result = try parser.parseToml(toml_content);
-    defer result.deinit(allocator);
+test "parse stream with inline comments and optional routing_key" {
+    var parsed = try Config.loadFromTomlString(testing.allocator, valid_config_toml);
+    defer parsed.deinit();
+    const cfg = parsed.value;
 
-    try testing.expect(result.streams.len == 1);
-    const stream = result.streams[0];
-    try testing.expectEqualStrings("users-dev-stream", stream.name);
+    try testing.expect(cfg.streams.len == 1);
+    const stream = cfg.streams[0];
+    try testing.expectEqualStrings("users-stream", stream.name);
     try testing.expectEqualStrings("users", stream.source.resource);
     try testing.expect(stream.source.operations.len == 2);
     try testing.expectEqualStrings("insert", stream.source.operations[0]);
@@ -393,11 +192,31 @@ test "Custom TOML parser can parse streams array" {
     try testing.expectEqualStrings("id", stream.sink.routing_key.?);
 }
 
-test "Custom TOML parser can parse multiple streams with inline comments" {
-    const allocator = testing.allocator;
-
+test "parse multiple streams" {
     const toml_content =
-        \\[[streams]] # First stream for users
+        \\[metadata]
+        \\version = "v0"
+        \\
+        \\[source]
+        \\type = "postgres"
+        \\
+        \\[source.postgres]
+        \\host = "localhost"
+        \\port = 5432
+        \\database = "db"
+        \\user = "user"
+        \\password_env = "PWD"
+        \\slot_name = "slot"
+        \\publication_name = "pub"
+        \\
+        \\[sink]
+        \\type = "kafka"
+        \\
+        \\[sink.kafka]
+        \\brokers = ["kafka1:9092"]
+        \\
+        \\# First stream for users
+        \\[[streams]]
         \\name = "users-stream"
         \\
         \\[streams.source]
@@ -411,7 +230,8 @@ test "Custom TOML parser can parse multiple streams with inline comments" {
         \\destination = "outboxx.users"
         \\routing_key = "id"
         \\
-        \\[[streams]] # Second stream for orders
+        \\# Second stream for orders
+        \\[[streams]]
         \\name = "orders-stream"
         \\
         \\[streams.source]
@@ -426,136 +246,112 @@ test "Custom TOML parser can parse multiple streams with inline comments" {
         \\routing_key = "order_id"
     ;
 
-    var parser = config.ConfigParser.init(allocator);
-    var result = try parser.parseToml(toml_content);
-    defer result.deinit(allocator);
+    var parsed = try Config.loadFromTomlString(testing.allocator, toml_content);
+    defer parsed.deinit();
+    const cfg = parsed.value;
 
-    // Verify we parsed both streams
-    try testing.expect(result.streams.len == 2);
+    try testing.expect(cfg.streams.len == 2);
 
-    // First stream
-    const stream1 = result.streams[0];
+    const stream1 = cfg.streams[0];
     try testing.expectEqualStrings("users-stream", stream1.name);
     try testing.expectEqualStrings("users", stream1.source.resource);
     try testing.expect(stream1.source.operations.len == 2);
-    try testing.expectEqualStrings("insert", stream1.source.operations[0]);
-    try testing.expectEqualStrings("update", stream1.source.operations[1]);
     try testing.expectEqualStrings("json", stream1.flow.format);
     try testing.expectEqualStrings("outboxx.users", stream1.sink.destination);
     try testing.expectEqualStrings("id", stream1.sink.routing_key.?);
 
-    // Second stream
-    const stream2 = result.streams[1];
+    const stream2 = cfg.streams[1];
     try testing.expectEqualStrings("orders-stream", stream2.name);
     try testing.expectEqualStrings("orders", stream2.source.resource);
     try testing.expect(stream2.source.operations.len == 3);
-    try testing.expectEqualStrings("insert", stream2.source.operations[0]);
-    try testing.expectEqualStrings("update", stream2.source.operations[1]);
     try testing.expectEqualStrings("delete", stream2.source.operations[2]);
-    try testing.expectEqualStrings("json", stream2.flow.format);
     try testing.expectEqualStrings("outboxx.orders", stream2.sink.destination);
     try testing.expectEqualStrings("order_id", stream2.sink.routing_key.?);
 }
 
-test "Config validation - unsupported format should fail" {
-    const allocator = testing.allocator;
+test "parse invalid port type fails" {
+    const toml_content =
+        \\[metadata]
+        \\version = "v0"
+        \\
+        \\[source]
+        \\type = "postgres"
+        \\
+        \\[source.postgres]
+        \\host = "localhost"
+        \\port = "not_a_number"
+        \\database = "db"
+        \\user = "user"
+        \\password_env = "PWD"
+        \\slot_name = "slot"
+        \\publication_name = "pub"
+        \\
+        \\[sink]
+        \\type = "kafka"
+        \\
+        \\[sink.kafka]
+        \\brokers = ["kafka1:9092"]
+    ;
 
-    // Create a valid default config
-    var test_config = createTestDefault(allocator);
-    defer test_config.deinit(allocator);
-
-    // Modify only the format to test unsupported value
-    // Access the existing stream and change only the format
-    var modified_stream = test_config.streams[0];
-    modified_stream.flow.format = "avro"; // This should be rejected
-
-    // Replace the streams array with our modified stream
-    allocator.free(test_config.streams);
-    test_config.streams = try allocator.dupe(config.Stream, &[_]config.Stream{modified_stream});
-
-    // Validation should fail due to unsupported format
-    try testing.expectError(error.InvalidEnumValue, test_config.validate(allocator));
+    try testing.expectError(error.InvalidValueType, Config.loadFromTomlString(testing.allocator, toml_content));
 }
 
-test "Config validation - json format should pass" {
-    const allocator = testing.allocator;
+// Validation tests
+test "Config validation - valid config passes" {
+    const cfg = createTestDefault();
+    try cfg.validate(testing.allocator);
+}
 
-    // Create a valid default config (already has json format)
-    var test_config = createTestDefault(allocator);
-    defer test_config.deinit(allocator);
+test "Config validation - missing version" {
+    var cfg = createTestDefault();
+    cfg.metadata.version = "";
+    try testing.expectError(error.MissingConfigVersion, cfg.validate(testing.allocator));
+}
 
-    // Validation should pass (default config already uses json format)
-    try test_config.validate(allocator);
+test "Config validation - unsupported version" {
+    var cfg = createTestDefault();
+    cfg.metadata.version = "1";
+    try testing.expectError(error.UnsupportedConfigVersion, cfg.validate(testing.allocator));
+}
+
+test "Config validation - unsupported format should fail" {
+    var cfg = createTestDefault();
+    cfg.streams = &.{.{
+        .name = "test_stream",
+        .source = .{ .resource = "users", .operations = &.{"insert"} },
+        .flow = .{ .format = "avro" },
+        .sink = .{ .destination = "test_topic", .routing_key = null },
+    }};
+
+    try testing.expectError(error.InvalidEnumValue, cfg.validate(testing.allocator));
 }
 
 test "Config validation - invalid source type shows proper error format" {
-    const allocator = testing.allocator;
-
-    var test_config = createTestDefault(allocator);
-    defer test_config.deinit(allocator);
-    test_config.source.type = "invalid_source_type";
-
-    try testing.expectError(error.InvalidEnumValue, test_config.validate(allocator));
+    var cfg = createTestDefault();
+    cfg.source.type = "invalid_source_type";
+    try testing.expectError(error.InvalidEnumValue, cfg.validate(testing.allocator));
 }
 
 test "Config validation - invalid sink type shows proper error format" {
-    const allocator = testing.allocator;
-
-    var test_config = createTestDefault(allocator);
-    defer test_config.deinit(allocator);
-    test_config.sink.type = "invalid_sink_type";
-
-    try testing.expectError(error.InvalidEnumValue, test_config.validate(allocator));
+    var cfg = createTestDefault();
+    cfg.sink.type = "invalid_sink_type";
+    try testing.expectError(error.InvalidEnumValue, cfg.validate(testing.allocator));
 }
 
 test "Config validation - port 0 should fail" {
-    const allocator = testing.allocator;
-
-    var test_config = createTestDefault(allocator);
-    defer test_config.deinit(allocator);
-    test_config.source.postgres.?.port = 0;
-
-    try testing.expectError(error.InvalidPort, test_config.validate(allocator));
+    var cfg = createTestDefault();
+    cfg.source.postgres.?.port = 0;
+    try testing.expectError(error.InvalidPort, cfg.validate(testing.allocator));
 }
 
 test "Config validation - missing required PostgreSQL fields" {
-    const allocator = testing.allocator;
-
-    var test_config = createTestDefault(allocator);
-    defer test_config.deinit(allocator);
-    test_config.source.postgres.?.host = "";
-
-    try testing.expectError(error.MissingPostgresHost, test_config.validate(allocator));
+    var cfg = createTestDefault();
+    cfg.source.postgres.?.host = "";
+    try testing.expectError(error.MissingPostgresHost, cfg.validate(testing.allocator));
 }
 
 test "Config validation - empty streams array should fail" {
-    const allocator = testing.allocator;
-
-    var test_config = createTestDefault(allocator);
-    defer test_config.deinit(allocator);
-
-    // Properly clean up existing streams before setting empty array
-    for (test_config.streams) |stream| {
-        for (stream.source.operations) |operation| {
-            allocator.free(operation);
-        }
-        allocator.free(stream.source.operations);
-    }
-    allocator.free(test_config.streams);
-    test_config.streams = &[_]config.Stream{};
-
-    try testing.expectError(error.NoStreamsConfigured, test_config.validate(allocator));
-}
-
-test "parseIntValue with invalid input fails correctly" {
-    const allocator = testing.allocator;
-
-    const toml_content =
-        \\[source.postgres]
-        \\port = "invalid_port"
-    ;
-
-    var parser = config.ConfigParser.init(allocator);
-    const result = parser.parseToml(toml_content);
-    try testing.expectError(error.InvalidCharacter, result);
+    var cfg = createTestDefault();
+    cfg.streams = &.{};
+    try testing.expectError(error.NoStreamsConfigured, cfg.validate(testing.allocator));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -51,15 +51,18 @@ fn run(init: std.process.Init) !void {
     defer allocator.free(config_file_path);
 
     printStatus("Loading configuration from: {s}\n", .{config_file_path});
-    var config = try Config.loadFromTomlFile(init.io, allocator, config_file_path);
-    defer config.deinit(allocator);
+    var parsed = try Config.loadFromTomlFile(init.io, allocator, config_file_path);
+    defer parsed.deinit();
+    const config = parsed.value;
 
     try config.validate(allocator);
-    try config.loadPasswords(allocator, init.environ_map);
+
+    const pw = try config.loadPassword(allocator, init.environ_map);
+    defer allocator.free(pw);
 
     printConfigInfo(config);
 
-    try validatePostgres(allocator, config);
+    try validatePostgres(allocator, config, pw);
 
     const postgres = config.source.postgres.?;
 
@@ -69,7 +72,7 @@ fn run(init: std.process.Init) !void {
     printStatus("Starting processor for {} stream(s)...\n", .{config.streams.len});
     printStatus("Using PostgreSQL streaming replication (pgoutput protocol)\n", .{});
 
-    const conn_str = try config.postgresConnectionString(allocator);
+    const conn_str = try config.postgresConnectionString(allocator, pw);
     defer allocator.free(conn_str);
 
     var source = PostgresSource.init(allocator, postgres.slot_name, postgres.publication_name);
@@ -161,8 +164,8 @@ fn printConfigInfo(cfg: Config) void {
     printStatus("  Slot: {s}\n", .{postgres.slot_name});
 }
 
-fn validatePostgres(allocator: std.mem.Allocator, cfg: Config) !void {
-    const conn_str = try cfg.postgresConnectionString(allocator);
+fn validatePostgres(allocator: std.mem.Allocator, cfg: Config, pw: []const u8) !void {
+    const conn_str = try cfg.postgresConnectionString(allocator, pw);
     defer allocator.free(conn_str);
 
     printStatus("\nValidating PostgreSQL connection and settings...\n", .{});


### PR DESCRIPTION
Closes #24.

The hand-rolled `parseToml` was a line-by-line approximation of TOML with manual allocation tracking in `Config`. It only covered the subset of syntax the config happened to use and was easy to break.

This swaps it for [sam701/zig-toml](https://github.com/sam701/zig-toml), which maps the document straight into the config structs. `Config` is now plain data and doubles as the parse target; `toml.Parsed(Config)` owns the strings via its arena, so there's no `init`/`deinit`/password map to maintain. Net: ~900 lines removed.

### Changes

- Add the `toml` dependency, pinned to the library's `zig-0.16` branch. `main` tracks Zig 0.17-dev (`@typeInfo` uses `field_names`/`field_types`/`field_attrs`) and won't compile on 0.16, which uses `info.fields`.
- `Config` holds only parsed fields; the caller keeps the `Parsed` result alive. The source password is read from the env as an owned slice (`loadPassword`) instead of a `StringHashMap`, and passed into `postgresConnectionString`.
- Rewrite the config tests to parse via `loadFromTomlString` / `loadFromTomlFile`.
- Move one comment in `dev/config.toml` onto its own line (see caveat).

### Caveat

The library rejects a comment on the same line as a table header (`[[streams]] # comment` → `error.UnexpectedToken`); `parseTableHeader` expects a newline right after `]]`. This is valid TOML, so it's a library bug to fix upstream later. Comments after a value and on their own line work. Details in #24.
