### PR TITLE
Default to ReleaseFast and use the libc allocator in release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ help:
 	@echo "  make env-status    - Show environment status"
 	@echo ""
 	@echo "Load Testing (baseline: ~60k evt/s):"
-	@echo "  make load-up CDC=<cdc>     - Start infrastructure with CDC (outboxx|debezium)"
+	@echo "  make load-up CDC=<cdc>     - Start infrastructure with CDC (outboxx|debezium|both)"
 	@echo "  make load-switch CDC=<cdc> - Switch to different CDC solution"
 	@echo "  make load-test-steady      - Steady load (30k evt/s × 120s = 3.6M events)"
 	@echo "  make load-test-burst       - Burst load (10M events max speed)"

--- a/build.zig
+++ b/build.zig
@@ -4,8 +4,12 @@ pub fn build(b: *std.Build) void {
     // Standard target options allow the person running zig build to pick the architecture and OS
     const target = b.standardTargetOptions(.{});
 
-    // Standard optimization options allow the person running zig build to pick the optimization level
-    const optimize = b.standardOptimizeOption(.{});
+    // Product binary: default to ReleaseFast, override with -Doptimize=Debug.
+    const optimize = b.option(
+        std.builtin.OptimizeMode,
+        "optimize",
+        "Prioritize performance, safety, or binary size (default: ReleaseFast)",
+    ) orelse .ReleaseFast;
 
     // Constants module (application-wide constants)
     const constants_module = b.createModule(.{

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,19 +28,18 @@ pub fn main(init: std.process.Init) void {
 }
 
 fn run(init: std.process.Init) !void {
-    var gpa = std.heap.DebugAllocator(.{
-        .safety = true,
-        .retain_metadata = true,
-    }){};
-    defer {
-        const deinit_status = gpa.deinit();
-        if (deinit_status == .leak) {
+    // Debug: DebugAllocator for leak detection. Release: libc allocator
+    // (already linked), much faster on the per-change hot path.
+    var debug_allocator = std.heap.DebugAllocator(.{}){};
+    const allocator, const is_debug = switch (builtin.mode) {
+        .Debug => .{ debug_allocator.allocator(), true },
+        else => .{ std.heap.c_allocator, false },
+    };
+    defer if (is_debug) {
+        if (debug_allocator.deinit() == .leak) {
             std.log.err("Memory leak detected!", .{});
-        } else {
-            std.log.debug("No memory leaks detected", .{});
         }
-    }
-    const allocator = gpa.allocator();
+    };
 
     printBanner();
 

--- a/src/source/postgres/pg_output_decoder.zig
+++ b/src/source/postgres/pg_output_decoder.zig
@@ -153,7 +153,9 @@ pub const PgOutputDecoder = struct {
         };
     }
 
-    pub fn decode(self: *Self, data: []const u8) DecoderError!PgOutputMessage {
+    pub fn decode(self: *Self, allocator: std.mem.Allocator, data: []const u8) DecoderError!PgOutputMessage {
+        self.allocator = allocator; // decode into the caller's (per-batch) allocator
+
         if (data.len == 0) {
             return DecoderError.InvalidMessage;
         }

--- a/src/source/postgres/pg_output_decoder_test.zig
+++ b/src/source/postgres/pg_output_decoder_test.zig
@@ -50,7 +50,7 @@ test "PgOutputDecoder: decode BEGIN message" {
     writeI64(data[9..17], 1234567890);
     writeU32(data[17..21], 42);
 
-    var msg = try pg_decoder.decode(&data);
+    var msg = try pg_decoder.decode(allocator, &data);
     defer msg.deinit(allocator);
 
     try testing.expect(msg == .begin);
@@ -71,7 +71,7 @@ test "PgOutputDecoder: decode COMMIT message" {
     writeU64(data[10..18], 0x2000);
     writeI64(data[18..26], 9999);
 
-    var msg = try pg_decoder.decode(&data);
+    var msg = try pg_decoder.decode(allocator, &data);
     defer msg.deinit(allocator);
 
     try testing.expect(msg == .commit);
@@ -132,7 +132,7 @@ test "PgOutputDecoder: decode RELATION message" {
     writeI32(&type_buf, -1);
     try data.appendSlice(allocator, &type_buf);
 
-    var msg = try pg_decoder.decode(data.items);
+    var msg = try pg_decoder.decode(allocator, data.items);
     defer msg.deinit(allocator);
 
     try testing.expect(msg == .relation);
@@ -187,7 +187,7 @@ test "PgOutputDecoder: decode INSERT message" {
     try data.appendSlice(allocator, &buf);
     try data.appendSlice(allocator, "Alice");
 
-    var msg = try pg_decoder.decode(data.items);
+    var msg = try pg_decoder.decode(allocator, data.items);
     defer msg.deinit(allocator);
 
     try testing.expect(msg == .insert);
@@ -244,7 +244,7 @@ test "PgOutputDecoder: decode UPDATE message with old tuple" {
     try data.appendSlice(allocator, &buf);
     try data.appendSlice(allocator, "new_name");
 
-    var msg = try pg_decoder.decode(data.items);
+    var msg = try pg_decoder.decode(allocator, data.items);
     defer msg.deinit(allocator);
 
     try testing.expect(msg == .update);
@@ -290,7 +290,7 @@ test "PgOutputDecoder: decode DELETE message" {
     try data.appendSlice(allocator, &buf);
     try data.appendSlice(allocator, "deleted_row");
 
-    var msg = try pg_decoder.decode(data.items);
+    var msg = try pg_decoder.decode(allocator, data.items);
     defer msg.deinit(allocator);
 
     try testing.expect(msg == .delete);
@@ -328,7 +328,7 @@ test "PgOutputDecoder: decode tuple with NULL values" {
     // Column 2: NULL
     try data.append(allocator, 'n');
 
-    var msg = try pg_decoder.decode(data.items);
+    var msg = try pg_decoder.decode(allocator, data.items);
     defer msg.deinit(allocator);
 
     try testing.expect(msg == .insert);
@@ -346,6 +346,6 @@ test "PgOutputDecoder: invalid message type" {
 
     const data = [_]u8{'X'}; // Unknown message type
 
-    const result = pg_decoder.decode(&data);
+    const result = pg_decoder.decode(allocator, &data);
     try testing.expectError(decoder_mod.DecoderError.UnknownMessageType, result);
 }

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -344,12 +344,11 @@ pub const PostgresSource = struct {
     fn extractChangeFromMessage(self: *Self, io: std.Io, batch_allocator: std.mem.Allocator, msg: replication_protocol.ReplicationMessage, changes: *std.ArrayList(ChangeEvent)) !u64 {
         switch (msg) {
             .xlog_data => |xlog| {
-                // Decode into the batch arena (freed in bulk at batch reset);
-                // the registry copies the relation data it keeps.
-                const pg_msg = self.decoder.decode(batch_allocator, xlog.wal_data) catch |err| {
+                var pg_msg = self.decoder.decode(batch_allocator, xlog.wal_data) catch |err| {
                     std.log.warn("Failed to decode pgoutput message at LSN {}: {}", .{ xlog.server_wal_end, err });
                     return PostgresSourceError.DecodeFailed; // Propagate error up
                 };
+                defer pg_msg.deinit(batch_allocator);
 
                 // Convert to ChangeEvent
                 const change_opt = self.message_processor.processMessage(io, batch_allocator, pg_msg, &self.registry) catch |err| {

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -344,12 +344,12 @@ pub const PostgresSource = struct {
     fn extractChangeFromMessage(self: *Self, io: std.Io, batch_allocator: std.mem.Allocator, msg: replication_protocol.ReplicationMessage, changes: *std.ArrayList(ChangeEvent)) !u64 {
         switch (msg) {
             .xlog_data => |xlog| {
-                // Decode pgoutput message
-                var pg_msg = self.decoder.decode(xlog.wal_data) catch |err| {
+                // Decode into the batch arena (freed in bulk at batch reset);
+                // the registry copies the relation data it keeps.
+                const pg_msg = self.decoder.decode(batch_allocator, xlog.wal_data) catch |err| {
                     std.log.warn("Failed to decode pgoutput message at LSN {}: {}", .{ xlog.server_wal_end, err });
                     return PostgresSourceError.DecodeFailed; // Propagate error up
                 };
-                defer pg_msg.deinit(self.allocator);
 
                 // Convert to ChangeEvent
                 const change_opt = self.message_processor.processMessage(io, batch_allocator, pg_msg, &self.registry) catch |err| {

--- a/tests/benchmarks/components/decoder_bench.zig
+++ b/tests/benchmarks/components/decoder_bench.zig
@@ -65,7 +65,7 @@ const BenchDecoderInsert = struct {
 
     pub fn run(self: *BenchDecoderInsert, allocator: std.mem.Allocator) void {
         var decoder = PgOutputDecoder.init(allocator);
-        var msg = decoder.decode(self.golden_data) catch unreachable;
+        var msg = decoder.decode(allocator, self.golden_data) catch unreachable;
         defer msg.deinit(allocator);
     }
 };

--- a/tests/load/cdc/outboxx/Dockerfile
+++ b/tests/load/cdc/outboxx/Dockerfile
@@ -15,8 +15,8 @@ RUN nix develop --command echo "Dependencies cached"
 # Now copy the rest of the project
 COPY . .
 
-# Build using nix develop + zig build (ReleaseSafe for profiling with debug symbols)
-RUN nix develop --command zig build -Doptimize=ReleaseSafe
+# Build the load binary (ReleaseFast for max throughput, matching the product)
+RUN nix develop --command zig build -Doptimize=ReleaseFast
 
 # Patch binary to use system linker instead of Nix linker
 RUN nix develop --command bash -c " \

--- a/tests/load/cdc/outboxx/config.toml
+++ b/tests/load/cdc/outboxx/config.toml
@@ -10,10 +10,9 @@ host = "postgres"
 port = 5432
 database = "outboxx_load"
 user = "postgres"
-password = "POSTGRES_PASSWORD"
+password_env = "POSTGRES_PASSWORD"
 slot_name = "load_slot"
 publication_name = "outboxx_load_pub"
-engine = "streaming"
 
 [sink]
 type = "kafka"

--- a/tests/load/scripts/start.sh
+++ b/tests/load/scripts/start.sh
@@ -18,13 +18,22 @@ check_prerequisites() {
     fi
 }
 
-# Supported CDC solutions
-SUPPORTED_CDC=("outboxx" "debezium")
-if [[ ! " ${SUPPORTED_CDC[@]} " =~ " ${CDC} " ]]; then
-    echo "Error: Unsupported CDC solution: $CDC"
-    echo "Supported: ${SUPPORTED_CDC[*]}"
-    exit 1
-fi
+# Resolve which CDC services to start ("both" runs them in parallel: separate
+# replication slots, publications and Kafka topics keep them independent).
+case "$CDC" in
+    outboxx|debezium) CDC_LIST=("$CDC") ;;
+    both)             CDC_LIST=("outboxx" "debezium") ;;
+    *)
+        echo "Error: Unsupported CDC solution: $CDC"
+        echo "Supported: outboxx, debezium, both"
+        exit 1
+        ;;
+esac
+
+HAS_DEBEZIUM=false
+for cdc in "${CDC_LIST[@]}"; do
+    [ "$cdc" = "debezium" ] && HAS_DEBEZIUM=true
+done
 
 echo "Starting load testing infrastructure with $CDC..."
 cd "$LOAD_DIR"
@@ -46,12 +55,16 @@ done
 echo "Waiting for Kafka..."
 sleep 5
 
-# Start CDC solution
-echo "Starting $CDC CDC..."
-docker compose --profile "$CDC" up --build -d "$CDC"
+# Start CDC solution(s)
+echo "Starting CDC: ${CDC_LIST[*]}..."
+profile_args=()
+for cdc in "${CDC_LIST[@]}"; do
+    profile_args+=(--profile "$cdc")
+done
+docker compose "${profile_args[@]}" up --build -d "${CDC_LIST[@]}"
 
 # Wait for CDC to be ready
-if [ "$CDC" = "debezium" ]; then
+if [ "$HAS_DEBEZIUM" = true ]; then
     echo "Waiting for Debezium Kafka Connect..."
     until curl -s -o /dev/null -w "%{http_code}" http://localhost:8083/ | grep -q "200"; do
         sleep 2
@@ -71,7 +84,7 @@ echo "  Grafana:    http://localhost:3000 (admin/admin)"
 echo "  Prometheus: http://localhost:9090"
 echo "  cAdvisor:   http://localhost:8080"
 echo ""
-if [ "$CDC" = "debezium" ]; then
+if [ "$HAS_DEBEZIUM" = true ]; then
     echo "  Debezium API: http://localhost:8083"
     echo ""
 fi


### PR DESCRIPTION
## Problem
The product binary was built in Debug with `DebugAllocator` (`safety` + `retain_metadata`) as the runtime heap — the slowest std allocator for the per-change allocations on the hot path, and `retain_metadata` never frees freed-block metadata. Config, not a language limit.

## Solution
- `build.zig`: default `optimize` to `ReleaseFast` (override with `-Doptimize=Debug`).
- `main.zig`: `DebugAllocator` only in Debug; release uses `std.heap.c_allocator`. Dropped `retain_metadata`.
- pgoutput `decode` takes the batch allocator (the per-batch arena in the streaming path), so its allocations are arena bumps, not a per-message `malloc`/`free`. Freed via `pg_msg.deinit` — a no-op on the arena, a real free under a plain allocator (keeps leak-checked tests honest).
- load-test image (`tests/load/cdc/outboxx/Dockerfile`): build `ReleaseFast` instead of `ReleaseSafe` (a profiling leftover) so it measures real product throughput.

Note: the default also applies to `zig build test`, so CI now runs in ReleaseFast and loses runtime safety checks (leaks still caught via `testing.allocator`). Pin to `-Doptimize=Debug`/`ReleaseSafe` to restore.