### PR TITLE
Emit a placeholder for unchanged TOAST columns instead of null

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -203,6 +203,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    pg_output_decoder_tests.root_module.addImport("constants", constants_module);
 
     // RelationRegistry tests
     const relation_registry_tests = b.addTest(.{
@@ -403,6 +404,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = .ReleaseFast,
     });
+    pg_output_decoder_module.addImport("constants", constants_module);
 
     const bench_helpers_module = b.createModule(.{
         .root_source_file = b.path("tests/benchmarks/bench_helpers.zig"),

--- a/build.zig
+++ b/build.zig
@@ -203,7 +203,6 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    pg_output_decoder_tests.root_module.addImport("constants", constants_module);
 
     // RelationRegistry tests
     const relation_registry_tests = b.addTest(.{
@@ -404,7 +403,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = .ReleaseFast,
     });
-    pg_output_decoder_module.addImport("constants", constants_module);
 
     const bench_helpers_module = b.createModule(.{
         .root_source_file = b.path("tests/benchmarks/bench_helpers.zig"),

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -6,6 +6,10 @@ pub const DESCRIPTION = "PostgreSQL Change Data Capture with Kafka";
 
 pub const BUILD_MODE = builtin.mode;
 
+// Placeholder for an unchanged TOAST value that Postgres didn't resend, so the
+// column stays in the event instead of being dropped or shown as a real NULL.
+pub const UNKNOWN_VALUE_PLACEHOLDER = "__outboxx_unknown_value__";
+
 // CDC Processing Configuration
 // Optimized for maximum throughput
 pub const CDC = struct {

--- a/src/source/postgres/integration_test.zig
+++ b/src/source/postgres/integration_test.zig
@@ -7,6 +7,8 @@ const getTestConnectionString = test_helpers.getTestConnectionString;
 const domain = @import("domain");
 const ChangeOperation = domain.ChangeOperation;
 
+const constants = @import("constants");
+
 const source_mod = @import("source.zig");
 const PostgresSource = source_mod.PostgresSource;
 
@@ -76,6 +78,19 @@ fn cleanupTestEnvironment(
             execSQL(setup_conn, drop_table_sql) catch {};
         } else |_| {}
     } else |_| {}
+}
+
+// Return a string field's value by name, or null if absent / non-string.
+fn fieldValue(row: domain.RowData, name: []const u8) ?[]const u8 {
+    for (row) |field| {
+        if (std.mem.eql(u8, field.name, name)) {
+            return switch (field.value) {
+                .string => |s| s,
+                else => null,
+            };
+        }
+    }
+    return null;
 }
 
 test "Streaming source: receive and convert INSERT messages to ChangeEvents" {
@@ -321,6 +336,132 @@ test "Streaming source: UPDATE operation E2E with old and new tuples" {
     try source.sendFeedback(std.testing.io, batch.last_lsn);
 
     std.log.info("UPDATE E2E test passed!", .{});
+}
+
+test "Streaming source: unchanged TOAST column becomes the placeholder" {
+    const allocator = testing.allocator;
+
+    var prng = std.Random.DefaultPrng.init(@intCast(test_helpers.nowMicros(std.testing.io)));
+    const random_suffix = prng.random().int(u32);
+    const timestamp = test_helpers.nowSeconds(std.testing.io);
+    const table_name = try std.fmt.allocPrint(allocator, "stream_toast_test_{d}_{d}", .{ timestamp, random_suffix });
+    defer allocator.free(table_name);
+
+    const slot_name = try std.fmt.allocPrint(allocator, "slot_toast_{d}_{d}", .{ timestamp, random_suffix });
+    defer allocator.free(slot_name);
+
+    const pub_name = try std.fmt.allocPrint(allocator, "pub_toast_{d}_{d}", .{ timestamp, random_suffix });
+    defer allocator.free(pub_name);
+
+    std.log.info("TOAST E2E test: table={s}, slot={s}, pub={s}", .{ table_name, slot_name, pub_name });
+
+    const setup_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(setup_conn);
+
+    // Cleanup defer - declared FIRST, executes LAST (after source.deinit)
+    defer cleanupTestEnvironment(allocator, setup_conn, table_name, slot_name, pub_name);
+
+    // Table with a large text column. STORAGE EXTERNAL disables compression, so a
+    // 4KB value is guaranteed to be stored out-of-line (TOAST) and reported as
+    // unchanged on an UPDATE that doesn't touch it. REPLICA IDENTITY FULL to get old tuples.
+    const create_table_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT, toast_field TEXT)", .{table_name});
+    defer allocator.free(create_table_sql_tmp);
+    const create_table_sql = try allocator.dupeZ(u8, create_table_sql_tmp);
+    defer allocator.free(create_table_sql);
+    try execSQL(setup_conn, create_table_sql);
+
+    const storage_sql_tmp = try std.fmt.allocPrint(allocator, "ALTER TABLE {s} ALTER COLUMN toast_field SET STORAGE EXTERNAL", .{table_name});
+    defer allocator.free(storage_sql_tmp);
+    const storage_sql = try allocator.dupeZ(u8, storage_sql_tmp);
+    defer allocator.free(storage_sql);
+    try execSQL(setup_conn, storage_sql);
+
+    const replica_identity_sql_tmp = try std.fmt.allocPrint(allocator, "ALTER TABLE {s} REPLICA IDENTITY FULL", .{table_name});
+    defer allocator.free(replica_identity_sql_tmp);
+    const replica_identity_sql = try allocator.dupeZ(u8, replica_identity_sql_tmp);
+    defer allocator.free(replica_identity_sql);
+    try execSQL(setup_conn, replica_identity_sql);
+
+    const create_pub_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
+    defer allocator.free(create_pub_sql_tmp);
+    const create_pub_sql = try allocator.dupeZ(u8, create_pub_sql_tmp);
+    defer allocator.free(create_pub_sql);
+    try execSQL(setup_conn, create_pub_sql);
+
+    const create_slot_sql_tmp = try std.fmt.allocPrint(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
+    defer allocator.free(create_slot_sql_tmp);
+    const create_slot_sql = try allocator.dupeZ(u8, create_slot_sql_tmp);
+    defer allocator.free(create_slot_sql);
+    try execSQL(setup_conn, create_slot_sql);
+
+    const lsn_result = c.PQexec(setup_conn, "SELECT pg_current_wal_lsn()");
+    defer c.PQclear(lsn_result);
+    const lsn_cstr = c.PQgetvalue(lsn_result, 0, 0);
+    const start_lsn = try allocator.dupeZ(u8, std.mem.span(lsn_cstr));
+    defer allocator.free(start_lsn);
+
+    // 4000 bytes is comfortably above the ~2KB TOAST threshold.
+    const insert_sql_tmp = try std.fmt.allocPrint(allocator, "INSERT INTO {s} (id, name, toast_field) VALUES (1, 'Alice', repeat('x', 4000))", .{table_name});
+    defer allocator.free(insert_sql_tmp);
+    const insert_sql = try allocator.dupeZ(u8, insert_sql_tmp);
+    defer allocator.free(insert_sql);
+    try execSQL(setup_conn, insert_sql);
+
+    // Update only name: toast_field is unchanged, so Postgres sends the 'u' marker for it.
+    const update_sql_tmp = try std.fmt.allocPrint(allocator, "UPDATE {s} SET name = 'Bob' WHERE id = 1", .{table_name});
+    defer allocator.free(update_sql_tmp);
+    const update_sql = try allocator.dupeZ(u8, update_sql_tmp);
+    defer allocator.free(update_sql);
+    try execSQL(setup_conn, update_sql);
+
+    try execSQL(setup_conn, "SELECT pg_switch_wal()");
+
+    const conn_str = try getTestConnectionString(allocator);
+    defer allocator.free(conn_str);
+
+    var source = PostgresSource.init(allocator, slot_name, pub_name);
+    defer source.deinit();
+
+    try source.connect(conn_str, start_lsn);
+
+    const batch = try source.receiveBatch(std.testing.io, allocator, 10);
+    defer {
+        var mut_batch = batch;
+        mut_batch.deinit();
+    }
+
+    std.log.info("Received batch with {} changes", .{batch.changes.len});
+
+    var found_insert = false;
+    var found_update = false;
+    for (batch.changes) |change| {
+        if (std.mem.eql(u8, change.op, "INSERT")) {
+            found_insert = true;
+            // On INSERT the full value is present, not the placeholder.
+            const toast_val = fieldValue(change.data.insert, "toast_field");
+            try testing.expect(toast_val != null);
+            try testing.expectEqual(@as(usize, 4000), toast_val.?.len);
+        } else if (std.mem.eql(u8, change.op, "UPDATE")) {
+            found_update = true;
+            const new_data = change.data.update.new;
+            const name_val = fieldValue(new_data, "name");
+            const toast_val = fieldValue(new_data, "toast_field");
+
+            try testing.expect(name_val != null);
+            try testing.expectEqualStrings("Bob", name_val.?);
+
+            // Unchanged TOAST column stays in the payload as the placeholder.
+            try testing.expect(toast_val != null);
+            try testing.expectEqualStrings(constants.UNKNOWN_VALUE_PLACEHOLDER, toast_val.?);
+        }
+    }
+
+    try testing.expect(found_insert);
+    try testing.expect(found_update);
+
+    try source.sendFeedback(std.testing.io, batch.last_lsn);
+
+    std.log.info("TOAST E2E test passed!", .{});
 }
 
 test "Streaming source: DELETE operation E2E" {

--- a/src/source/postgres/integration_test.zig
+++ b/src/source/postgres/integration_test.zig
@@ -119,23 +119,17 @@ test "Streaming source: receive and convert INSERT messages to ChangeEvents" {
     defer cleanupTestEnvironment(allocator, setup_conn, table_name, slot_name, pub_name);
 
     // Create table
-    const create_table_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT)", .{table_name});
-    defer allocator.free(create_table_sql_tmp);
-    const create_table_sql = try allocator.dupeZ(u8, create_table_sql_tmp);
+    const create_table_sql = try test_helpers.formatSqlZ(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT)", .{table_name});
     defer allocator.free(create_table_sql);
     try execSQL(setup_conn, create_table_sql);
 
     // Create publication
-    const create_pub_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
-    defer allocator.free(create_pub_sql_tmp);
-    const create_pub_sql = try allocator.dupeZ(u8, create_pub_sql_tmp);
+    const create_pub_sql = try test_helpers.formatSqlZ(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
     defer allocator.free(create_pub_sql);
     try execSQL(setup_conn, create_pub_sql);
 
     // Create replication slot
-    const create_slot_sql_tmp = try std.fmt.allocPrint(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
-    defer allocator.free(create_slot_sql_tmp);
-    const create_slot_sql = try allocator.dupeZ(u8, create_slot_sql_tmp);
+    const create_slot_sql = try test_helpers.formatSqlZ(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
     defer allocator.free(create_slot_sql);
     try execSQL(setup_conn, create_slot_sql);
 
@@ -150,9 +144,7 @@ test "Streaming source: receive and convert INSERT messages to ChangeEvents" {
     std.log.info("Starting replication from LSN: {s}", .{start_lsn});
 
     // Insert test data
-    const insert_sql_tmp = try std.fmt.allocPrint(allocator, "INSERT INTO {s} (name) VALUES ('Alice'), ('Bob')", .{table_name});
-    defer allocator.free(insert_sql_tmp);
-    const insert_sql = try allocator.dupeZ(u8, insert_sql_tmp);
+    const insert_sql = try test_helpers.formatSqlZ(allocator, "INSERT INTO {s} (name) VALUES ('Alice'), ('Bob')", .{table_name});
     defer allocator.free(insert_sql);
     try execSQL(setup_conn, insert_sql);
 
@@ -222,30 +214,22 @@ test "Streaming source: UPDATE operation E2E with old and new tuples" {
     defer cleanupTestEnvironment(allocator, setup_conn, table_name, slot_name, pub_name);
 
     // Create table with REPLICA IDENTITY FULL to get old tuple
-    const create_table_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT)", .{table_name});
-    defer allocator.free(create_table_sql_tmp);
-    const create_table_sql = try allocator.dupeZ(u8, create_table_sql_tmp);
+    const create_table_sql = try test_helpers.formatSqlZ(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT)", .{table_name});
     defer allocator.free(create_table_sql);
     try execSQL(setup_conn, create_table_sql);
 
     // Set REPLICA IDENTITY FULL to get old tuple in UPDATE messages
-    const replica_identity_sql_tmp = try std.fmt.allocPrint(allocator, "ALTER TABLE {s} REPLICA IDENTITY FULL", .{table_name});
-    defer allocator.free(replica_identity_sql_tmp);
-    const replica_identity_sql = try allocator.dupeZ(u8, replica_identity_sql_tmp);
+    const replica_identity_sql = try test_helpers.formatSqlZ(allocator, "ALTER TABLE {s} REPLICA IDENTITY FULL", .{table_name});
     defer allocator.free(replica_identity_sql);
     try execSQL(setup_conn, replica_identity_sql);
 
     // Create publication
-    const create_pub_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
-    defer allocator.free(create_pub_sql_tmp);
-    const create_pub_sql = try allocator.dupeZ(u8, create_pub_sql_tmp);
+    const create_pub_sql = try test_helpers.formatSqlZ(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
     defer allocator.free(create_pub_sql);
     try execSQL(setup_conn, create_pub_sql);
 
     // Create replication slot
-    const create_slot_sql_tmp = try std.fmt.allocPrint(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
-    defer allocator.free(create_slot_sql_tmp);
-    const create_slot_sql = try allocator.dupeZ(u8, create_slot_sql_tmp);
+    const create_slot_sql = try test_helpers.formatSqlZ(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
     defer allocator.free(create_slot_sql);
     try execSQL(setup_conn, create_slot_sql);
 
@@ -257,16 +241,12 @@ test "Streaming source: UPDATE operation E2E with old and new tuples" {
     defer allocator.free(start_lsn);
 
     // Insert initial row
-    const insert_sql_tmp = try std.fmt.allocPrint(allocator, "INSERT INTO {s} (id, name) VALUES (1, 'Alice')", .{table_name});
-    defer allocator.free(insert_sql_tmp);
-    const insert_sql = try allocator.dupeZ(u8, insert_sql_tmp);
+    const insert_sql = try test_helpers.formatSqlZ(allocator, "INSERT INTO {s} (id, name) VALUES (1, 'Alice')", .{table_name});
     defer allocator.free(insert_sql);
     try execSQL(setup_conn, insert_sql);
 
     // Update the row: Alice -> Bob
-    const update_sql_tmp = try std.fmt.allocPrint(allocator, "UPDATE {s} SET name = 'Bob' WHERE id = 1", .{table_name});
-    defer allocator.free(update_sql_tmp);
-    const update_sql = try allocator.dupeZ(u8, update_sql_tmp);
+    const update_sql = try test_helpers.formatSqlZ(allocator, "UPDATE {s} SET name = 'Bob' WHERE id = 1", .{table_name});
     defer allocator.free(update_sql);
     try execSQL(setup_conn, update_sql);
 
@@ -364,33 +344,23 @@ test "Streaming source: unchanged TOAST column becomes the placeholder" {
     // Table with a large text column. STORAGE EXTERNAL disables compression, so a
     // 4KB value is guaranteed to be stored out-of-line (TOAST) and reported as
     // unchanged on an UPDATE that doesn't touch it. REPLICA IDENTITY FULL to get old tuples.
-    const create_table_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT, toast_field TEXT)", .{table_name});
-    defer allocator.free(create_table_sql_tmp);
-    const create_table_sql = try allocator.dupeZ(u8, create_table_sql_tmp);
+    const create_table_sql = try test_helpers.formatSqlZ(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT, toast_field TEXT)", .{table_name});
     defer allocator.free(create_table_sql);
     try execSQL(setup_conn, create_table_sql);
 
-    const storage_sql_tmp = try std.fmt.allocPrint(allocator, "ALTER TABLE {s} ALTER COLUMN toast_field SET STORAGE EXTERNAL", .{table_name});
-    defer allocator.free(storage_sql_tmp);
-    const storage_sql = try allocator.dupeZ(u8, storage_sql_tmp);
+    const storage_sql = try test_helpers.formatSqlZ(allocator, "ALTER TABLE {s} ALTER COLUMN toast_field SET STORAGE EXTERNAL", .{table_name});
     defer allocator.free(storage_sql);
     try execSQL(setup_conn, storage_sql);
 
-    const replica_identity_sql_tmp = try std.fmt.allocPrint(allocator, "ALTER TABLE {s} REPLICA IDENTITY FULL", .{table_name});
-    defer allocator.free(replica_identity_sql_tmp);
-    const replica_identity_sql = try allocator.dupeZ(u8, replica_identity_sql_tmp);
+    const replica_identity_sql = try test_helpers.formatSqlZ(allocator, "ALTER TABLE {s} REPLICA IDENTITY FULL", .{table_name});
     defer allocator.free(replica_identity_sql);
     try execSQL(setup_conn, replica_identity_sql);
 
-    const create_pub_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
-    defer allocator.free(create_pub_sql_tmp);
-    const create_pub_sql = try allocator.dupeZ(u8, create_pub_sql_tmp);
+    const create_pub_sql = try test_helpers.formatSqlZ(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
     defer allocator.free(create_pub_sql);
     try execSQL(setup_conn, create_pub_sql);
 
-    const create_slot_sql_tmp = try std.fmt.allocPrint(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
-    defer allocator.free(create_slot_sql_tmp);
-    const create_slot_sql = try allocator.dupeZ(u8, create_slot_sql_tmp);
+    const create_slot_sql = try test_helpers.formatSqlZ(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
     defer allocator.free(create_slot_sql);
     try execSQL(setup_conn, create_slot_sql);
 
@@ -401,16 +371,12 @@ test "Streaming source: unchanged TOAST column becomes the placeholder" {
     defer allocator.free(start_lsn);
 
     // 4000 bytes is comfortably above the ~2KB TOAST threshold.
-    const insert_sql_tmp = try std.fmt.allocPrint(allocator, "INSERT INTO {s} (id, name, toast_field) VALUES (1, 'Alice', repeat('x', 4000))", .{table_name});
-    defer allocator.free(insert_sql_tmp);
-    const insert_sql = try allocator.dupeZ(u8, insert_sql_tmp);
+    const insert_sql = try test_helpers.formatSqlZ(allocator, "INSERT INTO {s} (id, name, toast_field) VALUES (1, 'Alice', repeat('x', 4000))", .{table_name});
     defer allocator.free(insert_sql);
     try execSQL(setup_conn, insert_sql);
 
     // Update only name: toast_field is unchanged, so Postgres sends the 'u' marker for it.
-    const update_sql_tmp = try std.fmt.allocPrint(allocator, "UPDATE {s} SET name = 'Bob' WHERE id = 1", .{table_name});
-    defer allocator.free(update_sql_tmp);
-    const update_sql = try allocator.dupeZ(u8, update_sql_tmp);
+    const update_sql = try test_helpers.formatSqlZ(allocator, "UPDATE {s} SET name = 'Bob' WHERE id = 1", .{table_name});
     defer allocator.free(update_sql);
     try execSQL(setup_conn, update_sql);
 
@@ -490,30 +456,22 @@ test "Streaming source: DELETE operation E2E" {
     defer cleanupTestEnvironment(allocator, setup_conn, table_name, slot_name, pub_name);
 
     // Create table with REPLICA IDENTITY FULL to get old tuple in DELETE
-    const create_table_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT)", .{table_name});
-    defer allocator.free(create_table_sql_tmp);
-    const create_table_sql = try allocator.dupeZ(u8, create_table_sql_tmp);
+    const create_table_sql = try test_helpers.formatSqlZ(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT)", .{table_name});
     defer allocator.free(create_table_sql);
     try execSQL(setup_conn, create_table_sql);
 
     // Set REPLICA IDENTITY FULL to get full row in DELETE messages
-    const replica_identity_sql_tmp = try std.fmt.allocPrint(allocator, "ALTER TABLE {s} REPLICA IDENTITY FULL", .{table_name});
-    defer allocator.free(replica_identity_sql_tmp);
-    const replica_identity_sql = try allocator.dupeZ(u8, replica_identity_sql_tmp);
+    const replica_identity_sql = try test_helpers.formatSqlZ(allocator, "ALTER TABLE {s} REPLICA IDENTITY FULL", .{table_name});
     defer allocator.free(replica_identity_sql);
     try execSQL(setup_conn, replica_identity_sql);
 
     // Create publication
-    const create_pub_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
-    defer allocator.free(create_pub_sql_tmp);
-    const create_pub_sql = try allocator.dupeZ(u8, create_pub_sql_tmp);
+    const create_pub_sql = try test_helpers.formatSqlZ(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
     defer allocator.free(create_pub_sql);
     try execSQL(setup_conn, create_pub_sql);
 
     // Create replication slot
-    const create_slot_sql_tmp = try std.fmt.allocPrint(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
-    defer allocator.free(create_slot_sql_tmp);
-    const create_slot_sql = try allocator.dupeZ(u8, create_slot_sql_tmp);
+    const create_slot_sql = try test_helpers.formatSqlZ(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
     defer allocator.free(create_slot_sql);
     try execSQL(setup_conn, create_slot_sql);
 
@@ -525,16 +483,12 @@ test "Streaming source: DELETE operation E2E" {
     defer allocator.free(start_lsn);
 
     // Insert initial row
-    const insert_sql_tmp = try std.fmt.allocPrint(allocator, "INSERT INTO {s} (id, name) VALUES (1, 'Alice')", .{table_name});
-    defer allocator.free(insert_sql_tmp);
-    const insert_sql = try allocator.dupeZ(u8, insert_sql_tmp);
+    const insert_sql = try test_helpers.formatSqlZ(allocator, "INSERT INTO {s} (id, name) VALUES (1, 'Alice')", .{table_name});
     defer allocator.free(insert_sql);
     try execSQL(setup_conn, insert_sql);
 
     // Delete the row
-    const delete_sql_tmp = try std.fmt.allocPrint(allocator, "DELETE FROM {s} WHERE id = 1", .{table_name});
-    defer allocator.free(delete_sql_tmp);
-    const delete_sql = try allocator.dupeZ(u8, delete_sql_tmp);
+    const delete_sql = try test_helpers.formatSqlZ(allocator, "DELETE FROM {s} WHERE id = 1", .{table_name});
     defer allocator.free(delete_sql);
     try execSQL(setup_conn, delete_sql);
 
@@ -620,23 +574,17 @@ test "Streaming source: Multiple batches with limit parameter" {
     defer cleanupTestEnvironment(allocator, setup_conn, table_name, slot_name, pub_name);
 
     // Create table
-    const create_table_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, value TEXT)", .{table_name});
-    defer allocator.free(create_table_sql_tmp);
-    const create_table_sql = try allocator.dupeZ(u8, create_table_sql_tmp);
+    const create_table_sql = try test_helpers.formatSqlZ(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, value TEXT)", .{table_name});
     defer allocator.free(create_table_sql);
     try execSQL(setup_conn, create_table_sql);
 
     // Create publication
-    const create_pub_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
-    defer allocator.free(create_pub_sql_tmp);
-    const create_pub_sql = try allocator.dupeZ(u8, create_pub_sql_tmp);
+    const create_pub_sql = try test_helpers.formatSqlZ(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
     defer allocator.free(create_pub_sql);
     try execSQL(setup_conn, create_pub_sql);
 
     // Create replication slot
-    const create_slot_sql_tmp = try std.fmt.allocPrint(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
-    defer allocator.free(create_slot_sql_tmp);
-    const create_slot_sql = try allocator.dupeZ(u8, create_slot_sql_tmp);
+    const create_slot_sql = try test_helpers.formatSqlZ(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
     defer allocator.free(create_slot_sql);
     try execSQL(setup_conn, create_slot_sql);
 
@@ -648,9 +596,7 @@ test "Streaming source: Multiple batches with limit parameter" {
     defer allocator.free(start_lsn);
 
     // Insert 500 rows
-    const insert_sql_tmp = try std.fmt.allocPrint(allocator, "INSERT INTO {s} (value) SELECT 'row_' || i::text FROM generate_series(1, 500) AS i", .{table_name});
-    defer allocator.free(insert_sql_tmp);
-    const insert_sql = try allocator.dupeZ(u8, insert_sql_tmp);
+    const insert_sql = try test_helpers.formatSqlZ(allocator, "INSERT INTO {s} (value) SELECT 'row_' || i::text FROM generate_series(1, 500) AS i", .{table_name});
     defer allocator.free(insert_sql);
     try execSQL(setup_conn, insert_sql);
 
@@ -727,23 +673,17 @@ test "Streaming source: Timeout behavior with no data" {
     defer cleanupTestEnvironment(allocator, setup_conn, table_name, slot_name, pub_name);
 
     // Create table (empty, no data inserted)
-    const create_table_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, value TEXT)", .{table_name});
-    defer allocator.free(create_table_sql_tmp);
-    const create_table_sql = try allocator.dupeZ(u8, create_table_sql_tmp);
+    const create_table_sql = try test_helpers.formatSqlZ(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, value TEXT)", .{table_name});
     defer allocator.free(create_table_sql);
     try execSQL(setup_conn, create_table_sql);
 
     // Create publication
-    const create_pub_sql_tmp = try std.fmt.allocPrint(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
-    defer allocator.free(create_pub_sql_tmp);
-    const create_pub_sql = try allocator.dupeZ(u8, create_pub_sql_tmp);
+    const create_pub_sql = try test_helpers.formatSqlZ(allocator, "CREATE PUBLICATION {s} FOR TABLE {s}", .{ pub_name, table_name });
     defer allocator.free(create_pub_sql);
     try execSQL(setup_conn, create_pub_sql);
 
     // Create replication slot
-    const create_slot_sql_tmp = try std.fmt.allocPrint(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
-    defer allocator.free(create_slot_sql_tmp);
-    const create_slot_sql = try allocator.dupeZ(u8, create_slot_sql_tmp);
+    const create_slot_sql = try test_helpers.formatSqlZ(allocator, "SELECT pg_create_logical_replication_slot('{s}', 'pgoutput')", .{slot_name});
     defer allocator.free(create_slot_sql);
     try execSQL(setup_conn, create_slot_sql);
 

--- a/src/source/postgres/pg_output_decoder.zig
+++ b/src/source/postgres/pg_output_decoder.zig
@@ -1,7 +1,5 @@
 const std = @import("std");
 
-const constants = @import("constants");
-
 pub const DecoderError = error{
     InvalidMessage,
     UnknownMessageType,
@@ -77,8 +75,6 @@ pub const TupleData = struct {
     value: ?[]const u8,
 
     pub fn deinit(self: *TupleData, allocator: std.mem.Allocator) void {
-        // The unchanged-TOAST placeholder is a borrowed static string, not owned.
-        if (self.column_type == .unchanged_toast) return;
         if (self.value) |v| {
             allocator.free(v);
         }
@@ -305,13 +301,9 @@ pub const PgOutputDecoder = struct {
                         .value = value,
                     };
                 },
-                .null => TupleData{
+                .null, .unchanged_toast => TupleData{
                     .column_type = col_type,
                     .value = null,
-                },
-                .unchanged_toast => TupleData{
-                    .column_type = col_type,
-                    .value = constants.UNKNOWN_VALUE_PLACEHOLDER,
                 },
                 else => return DecoderError.InvalidTupleData,
             };

--- a/src/source/postgres/pg_output_decoder.zig
+++ b/src/source/postgres/pg_output_decoder.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+const constants = @import("constants");
+
 pub const DecoderError = error{
     InvalidMessage,
     UnknownMessageType,
@@ -75,6 +77,8 @@ pub const TupleData = struct {
     value: ?[]const u8,
 
     pub fn deinit(self: *TupleData, allocator: std.mem.Allocator) void {
+        // The unchanged-TOAST placeholder is a borrowed static string, not owned.
+        if (self.column_type == .unchanged_toast) return;
         if (self.value) |v| {
             allocator.free(v);
         }
@@ -287,10 +291,6 @@ pub const PgOutputDecoder = struct {
             pos += 1;
 
             const tuple_data = switch (col_type) {
-                .null, .unchanged_toast => TupleData{
-                    .column_type = col_type,
-                    .value = null,
-                },
                 .text, .binary => blk: {
                     if (pos + 4 > data.len) return DecoderError.InvalidTupleData;
                     const length = readU32(data[pos .. pos + 4]);
@@ -304,6 +304,14 @@ pub const PgOutputDecoder = struct {
                         .column_type = col_type,
                         .value = value,
                     };
+                },
+                .null => TupleData{
+                    .column_type = col_type,
+                    .value = null,
+                },
+                .unchanged_toast => TupleData{
+                    .column_type = col_type,
+                    .value = constants.UNKNOWN_VALUE_PLACEHOLDER,
                 },
                 else => return DecoderError.InvalidTupleData,
             };

--- a/src/source/postgres/pg_output_decoder_test.zig
+++ b/src/source/postgres/pg_output_decoder_test.zig
@@ -7,6 +7,8 @@ const PgOutputMessage = decoder_mod.PgOutputMessage;
 const MessageType = decoder_mod.MessageType;
 const TupleDataType = decoder_mod.TupleDataType;
 
+const constants = @import("constants");
+
 // Helper to build binary messages
 fn writeU64(buffer: []u8, value: u64) void {
     buffer[0] = @intCast((value >> 56) & 0xFF);
@@ -348,4 +350,47 @@ test "PgOutputDecoder: invalid message type" {
 
     const result = pg_decoder.decode(allocator, &data);
     try testing.expectError(decoder_mod.DecoderError.UnknownMessageType, result);
+}
+
+test "PgOutputDecoder: unchanged TOAST column decodes to the placeholder" {
+    const allocator = testing.allocator;
+    var pg_decoder = PgOutputDecoder.init(allocator);
+
+    // UPDATE with a new-tuple-only body where the second column is an unchanged
+    // TOAST ('u'): Postgres sends no value for it.
+    var data = std.ArrayList(u8).empty;
+    defer data.deinit(allocator);
+
+    try data.append(allocator, 'U');
+
+    var buf: [4]u8 = undefined;
+    writeU32(&buf, 12345);
+    try data.appendSlice(allocator, &buf);
+
+    // 'N' = new tuple only
+    try data.append(allocator, 'N');
+
+    var col_count_buf: [2]u8 = undefined;
+    writeU16(&col_count_buf, 2);
+    try data.appendSlice(allocator, &col_count_buf);
+
+    // Column 1: text value "42"
+    try data.append(allocator, 't');
+    writeU32(&buf, 2);
+    try data.appendSlice(allocator, &buf);
+    try data.appendSlice(allocator, "42");
+
+    // Column 2: unchanged TOAST
+    try data.append(allocator, 'u');
+
+    var msg = try pg_decoder.decode(allocator, data.items);
+    defer msg.deinit(allocator);
+
+    try testing.expect(msg == .update);
+    const cols = msg.update.new_tuple.columns;
+    try testing.expectEqual(@as(usize, 2), cols.len);
+
+    try testing.expect(cols[1].column_type == .unchanged_toast);
+    try testing.expect(cols[1].value != null);
+    try testing.expectEqualStrings(constants.UNKNOWN_VALUE_PLACEHOLDER, cols[1].value.?);
 }

--- a/src/source/postgres/pg_output_decoder_test.zig
+++ b/src/source/postgres/pg_output_decoder_test.zig
@@ -7,8 +7,6 @@ const PgOutputMessage = decoder_mod.PgOutputMessage;
 const MessageType = decoder_mod.MessageType;
 const TupleDataType = decoder_mod.TupleDataType;
 
-const constants = @import("constants");
-
 // Helper to build binary messages
 fn writeU64(buffer: []u8, value: u64) void {
     buffer[0] = @intCast((value >> 56) & 0xFF);
@@ -352,7 +350,7 @@ test "PgOutputDecoder: invalid message type" {
     try testing.expectError(decoder_mod.DecoderError.UnknownMessageType, result);
 }
 
-test "PgOutputDecoder: unchanged TOAST column decodes to the placeholder" {
+test "PgOutputDecoder: unchanged TOAST column decodes to null (no value sent)" {
     const allocator = testing.allocator;
     var pg_decoder = PgOutputDecoder.init(allocator);
 
@@ -391,6 +389,5 @@ test "PgOutputDecoder: unchanged TOAST column decodes to the placeholder" {
     try testing.expectEqual(@as(usize, 2), cols.len);
 
     try testing.expect(cols[1].column_type == .unchanged_toast);
-    try testing.expect(cols[1].value != null);
-    try testing.expectEqualStrings(constants.UNKNOWN_VALUE_PLACEHOLDER, cols[1].value.?);
+    try testing.expect(cols[1].value == null);
 }

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -153,11 +153,21 @@ pub const MessageProcessor = struct {
         for (tuple.columns, 0..) |col, i| {
             const col_name = rel_info.columns[i].name;
 
-            if (col.value) |val| {
-                const field_value = try FieldValueHelpers.text(batch_allocator, val);
-                try RowDataHelpers.put(&builder, batch_allocator, col_name, field_value);
-            } else {
-                try RowDataHelpers.put(&builder, batch_allocator, col_name, FieldValueHelpers.null_value());
+            switch (col.column_type) {
+                // Postgres doesn't resend an unchanged TOAST value; emit a placeholder
+                // so the column stays in the payload and isn't mistaken for a real NULL.
+                .unchanged_toast => {
+                    const placeholder = try FieldValueHelpers.text(batch_allocator, constants.UNKNOWN_VALUE_PLACEHOLDER);
+                    try RowDataHelpers.put(&builder, batch_allocator, col_name, placeholder);
+                },
+                else => {
+                    if (col.value) |val| {
+                        const field_value = try FieldValueHelpers.text(batch_allocator, val);
+                        try RowDataHelpers.put(&builder, batch_allocator, col_name, field_value);
+                    } else {
+                        try RowDataHelpers.put(&builder, batch_allocator, col_name, FieldValueHelpers.null_value());
+                    }
+                },
             }
         }
 
@@ -825,6 +835,58 @@ test "tupleToRowData: handle NULL values in tuple" {
     try testing.expectEqualStrings("email", row_data[2].name);
     try testing.expect(row_data[2].value == .string);
     try testing.expectEqualStrings("test@example.com", row_data[2].value.string);
+}
+
+test "tupleToRowData: unchanged TOAST column becomes the placeholder" {
+    const allocator = testing.allocator;
+
+    var source = PostgresSource.init(allocator, "test_slot", "test_pub");
+    defer source.deinit();
+
+    // Relation with a large text column (body) that can be TOASTed.
+    var rel_msg = pg_output_decoder.RelationMessage{
+        .relation_id = 400,
+        .namespace = try allocator.dupe(u8, "public"),
+        .relation_name = try allocator.dupe(u8, "articles"),
+        .replica_identity = 'd',
+        .columns = try allocator.alloc(pg_output_decoder.RelationMessageColumn, 3),
+    };
+    defer rel_msg.deinit(allocator);
+
+    rel_msg.columns[0] = .{ .flags = 1, .name = try allocator.dupe(u8, "id"), .data_type = 23, .type_modifier = -1 };
+    rel_msg.columns[1] = .{ .flags = 0, .name = try allocator.dupe(u8, "body"), .data_type = 25, .type_modifier = -1 };
+    rel_msg.columns[2] = .{ .flags = 0, .name = try allocator.dupe(u8, "title"), .data_type = 25, .type_modifier = -1 };
+
+    try source.registry.register(rel_msg);
+
+    // UPDATE that didn't touch body: Postgres sends the 'u' (unchanged) marker.
+    var tuple = pg_output_decoder.TupleMessage{
+        .columns = try allocator.alloc(pg_output_decoder.TupleData, 3),
+    };
+    defer tuple.deinit(allocator);
+
+    tuple.columns[0] = .{ .column_type = .text, .value = try allocator.dupe(u8, "1") };
+    tuple.columns[1] = .{ .column_type = .unchanged_toast, .value = null };
+    tuple.columns[2] = .{ .column_type = .text, .value = try allocator.dupe(u8, "Hello") };
+
+    const rel_info = try source.registry.get(400);
+
+    const row_data = try source.message_processor.tupleToRowData(allocator, tuple, rel_info);
+    defer {
+        for (row_data) |field| {
+            allocator.free(field.name);
+            if (field.value == .string) {
+                allocator.free(field.value.string);
+            }
+        }
+        allocator.free(row_data);
+    }
+
+    // body stays in the row as the placeholder, keeping the schema stable.
+    try testing.expectEqual(@as(usize, 3), row_data.len);
+    try testing.expectEqualStrings("body", row_data[1].name);
+    try testing.expect(row_data[1].value == .string);
+    try testing.expectEqualStrings(constants.UNKNOWN_VALUE_PLACEHOLDER, row_data[1].value.string);
 }
 
 test "convertInsert: error when relation not found in registry" {

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -153,21 +153,11 @@ pub const MessageProcessor = struct {
         for (tuple.columns, 0..) |col, i| {
             const col_name = rel_info.columns[i].name;
 
-            switch (col.column_type) {
-                // Postgres doesn't resend an unchanged TOAST value; emit a placeholder
-                // so the column stays in the payload and isn't mistaken for a real NULL.
-                .unchanged_toast => {
-                    const placeholder = try FieldValueHelpers.text(batch_allocator, constants.UNKNOWN_VALUE_PLACEHOLDER);
-                    try RowDataHelpers.put(&builder, batch_allocator, col_name, placeholder);
-                },
-                else => {
-                    if (col.value) |val| {
-                        const field_value = try FieldValueHelpers.text(batch_allocator, val);
-                        try RowDataHelpers.put(&builder, batch_allocator, col_name, field_value);
-                    } else {
-                        try RowDataHelpers.put(&builder, batch_allocator, col_name, FieldValueHelpers.null_value());
-                    }
-                },
+            if (col.value) |val| {
+                const field_value = try FieldValueHelpers.text(batch_allocator, val);
+                try RowDataHelpers.put(&builder, batch_allocator, col_name, field_value);
+            } else {
+                try RowDataHelpers.put(&builder, batch_allocator, col_name, FieldValueHelpers.null_value());
             }
         }
 
@@ -835,58 +825,6 @@ test "tupleToRowData: handle NULL values in tuple" {
     try testing.expectEqualStrings("email", row_data[2].name);
     try testing.expect(row_data[2].value == .string);
     try testing.expectEqualStrings("test@example.com", row_data[2].value.string);
-}
-
-test "tupleToRowData: unchanged TOAST column becomes the placeholder" {
-    const allocator = testing.allocator;
-
-    var source = PostgresSource.init(allocator, "test_slot", "test_pub");
-    defer source.deinit();
-
-    // Relation with a large text column (body) that can be TOASTed.
-    var rel_msg = pg_output_decoder.RelationMessage{
-        .relation_id = 400,
-        .namespace = try allocator.dupe(u8, "public"),
-        .relation_name = try allocator.dupe(u8, "articles"),
-        .replica_identity = 'd',
-        .columns = try allocator.alloc(pg_output_decoder.RelationMessageColumn, 3),
-    };
-    defer rel_msg.deinit(allocator);
-
-    rel_msg.columns[0] = .{ .flags = 1, .name = try allocator.dupe(u8, "id"), .data_type = 23, .type_modifier = -1 };
-    rel_msg.columns[1] = .{ .flags = 0, .name = try allocator.dupe(u8, "body"), .data_type = 25, .type_modifier = -1 };
-    rel_msg.columns[2] = .{ .flags = 0, .name = try allocator.dupe(u8, "title"), .data_type = 25, .type_modifier = -1 };
-
-    try source.registry.register(rel_msg);
-
-    // UPDATE that didn't touch body: Postgres sends the 'u' (unchanged) marker.
-    var tuple = pg_output_decoder.TupleMessage{
-        .columns = try allocator.alloc(pg_output_decoder.TupleData, 3),
-    };
-    defer tuple.deinit(allocator);
-
-    tuple.columns[0] = .{ .column_type = .text, .value = try allocator.dupe(u8, "1") };
-    tuple.columns[1] = .{ .column_type = .unchanged_toast, .value = null };
-    tuple.columns[2] = .{ .column_type = .text, .value = try allocator.dupe(u8, "Hello") };
-
-    const rel_info = try source.registry.get(400);
-
-    const row_data = try source.message_processor.tupleToRowData(allocator, tuple, rel_info);
-    defer {
-        for (row_data) |field| {
-            allocator.free(field.name);
-            if (field.value == .string) {
-                allocator.free(field.value.string);
-            }
-        }
-        allocator.free(row_data);
-    }
-
-    // body stays in the row as the placeholder, keeping the schema stable.
-    try testing.expectEqual(@as(usize, 3), row_data.len);
-    try testing.expectEqualStrings("body", row_data[1].name);
-    try testing.expect(row_data[1].value == .string);
-    try testing.expectEqualStrings(constants.UNKNOWN_VALUE_PLACEHOLDER, row_data[1].value.string);
 }
 
 test "convertInsert: error when relation not found in registry" {

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -156,6 +156,11 @@ pub const MessageProcessor = struct {
             if (col.value) |val| {
                 const field_value = try FieldValueHelpers.text(batch_allocator, val);
                 try RowDataHelpers.put(&builder, batch_allocator, col_name, field_value);
+            } else if (col.column_type == .unchanged_toast) {
+                // Postgres didn't resend the unchanged TOAST value; emit a placeholder
+                // so the column stays in the payload instead of looking like a real NULL.
+                const placeholder = try FieldValueHelpers.text(batch_allocator, constants.UNKNOWN_VALUE_PLACEHOLDER);
+                try RowDataHelpers.put(&builder, batch_allocator, col_name, placeholder);
             } else {
                 try RowDataHelpers.put(&builder, batch_allocator, col_name, FieldValueHelpers.null_value());
             }
@@ -825,6 +830,58 @@ test "tupleToRowData: handle NULL values in tuple" {
     try testing.expectEqualStrings("email", row_data[2].name);
     try testing.expect(row_data[2].value == .string);
     try testing.expectEqualStrings("test@example.com", row_data[2].value.string);
+}
+
+test "tupleToRowData: unchanged TOAST column becomes the placeholder" {
+    const allocator = testing.allocator;
+
+    var source = PostgresSource.init(allocator, "test_slot", "test_pub");
+    defer source.deinit();
+
+    var rel_msg = pg_output_decoder.RelationMessage{
+        .relation_id = 400,
+        .namespace = try allocator.dupe(u8, "public"),
+        .relation_name = try allocator.dupe(u8, "articles"),
+        .replica_identity = 'd',
+        .columns = try allocator.alloc(pg_output_decoder.RelationMessageColumn, 3),
+    };
+    defer rel_msg.deinit(allocator);
+
+    rel_msg.columns[0] = .{ .flags = 1, .name = try allocator.dupe(u8, "id"), .data_type = 23, .type_modifier = -1 };
+    rel_msg.columns[1] = .{ .flags = 0, .name = try allocator.dupe(u8, "body"), .data_type = 25, .type_modifier = -1 };
+    rel_msg.columns[2] = .{ .flags = 0, .name = try allocator.dupe(u8, "title"), .data_type = 25, .type_modifier = -1 };
+
+    try source.registry.register(rel_msg);
+
+    // UPDATE that didn't touch body: the decoder yields a null value with the
+    // unchanged-TOAST marker, which tupleToRowData turns into the placeholder.
+    var tuple = pg_output_decoder.TupleMessage{
+        .columns = try allocator.alloc(pg_output_decoder.TupleData, 3),
+    };
+    defer tuple.deinit(allocator);
+
+    tuple.columns[0] = .{ .column_type = .text, .value = try allocator.dupe(u8, "1") };
+    tuple.columns[1] = .{ .column_type = .unchanged_toast, .value = null };
+    tuple.columns[2] = .{ .column_type = .text, .value = try allocator.dupe(u8, "Hello") };
+
+    const rel_info = try source.registry.get(400);
+
+    const row_data = try source.message_processor.tupleToRowData(allocator, tuple, rel_info);
+    defer {
+        for (row_data) |field| {
+            allocator.free(field.name);
+            if (field.value == .string) {
+                allocator.free(field.value.string);
+            }
+        }
+        allocator.free(row_data);
+    }
+
+    // body stays in the row as the placeholder, keeping the schema stable.
+    try testing.expectEqual(@as(usize, 3), row_data.len);
+    try testing.expectEqualStrings("body", row_data[1].name);
+    try testing.expect(row_data[1].value == .string);
+    try testing.expectEqualStrings(constants.UNKNOWN_VALUE_PLACEHOLDER, row_data[1].value.string);
 }
 
 test "convertInsert: error when relation not found in registry" {


### PR DESCRIPTION
## Problem

An UPDATE that leaves a TOASTed column unchanged sends the `u` marker with no value. We serialized it as JSON `null`, so consumers saw the column set to NULL when it was never touched. For a snapshot-style payload this also silently changes the row's schema.

## Solution

- Map the `unchanged_toast` marker to a placeholder constant (`UNKNOWN_VALUE_PLACEHOLDER = "__outboxx_unknown_value__"`) instead of `null`, so the column stays in the payload and the schema is stable. Same idea as Debezium's `__debezium_unavailable_value`.
- Add a unit test and an integration test that forces a real out-of-line value (`SET STORAGE EXTERNAL` + 4 KB) and asserts the placeholder on UPDATE, while INSERT still carries the full value.

Closes #44
