### PR TITLE
Take the Postgres source connection as an env-supplied libpq conninfo

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,7 +10,7 @@ useDefault = true
 description = "Env-var name references are not secrets; dev/CI stacks ship throwaway credentials"
 regexTarget = "line"
 regexes = [
-  # An env-var NAME reference, not a secret: password_env = "POSTGRES_PASSWORD".
+  # An env-var NAME reference, not a secret: password_env = "KAFKA_PASSWORD".
   '''password_env\s*=\s*"[A-Z0-9_]+"''',
 ]
 paths = [

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,10 @@ build:
 	@echo "zig build"
 	@zig build
 
-# Run the application
+# Run the application against the dev config. POSTGRES_URL falls back to the local
+# dev database; override it to point elsewhere. Needs services up (make env-up).
 run:
-	zig build run
+	POSTGRES_URL="$${POSTGRES_URL:-postgres://postgres:password@localhost:5432/outboxx_test?sslmode=disable}" zig build run -- --config dev/config.toml
 
 # Run unit tests
 test-unit:

--- a/README.md
+++ b/README.md
@@ -75,11 +75,10 @@ version = "v0"
 type = "postgres"
 
 [source.postgres]
-host = "localhost"
-port = 5432
-database = "mydb"
-user = "postgres"
-password_env = "POSTGRES_PASSWORD"
+# libpq connection string (URL or DSN) is read from this env var, never from the file.
+# Configure TLS inside the string via sslmode/sslrootcert/sslcert/sslkey. Example:
+#   export POSTGRES_URL="postgres://user:password@host:5432/dbname?sslmode=require"
+connection_env = "POSTGRES_URL"
 slot_name = "outboxx_slot"
 publication_name = "outboxx_publication"
 
@@ -88,7 +87,8 @@ type = "kafka"
 
 [sink.kafka]
 brokers = ["localhost:9092"]
-tls = false  # encryption is on by default; false for local plaintext
+# encryption is on by default; false for local plaintext
+tls = false
 # For managed brokers add a [sink.kafka.sasl] section (mechanism/username/password_env).
 
 # Multiple streams for different tables
@@ -167,7 +167,7 @@ ALTER TABLE my_table REPLICA IDENTITY FULL;
 make build
 
 # Run with your configuration
-export POSTGRES_PASSWORD="your_password"
+export POSTGRES_URL="postgres://user:your_password@host:5432/dbname?sslmode=require"
 ./zig-out/bin/outboxx --config config.toml
 ```
 

--- a/dev/config.toml
+++ b/dev/config.toml
@@ -4,7 +4,7 @@
 # Usage:
 # From the project root directory: ./dev/run-dev.sh or:
 # 1. Start development environment: make env-up
-# 2. Set password: export POSTGRES_PASSWORD="password"
+# 2. Set connection: export POSTGRES_URL="postgres://postgres:password@localhost:5432/outboxx_test?sslmode=disable"
 # 3. Run application: zig build run -- --config dev/config.toml
 
 [metadata]
@@ -14,11 +14,10 @@ version = "v0"
 type = "postgres" # Reference to the "source.postgres"
 
 [source.postgres]
-host = "localhost"
-port = 5432
-database = "outboxx_test"
-user = "postgres"
-password_env = "POSTGRES_PASSWORD"  # Set with: export POSTGRES_PASSWORD="password"
+# libpq connection string (URL or DSN) lives in this env var, kept out of the file so the
+# password never lands on disk. Local Postgres has no TLS, hence sslmode=disable in the URL;
+# use require or verify-full in production.
+connection_env = "POSTGRES_URL"
 slot_name = "outboxx_slot"
 publication_name = "outboxx_publication"
 

--- a/dev/run-dev.sh
+++ b/dev/run-dev.sh
@@ -22,8 +22,8 @@ else
 fi
 
 # Set environment variables
-export POSTGRES_PASSWORD="password"
-echo "🔐 PostgreSQL password set"
+export POSTGRES_URL="postgres://postgres:password@localhost:5432/outboxx_test?sslmode=disable"
+echo "🔐 PostgreSQL connection set"
 
 # Show configuration info
 echo ""

--- a/docs/STREAMING_REPLICATION_DESIGN.md
+++ b/docs/STREAMING_REPLICATION_DESIGN.md
@@ -297,9 +297,7 @@ CREATE PUBLICATION outboxx_pub FOR TABLE users, orders;
 
 ```toml
 [source.postgres]
-host = "localhost"
-port = 5432
-database = "outboxx_test"
+connection_env = "POSTGRES_URL"
 slot_name = "outboxx_slot"
 publication_name = "outboxx_pub"
 ```

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -6,7 +6,7 @@
 # as the project develops. Not all features shown are fully implemented yet.
 #
 # Environment Variables Required:
-# export POSTGRES_PASSWORD="your_postgres_password"
+# export POSTGRES_URL="postgres://user:password@host:5432/dbname?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca.crt"
 # export MYSQL_PASSWORD="your_mysql_password"
 
 [metadata]
@@ -27,11 +27,13 @@ flows = ["direct", "transform"]
 type = "postgres"  # Available: "postgres", "mysql" (mysql implementation pending)
 
 [source.postgres]
-host = "localhost"
-port = 5432
-database = "outboxx_test"
-user = "postgres"
-password_env = "POSTGRES_PASSWORD"  # Security: Always use environment variables for passwords
+# Full libpq connection string (URL or DSN) is read from this environment variable, never
+# from the file, so the password stays off disk. TLS is configured inside the string via the
+# standard libpq parameters: sslmode (disable | allow | prefer | require | verify-ca |
+# verify-full), sslrootcert, sslcert, sslkey. Without an explicit sslmode libpq defaults to
+# prefer (opportunistic, unverified); use require or verify-full to enforce and pin the CA.
+#   export POSTGRES_URL="postgres://user:pass@host:5432/db?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca.crt"
+connection_env = "POSTGRES_URL"
 slot_name = "outboxx_slot"           # PostgreSQL logical replication slot name
 publication_name = "outboxx_publication"  # PostgreSQL publication for logical replication
 

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -33,11 +33,11 @@ pub const Metadata = struct {
 };
 
 pub const PostgresSource = struct {
-    host: []const u8,
-    port: u16,
-    database: []const u8,
-    user: []const u8,
-    password_env: []const u8,
+    // Name of the environment variable holding the libpq connection string (URL or DSN),
+    // e.g. postgres://user:pass@host:5432/db?sslmode=verify-full&sslrootcert=/certs/ca.crt.
+    // Kept out of the config file so the password never lands on disk; TLS is configured
+    // through the string's sslmode/ssl* parameters.
+    connection_env: []const u8,
     slot_name: []const u8,
     publication_name: []const u8,
 };
@@ -58,8 +58,8 @@ pub const SourceConfig = struct {
     mysql: ?MysqlSource = null,
 };
 
-// Read a password from the named environment variable; caller owns the result.
-fn readEnvPassword(allocator: std.mem.Allocator, environ_map: *std.process.Environ.Map, env_name: []const u8) ![]u8 {
+// Read the named environment variable; caller owns the result.
+fn readEnvVar(allocator: std.mem.Allocator, environ_map: *std.process.Environ.Map, env_name: []const u8) ![]u8 {
     const value = environ_map.get(env_name) orelse {
         std.log.warn("Environment variable '{s}' not found", .{env_name});
         return error.EnvironmentVariableNotFound;
@@ -77,7 +77,7 @@ pub const KafkaSasl = struct {
 
     /// Read the SASL password from its configured environment variable; caller owns the result.
     pub fn loadPassword(self: KafkaSasl, allocator: std.mem.Allocator, environ_map: *std.process.Environ.Map) ![]u8 {
-        return readEnvPassword(allocator, environ_map, self.password_env);
+        return readEnvVar(allocator, environ_map, self.password_env);
     }
 };
 
@@ -160,18 +160,6 @@ pub const Config = struct {
         return parser.parseString(content);
     }
 
-    /// Read the configured source's password from the environment; caller owns the result.
-    pub fn loadPassword(self: Config, allocator: std.mem.Allocator, environ_map: *std.process.Environ.Map) ![]u8 {
-        const env_name = if (self.source.postgres) |postgres|
-            postgres.password_env
-        else if (self.source.mysql) |mysql|
-            mysql.password_env
-        else
-            return error.PasswordNotConfigured;
-
-        return readEnvPassword(allocator, environ_map, env_name);
-    }
-
     /// Read the Kafka SASL password from the environment; caller owns the result.
     /// Returns null unless the sink actually negotiates SASL.
     pub fn loadKafkaSaslPassword(self: Config, allocator: std.mem.Allocator, environ_map: *std.process.Environ.Map) !?[]u8 {
@@ -181,15 +169,12 @@ pub const Config = struct {
         return try sasl.loadPassword(allocator, environ_map);
     }
 
-    /// Build the libpq connection string for the configured PostgreSQL source.
-    pub fn postgresConnectionString(self: Config, allocator: std.mem.Allocator, password: []const u8) ![]u8 {
+    /// Read the Postgres source's libpq connection string from its configured environment
+    /// variable; caller owns the result. The value is a full conninfo (URL or DSN) and may
+    /// carry the password, so callers must not log it verbatim.
+    pub fn loadPostgresConninfo(self: Config, allocator: std.mem.Allocator, environ_map: *std.process.Environ.Map) ![]u8 {
         const postgres = self.source.postgres orelse return error.PostgresNotConfigured;
-
-        return std.fmt.allocPrint(
-            allocator,
-            "host={s} port={d} dbname={s} user={s} password={s} replication=database gssencmode=disable",
-            .{ postgres.host, postgres.port, postgres.database, postgres.user, password },
-        );
+        return readEnvVar(allocator, environ_map, postgres.connection_env);
     }
 
     // Helper validation functions
@@ -405,9 +390,7 @@ pub const Config = struct {
                 return error.MissingPostgresConfig;
             }
             const postgres = self.source.postgres.?;
-            if (postgres.host.len == 0) return error.MissingPostgresHost;
-            if (postgres.database.len == 0) return error.MissingPostgresDatabase;
-            if (postgres.user.len == 0) return error.MissingPostgresUser;
+            if (postgres.connection_env.len == 0) return error.MissingPostgresConnectionEnv;
             if (postgres.slot_name.len == 0) return error.MissingPostgresSlotName;
         } else if (std.mem.eql(u8, self.source.type, "mysql")) {
             if (self.source.mysql == null) {
@@ -436,13 +419,9 @@ pub const Config = struct {
         // Enhanced source validation with string limits and format checks
         if (std.mem.eql(u8, self.source.type, "postgres")) {
             const postgres = self.source.postgres.?;
-            try validateHostname(postgres.host, "postgres.host");
-            try validatePort(postgres.port, "postgres.port");
-            try validatePostgresIdentifier(postgres.database, "postgres.database");
-            try validatePostgresIdentifier(postgres.user, "postgres.user");
+            try validateStringLength(postgres.connection_env, ValidationLimits.MAX_IDENTIFIER_LEN, "postgres.connection_env");
             try validatePostgresIdentifier(postgres.slot_name, "postgres.slot_name");
             try validatePostgresIdentifier(postgres.publication_name, "postgres.publication_name");
-            try validateStringLength(postgres.password_env, ValidationLimits.MAX_IDENTIFIER_LEN, "postgres.password_env");
         } else if (std.mem.eql(u8, self.source.type, "mysql")) {
             const mysql = self.source.mysql.?;
             try validateHostname(mysql.host, "mysql.host");

--- a/src/config/config_test.zig
+++ b/src/config/config_test.zig
@@ -11,11 +11,7 @@ fn createTestDefault() Config {
         .source = .{
             .type = "postgres",
             .postgres = .{
-                .host = "localhost",
-                .port = 5432,
-                .database = "outboxx_test",
-                .user = "postgres",
-                .password_env = "POSTGRES_PASSWORD",
+                .connection_env = "POSTGRES_URL",
                 .slot_name = "outboxx_slot",
                 .publication_name = "outboxx_publication",
             },
@@ -47,11 +43,7 @@ const valid_config_toml =
     \\type = "postgres"
     \\
     \\[source.postgres]
-    \\host = "pg.example.com"
-    \\port = 5433
-    \\database = "production_db"
-    \\user = "app_user"
-    \\password_env = "PROD_PASSWORD"
+    \\connection_env = "PROD_POSTGRES_URL"
     \\slot_name = "prod_slot"
     \\publication_name = "prod_pub"
     \\
@@ -81,9 +73,8 @@ test "createTestDefault" {
 
     try testing.expect(cfg.source.postgres != null);
     const postgres = cfg.source.postgres.?;
-    try testing.expectEqualStrings("localhost", postgres.host);
-    try testing.expect(postgres.port == 5432);
-    try testing.expectEqualStrings("outboxx_test", postgres.database);
+    try testing.expectEqualStrings("POSTGRES_URL", postgres.connection_env);
+    try testing.expectEqualStrings("outboxx_slot", postgres.slot_name);
 
     try testing.expect(cfg.sink.kafka != null);
     try testing.expect(cfg.sink.kafka.?.brokers.len == 1);
@@ -110,9 +101,8 @@ test "loadFromTomlFile - real file" {
     try testing.expectEqualStrings("v0", cfg.metadata.version);
     try testing.expect(cfg.source.postgres != null);
     const postgres = cfg.source.postgres.?;
-    try testing.expectEqualStrings("pg.example.com", postgres.host);
-    try testing.expect(postgres.port == 5433);
-    try testing.expectEqualStrings("production_db", postgres.database);
+    try testing.expectEqualStrings("PROD_POSTGRES_URL", postgres.connection_env);
+    try testing.expectEqualStrings("prod_slot", postgres.slot_name);
 }
 
 test "loadFromTomlString - empty document fails" {
@@ -126,11 +116,7 @@ test "parse PostgreSQL config section" {
 
     try testing.expect(cfg.source.postgres != null);
     const postgres = cfg.source.postgres.?;
-    try testing.expectEqualStrings("pg.example.com", postgres.host);
-    try testing.expect(postgres.port == 5433);
-    try testing.expectEqualStrings("production_db", postgres.database);
-    try testing.expectEqualStrings("app_user", postgres.user);
-    try testing.expectEqualStrings("PROD_PASSWORD", postgres.password_env);
+    try testing.expectEqualStrings("PROD_POSTGRES_URL", postgres.connection_env);
     try testing.expectEqualStrings("prod_slot", postgres.slot_name);
     try testing.expectEqualStrings("prod_pub", postgres.publication_name);
 }
@@ -144,11 +130,7 @@ test "parse Kafka config section with multiple brokers" {
         \\type = "postgres"
         \\
         \\[source.postgres]
-        \\host = "localhost"
-        \\port = 5432
-        \\database = "db"
-        \\user = "user"
-        \\password_env = "PWD"
+        \\connection_env = "PG_URL"
         \\slot_name = "slot"
         \\publication_name = "pub"
         \\
@@ -180,11 +162,7 @@ test "parse Kafka tls and sasl sections" {
         \\type = "postgres"
         \\
         \\[source.postgres]
-        \\host = "localhost"
-        \\port = 5432
-        \\database = "db"
-        \\user = "user"
-        \\password_env = "PWD"
+        \\connection_env = "PG_URL"
         \\slot_name = "slot"
         \\publication_name = "pub"
         \\
@@ -224,11 +202,7 @@ test "default tls is enabled" {
         \\type = "postgres"
         \\
         \\[source.postgres]
-        \\host = "localhost"
-        \\port = 5432
-        \\database = "db"
-        \\user = "user"
-        \\password_env = "PWD"
+        \\connection_env = "PG_URL"
         \\slot_name = "slot"
         \\publication_name = "pub"
         \\
@@ -246,13 +220,6 @@ test "default tls is enabled" {
     try testing.expect(kafka.tls);
     try testing.expect(kafka.sasl == null);
     try testing.expectEqualStrings("ssl", kafka.securityProtocol());
-}
-
-test "parse integer values" {
-    var parsed = try Config.loadFromTomlString(testing.allocator, valid_config_toml);
-    defer parsed.deinit();
-
-    try testing.expect(parsed.value.source.postgres.?.port == 5433);
 }
 
 test "parse stream with inline comments and optional routing_key" {
@@ -281,11 +248,7 @@ test "parse multiple streams" {
         \\type = "postgres"
         \\
         \\[source.postgres]
-        \\host = "localhost"
-        \\port = 5432
-        \\database = "db"
-        \\user = "user"
-        \\password_env = "PWD"
+        \\connection_env = "PG_URL"
         \\slot_name = "slot"
         \\publication_name = "pub"
         \\
@@ -349,7 +312,7 @@ test "parse multiple streams" {
     try testing.expectEqualStrings("order_id", stream2.sink.routing_key.?);
 }
 
-test "parse invalid port type fails" {
+test "parse invalid boolean type fails" {
     const toml_content =
         \\[metadata]
         \\version = "v0"
@@ -358,11 +321,7 @@ test "parse invalid port type fails" {
         \\type = "postgres"
         \\
         \\[source.postgres]
-        \\host = "localhost"
-        \\port = "not_a_number"
-        \\database = "db"
-        \\user = "user"
-        \\password_env = "PWD"
+        \\connection_env = "PG_URL"
         \\slot_name = "slot"
         \\publication_name = "pub"
         \\
@@ -371,6 +330,7 @@ test "parse invalid port type fails" {
         \\
         \\[sink.kafka]
         \\brokers = ["kafka1:9092"]
+        \\tls = "not_a_bool"
     ;
 
     try testing.expectError(error.InvalidValueType, Config.loadFromTomlString(testing.allocator, toml_content));
@@ -416,18 +376,6 @@ test "Config validation - invalid sink type shows proper error format" {
     var cfg = createTestDefault();
     cfg.sink.type = "invalid_sink_type";
     try testing.expectError(error.InvalidEnumValue, cfg.validate(testing.allocator));
-}
-
-test "Config validation - port 0 should fail" {
-    var cfg = createTestDefault();
-    cfg.source.postgres.?.port = 0;
-    try testing.expectError(error.InvalidPort, cfg.validate(testing.allocator));
-}
-
-test "Config validation - missing required PostgreSQL fields" {
-    var cfg = createTestDefault();
-    cfg.source.postgres.?.host = "";
-    try testing.expectError(error.MissingPostgresHost, cfg.validate(testing.allocator));
 }
 
 test "Config validation - empty streams array should fail" {
@@ -477,4 +425,39 @@ test "securityProtocol derives from tls and sasl" {
 
     kafka.tls = false;
     try testing.expectEqualStrings("sasl_plaintext", kafka.securityProtocol());
+}
+
+test "parse postgres connection_env" {
+    const toml_content =
+        \\[metadata]
+        \\version = "v0"
+        \\
+        \\[source]
+        \\type = "postgres"
+        \\
+        \\[source.postgres]
+        \\connection_env = "POSTGRES_URL"
+        \\slot_name = "slot"
+        \\publication_name = "pub"
+        \\
+        \\[sink]
+        \\type = "kafka"
+        \\
+        \\[sink.kafka]
+        \\brokers = ["kafka1:9092"]
+    ;
+
+    var parsed = try Config.loadFromTomlString(testing.allocator, toml_content);
+    defer parsed.deinit();
+    const postgres = parsed.value.source.postgres.?;
+
+    try testing.expectEqualStrings("POSTGRES_URL", postgres.connection_env);
+    try testing.expectEqualStrings("slot", postgres.slot_name);
+    try testing.expectEqualStrings("pub", postgres.publication_name);
+}
+
+test "Config validation - empty postgres connection_env fails" {
+    var cfg = createTestDefault();
+    cfg.source.postgres.?.connection_env = "";
+    try testing.expectError(error.MissingPostgresConnectionEnv, cfg.validate(testing.allocator));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -58,15 +58,15 @@ fn run(init: std.process.Init) !void {
 
     try config.validate(allocator);
 
-    const pw = try config.loadPassword(allocator, init.environ_map);
-    defer allocator.free(pw);
+    const conninfo = try config.loadPostgresConninfo(allocator, init.environ_map);
+    defer allocator.free(conninfo);
 
     const kafka_sasl_pw = try config.loadKafkaSaslPassword(allocator, init.environ_map);
     defer if (kafka_sasl_pw) |p| allocator.free(p);
 
     printConfigInfo(config);
 
-    try validatePostgres(allocator, config, pw);
+    try validatePostgres(allocator, config, conninfo);
 
     const postgres = config.source.postgres.?;
 
@@ -76,14 +76,11 @@ fn run(init: std.process.Init) !void {
     printStatus("Starting processor for {} stream(s)...\n", .{config.streams.len});
     printStatus("Using PostgreSQL streaming replication (pgoutput protocol)\n", .{});
 
-    const conn_str = try config.postgresConnectionString(allocator, pw);
-    defer allocator.free(conn_str);
-
     var source = PostgresSource.init(allocator, postgres.slot_name, postgres.publication_name);
     // NOTE: source will be deinit'd by processor.deinit()
 
     printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
-    try source.connect(conn_str, "0/0");
+    try source.connect(conninfo, "0/0");
 
     const producer = try initKafkaProducer(allocator, config.sink.kafka.?, kafka_sasl_pw);
     // NOTE: producer will be deinit'd by processor.deinit()
@@ -186,22 +183,18 @@ fn parseConfigPath(args: std.process.Args, allocator: std.mem.Allocator) !?[]con
 fn printConfigInfo(cfg: Config) void {
     const postgres = cfg.source.postgres.?;
     printStatus("Configuration loaded:\n", .{});
-    printStatus("  PostgreSQL: {s}:{}\n", .{ postgres.host, postgres.port });
-    printStatus("  Database: {s}\n", .{postgres.database});
-    printStatus("  User: {s}\n", .{postgres.user});
+    printStatus("  PostgreSQL connection from ${s}\n", .{postgres.connection_env});
     printStatus("  Slot: {s}\n", .{postgres.slot_name});
+    printStatus("  Publication: {s}\n", .{postgres.publication_name});
 }
 
-fn validatePostgres(allocator: std.mem.Allocator, cfg: Config, pw: []const u8) !void {
-    const conn_str = try cfg.postgresConnectionString(allocator, pw);
-    defer allocator.free(conn_str);
-
+fn validatePostgres(allocator: std.mem.Allocator, cfg: Config, conninfo: []const u8) !void {
     printStatus("\nValidating PostgreSQL connection and settings...\n", .{});
 
     var validator = PostgresValidator.init(allocator);
     defer validator.deinit();
 
-    try validator.connect(conn_str);
+    try validator.connect(conninfo);
     try validator.checkPostgresVersion();
     try validator.checkWalLevel();
 

--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -80,20 +80,18 @@ pub const ReplicationProtocol = struct {
     }
 
     pub fn connect(self: *Self, connection_string: []const u8) ReplicationError!void {
-        // Build connection string with replication=database parameter
-        const repl_conn_str = std.fmt.allocPrint(
-            self.allocator,
-            "{s} replication=database",
-            .{connection_string},
-        ) catch return ReplicationError.OutOfMemory;
-        defer self.allocator.free(repl_conn_str);
+        // connection_string is a user-supplied libpq conninfo (URL or DSN). Pass it as the
+        // dbname keyword with expand_dbname=1 so libpq parses it, and add replication=database
+        // as a separate parameter; appending it to the string would break the URL form.
+        const conninfo_z = self.allocator.dupeZ(u8, connection_string) catch return ReplicationError.OutOfMemory;
+        defer self.allocator.free(conninfo_z);
 
-        const conn_str_z = self.allocator.dupeZ(u8, repl_conn_str) catch return ReplicationError.OutOfMemory;
-        defer self.allocator.free(conn_str_z);
+        const keywords = [_][*c]const u8{ "dbname", "replication", null };
+        const values = [_][*c]const u8{ conninfo_z.ptr, "database", null };
 
         std.log.debug("Connecting to PostgreSQL with replication mode", .{});
 
-        self.connection = c.PQconnectdb(conn_str_z.ptr);
+        self.connection = c.PQconnectdbParams(&keywords, &values, 1);
 
         if (self.connection == null) {
             std.log.warn("Failed to allocate replication connection", .{});
@@ -107,6 +105,10 @@ pub const ReplicationProtocol = struct {
             c.PQfinish(self.connection);
             self.connection = null;
             return ReplicationError.ConnectionFailed;
+        }
+
+        if (c.PQsslInUse(self.connection) == 0) {
+            std.log.info("PostgreSQL connection is not encrypted; set sslmode=require or higher in the connection string to enforce TLS", .{});
         }
 
         std.log.debug("Replication connection established", .{});

--- a/tests/load/docker-compose.yml
+++ b/tests/load/docker-compose.yml
@@ -156,7 +156,7 @@ services:
       kafka:
         condition: service_healthy
     environment:
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_URL: postgres://postgres:postgres@postgres:5432/bench?sslmode=disable
     volumes:
       - ./outboxx/config.toml:/app/config.toml:ro
     command: ["--config", "/app/config.toml"]

--- a/tests/load/outboxx/config.toml
+++ b/tests/load/outboxx/config.toml
@@ -5,11 +5,7 @@ version = "v0"
 type = "postgres"
 
 [source.postgres]
-host = "postgres"
-port = 5432
-database = "bench"
-user = "postgres"
-password_env = "POSTGRES_PASSWORD"
+connection_env = "POSTGRES_URL"
 slot_name = "outboxx_benchmark_slot"
 publication_name = "outboxx_benchmark_publication"
 


### PR DESCRIPTION
## Why

`postgresConnectionString` hardcoded `gssencmode=disable` and set no `sslmode`, so libpq fell back to `prefer`: TLS was opportunistic and unverified, with no way to require it or pin a CA (#47). Rather than model each libpq TLS knob as its own config field, this follows how the modern Postgres-native tooling does it (jackc/pglogrepl over pgx/pgconn): take a single libpq connection string and let it carry the TLS parameters.

## What

- `[source.postgres]` drops `host`/`port`/`database`/`user`/`password_env` (and the short-lived `sslmode`/`ssl*` fields) in favour of one `connection_env` naming an environment variable that holds a libpq conninfo — URL or DSN, e.g. `postgres://user:pass@host:5432/db?sslmode=verify-full&sslrootcert=/certs/ca.crt`. `slot_name`/`publication_name` stay.
- The secret never lands in the config file: the whole conninfo (password included) lives in the env var.
- TLS is whatever the string says. `require`/`verify-ca`/`verify-full` are now reachable and verifiable, which closes the #47 gap.
- The replication connection uses `PQconnectdbParams` with `expand_dbname=1`, so a URL conninfo composes cleanly with the `replication=database` we add ourselves (you can't append keyword params to a URL string).
- Default posture matches Debezium (`database.sslmode=prefer`) and pgconn: no silent rewrite of the user's string. Instead we check `PQsslInUse` after connecting and `WARN` when the link is unencrypted, nudging without surprising.

`dev/config.toml`, `dev/run-dev.sh` and the example config are updated to the new shape. Unit tests cover parsing and validation of `connection_env`; integration and e2e suites pass over the new connect path.

Closes #47