### PR TITLE
Normalize code comments across the project

### DIFF
--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const toml = @import("toml");
 
-// Configuration validation limits and constants
+/// Validation limits for configuration fields.
 pub const ValidationLimits = struct {
     // String length limits
     pub const MAX_HOSTNAME_LEN = 253;
@@ -16,7 +16,7 @@ pub const ValidationLimits = struct {
     pub const MAX_STREAMS_COUNT = 100;
 };
 
-// Supported enum values
+/// Allowed values for enum-like configuration fields.
 pub const SupportedValues = struct {
     pub const SOURCE_TYPES = [_][]const u8{ "postgres", "mysql" };
     pub const SINK_TYPES = [_][]const u8{ "kafka", "webhook" };
@@ -67,9 +67,9 @@ fn readEnvVar(allocator: std.mem.Allocator, environ_map: *std.process.Environ.Ma
     return allocator.dupe(u8, value);
 }
 
-// SASL authentication for the Kafka broker. Its presence enables SASL; all fields
-// are required once present. The password is read from the environment
-// (password_env), never stored in the config file, mirroring the source password.
+/// SASL authentication for the Kafka broker. Its presence enables SASL; all fields
+/// are required once present. The password is read from the environment
+/// (password_env), never stored in the config file, mirroring the source password.
 pub const KafkaSasl = struct {
     mechanism: []const u8, // PLAIN | SCRAM-SHA-256 | SCRAM-SHA-512
     username: []const u8,
@@ -134,8 +134,8 @@ pub const TableFilter = struct {
     exclude: []const []const u8,
 };
 
-// Configuration data, and the TOML parse target. Strings point into the arena of the
-// returned toml.Parsed(Config), so the caller keeps that value alive while using it.
+/// Configuration data, and the TOML parse target. Strings point into the arena of the
+/// returned toml.Parsed(Config), so the caller keeps that value alive while using it.
 pub const Config = struct {
     metadata: Metadata,
     source: SourceConfig,
@@ -179,7 +179,6 @@ pub const Config = struct {
 
     // Helper validation functions
 
-    /// Validate that a string is in the allowed enum values
     fn validateEnum(allocator: std.mem.Allocator, value: []const u8, allowed_values: []const []const u8, field_name: []const u8) !void {
         for (allowed_values) |allowed| {
             if (std.mem.eql(u8, value, allowed)) return;
@@ -202,7 +201,6 @@ pub const Config = struct {
         return error.InvalidEnumValue;
     }
 
-    /// Validate string length limits
     fn validateStringLength(value: []const u8, max_len: usize, field_name: []const u8) !void {
         if (value.len == 0) {
             std.log.warn("Empty {s} not allowed", .{field_name});
@@ -214,7 +212,6 @@ pub const Config = struct {
         }
     }
 
-    /// Validate port number range (1-65535)
     fn validatePort(port: u16, field_name: []const u8) !void {
         if (port == 0) {
             std.log.warn("Invalid {s}: {d} (must be 1-65535)", .{ field_name, port });
@@ -223,7 +220,6 @@ pub const Config = struct {
         // u16 max is 65535, so no upper bound check needed
     }
 
-    /// Validate array size limits
     fn validateArraySize(len: usize, max_len: usize, field_name: []const u8) !void {
         if (len == 0) {
             std.log.warn("Empty {s} array not allowed", .{field_name});
@@ -235,7 +231,7 @@ pub const Config = struct {
         }
     }
 
-    /// Validate PostgreSQL identifier format (alphanumeric + underscore, must start with letter or underscore)
+    // Alphanumeric plus underscore, must start with a letter or underscore.
     fn validatePostgresIdentifier(value: []const u8, field_name: []const u8) !void {
         try validateStringLength(value, ValidationLimits.MAX_IDENTIFIER_LEN, field_name);
 
@@ -257,7 +253,7 @@ pub const Config = struct {
         }
     }
 
-    /// Validate Kafka topic name format
+    // Kafka topic charset: a-z, A-Z, 0-9, '.', '_', '-'.
     fn validateKafkaTopicName(value: []const u8, field_name: []const u8) !void {
         try validateStringLength(value, ValidationLimits.MAX_KAFKA_TOPIC_LEN, field_name);
 
@@ -270,7 +266,7 @@ pub const Config = struct {
         }
     }
 
-    /// Validate hostname format (basic validation)
+    // Basic check only: alphanumeric, dots, hyphens.
     fn validateHostname(value: []const u8, field_name: []const u8) !void {
         try validateStringLength(value, ValidationLimits.MAX_HOSTNAME_LEN, field_name);
 
@@ -283,7 +279,6 @@ pub const Config = struct {
         }
     }
 
-    /// Validate stream operations array
     fn validateOperations(allocator: std.mem.Allocator, operations: []const []const u8) !void {
         try validateArraySize(operations.len, ValidationLimits.MAX_OPERATIONS_COUNT, "operations");
 
@@ -292,7 +287,7 @@ pub const Config = struct {
         }
     }
 
-    /// Validate stream name format (allow dashes since they are sanitized in main.zig)
+    // Like a Postgres identifier but also allows dashes (sanitized in main.zig).
     fn validateStreamName(value: []const u8, field_name: []const u8) !void {
         try validateStringLength(value, ValidationLimits.MAX_IDENTIFIER_LEN, field_name);
 
@@ -314,14 +309,12 @@ pub const Config = struct {
         }
     }
 
-    /// Validate Kafka SASL settings
     fn validateKafkaSasl(allocator: std.mem.Allocator, sasl: KafkaSasl) !void {
         try validateEnum(allocator, sasl.mechanism, &SupportedValues.KAFKA_SASL_MECHANISMS, "kafka.sasl.mechanism");
         try validateStringLength(sasl.username, ValidationLimits.MAX_HOSTNAME_LEN, "kafka.sasl.username");
         try validateStringLength(sasl.password_env, ValidationLimits.MAX_IDENTIFIER_LEN, "kafka.sasl.password_env");
     }
 
-    /// Validate individual stream configuration
     fn validateStream(allocator: std.mem.Allocator, stream: Stream) !void {
         // Stream name validation (allow dashes)
         try validateStreamName(stream.name, "stream.name");
@@ -340,7 +333,6 @@ pub const Config = struct {
         }
     }
 
-    /// Validate all streams
     fn validateStreams(allocator: std.mem.Allocator, streams: []const Stream) !void {
         try validateArraySize(streams.len, ValidationLimits.MAX_STREAMS_COUNT, "streams");
 

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -6,12 +6,11 @@ pub const DESCRIPTION = "PostgreSQL Change Data Capture with Kafka";
 
 pub const BUILD_MODE = builtin.mode;
 
-// Placeholder for an unchanged TOAST value that Postgres didn't resend, so the
-// column stays in the event instead of being dropped or shown as a real NULL.
+/// Placeholder for an unchanged TOAST value that Postgres didn't resend, so the
+/// column stays in the event instead of being dropped or shown as a real NULL.
 pub const UNKNOWN_VALUE_PLACEHOLDER = "__outboxx_unknown_value__";
 
-// CDC Processing Configuration
-// Optimized for maximum throughput
+/// CDC processing tuning constants, optimized for throughput.
 pub const CDC = struct {
     // PostgreSQL batch settings
     pub const BATCH_SIZE: u32 = 5000; // Events per batch - larger batches = higher throughput

--- a/src/domain/change_event.zig
+++ b/src/domain/change_event.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-// Change operation types
+/// Kind of change operation.
 pub const ChangeOperation = enum {
     INSERT,
     UPDATE,
@@ -8,10 +8,10 @@ pub const ChangeOperation = enum {
     UNKNOWN,
 };
 
-// Field value using std.json.Value for flexibility
+/// A single field's value, backed by std.json.Value.
 pub const FieldValue = std.json.Value;
 
-// Helper functions to create field values
+/// Constructors for FieldValue variants.
 pub const FieldValueHelpers = struct {
     pub fn integer(val: i64) std.json.Value {
         return std.json.Value{ .integer = val };
@@ -34,16 +34,16 @@ pub const FieldValueHelpers = struct {
     }
 };
 
-// Field data structure (name + value pair)
+/// A named field: a column name paired with its value.
 pub const FieldData = struct {
     name: []const u8,
     value: std.json.Value,
 };
 
-// Row data is a slice of fields
+/// A row as a slice of named fields.
 pub const RowData = []FieldData;
 
-// Helper functions for working with RowData
+/// Builders and accessors for RowData.
 pub const RowDataHelpers = struct {
     pub fn createBuilder(allocator: std.mem.Allocator) std.ArrayList(FieldData) {
         _ = allocator;
@@ -92,7 +92,7 @@ pub const RowDataHelpers = struct {
     }
 };
 
-// Data section for different operations
+/// Operation-specific payload of a change event.
 pub const DataSection = union(enum) {
     insert: RowData,
     delete: RowData,
@@ -102,7 +102,7 @@ pub const DataSection = union(enum) {
     },
 };
 
-// Source metadata
+/// Source metadata for a change event.
 pub const Metadata = struct {
     source: []const u8, // "postgres", "mysql", etc.
     resource: []const u8, // table/collection name
@@ -111,7 +111,7 @@ pub const Metadata = struct {
     lsn: ?[]const u8, // Log sequence number (optional, source-specific)
 };
 
-// Main domain model - clean change event
+/// A CDC change event: operation, data payload, and source metadata.
 pub const ChangeEvent = struct {
     op: []const u8, // operation as string
     data: DataSection,

--- a/src/kafka/producer.zig
+++ b/src/kafka/producer.zig
@@ -11,6 +11,7 @@ const KafkaError = error{
     ConnectionTestFailed,
 };
 
+/// A Kafka message: optional partition key and payload.
 pub const Message = struct {
     key: ?[]const u8,
     payload: []const u8,
@@ -26,6 +27,7 @@ pub const Security = struct {
     ssl_ca_location: ?[]const u8 = null,
 };
 
+/// Minimal librdkafka producer wrapper.
 pub const KafkaProducer = struct {
     producer: ?*c.rd_kafka_t,
     allocator: std.mem.Allocator,
@@ -184,7 +186,7 @@ pub const KafkaProducer = struct {
         return topic;
     }
 
-    // Batch produce - reserved for future optimizations
+    /// Batch-produce messages to a topic. Reserved for future optimizations.
     pub fn produce(self: *Self, topic_name: []const u8, messages: []const Message) !void {
         if (messages.len == 0) return;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -100,9 +100,9 @@ fn run(init: std.process.Init) !void {
     try processor.startStreaming(init.io, &shutdown_requested);
 }
 
-/// Build the Kafka sink from config, deriving librdkafka's security.protocol from the
-/// tls/sasl axes, and fail fast if the broker is unreachable at startup. The returned
-/// producer is owned by the caller (handed to the processor, which deinits it).
+// Build the Kafka sink from config, deriving librdkafka's security.protocol from the
+// tls/sasl axes, and fail fast if the broker is unreachable at startup. The returned
+// producer is owned by the caller (handed to the processor, which deinits it).
 fn initKafkaProducer(allocator: std.mem.Allocator, kafka: config_mod.KafkaSink, sasl_password: ?[]const u8) !KafkaProducer {
     const brokers_str = try std.mem.join(allocator, ",", kafka.brokers);
     defer allocator.free(brokers_str);
@@ -123,9 +123,8 @@ fn initKafkaProducer(allocator: std.mem.Allocator, kafka: config_mod.KafkaSink, 
     return producer;
 }
 
-/// Print user-facing messages to stdout
-/// Use this for status messages, configuration info, and other user output
-/// For logs and diagnostics, use std.log.* (writes to stderr)
+// Print user-facing messages to stdout. Use for status/config output; logs and
+// diagnostics go through std.log.* (stderr).
 fn printStatus(comptime fmt: []const u8, args: anytype) void {
     var buf: [4096]u8 = undefined;
     var stdout_writer = std.Io.File.stdout().writer(stdout_io, &buf);

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -12,6 +12,7 @@ const json_serializer = @import("json_serialization");
 const JsonSerializer = json_serializer.JsonSerializer;
 const constants = @import("constants");
 
+/// Return the streams whose resource and operations match a given table change; caller owns the list.
 pub fn matchStreams(allocator: std.mem.Allocator, streams: []const Stream, table_name: []const u8, operation: []const u8) !std.ArrayList(Stream) {
     var matched = std.ArrayList(Stream).empty;
 
@@ -112,6 +113,7 @@ pub const Processor = struct {
         self.source.deinit();
     }
 
+    /// Receive one batch, route each change to its streams, and stage the batch LSN for commit.
     pub fn processChangesToKafka(self: *Self, io: std.Io, batch_allocator: std.mem.Allocator, limit: u32) !void {
         var batch = try self.source.receiveBatch(io, batch_allocator, limit);
         defer batch.deinit();
@@ -185,6 +187,7 @@ pub const Processor = struct {
         return try allocator.dupe(u8, change_event.meta.resource);
     }
 
+    /// Run the batch loop until stop_signal is set, with a background flush/commit worker.
     pub fn startStreaming(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
         const producer = &self.producer;
 

--- a/src/serialization/json.zig
+++ b/src/serialization/json.zig
@@ -5,7 +5,7 @@ const DataSection = domain.DataSection;
 const FieldData = domain.FieldData;
 const RowData = domain.RowData;
 
-// JSON Serializer for ChangeEvent
+/// Serializes a ChangeEvent to JSON bytes.
 pub const JsonSerializer = struct {
     const Self = @This();
 
@@ -13,11 +13,10 @@ pub const JsonSerializer = struct {
         return Self{};
     }
 
-    // Serialize ChangeEvent to JSON bytes
+    /// Serialize a ChangeEvent to JSON bytes; caller owns the result.
     pub fn serialize(self: *const Self, event: ChangeEvent, allocator: std.mem.Allocator) ![]u8 {
         _ = self;
 
-        // Use custom JSON writer for proper formatting
         var output: std.Io.Writer.Allocating = .init(allocator);
         errdefer output.deinit();
 
@@ -27,7 +26,6 @@ pub const JsonSerializer = struct {
         try writer.writeAll(event.op);
         try writer.writeAll("\",\"data\":");
 
-        // Serialize data section
         try serializeDataSection(event.data, writer);
 
         try writer.writeAll(",\"meta\":{");

--- a/src/source/postgres/pg_output_decoder.zig
+++ b/src/source/postgres/pg_output_decoder.zig
@@ -7,7 +7,7 @@ pub const DecoderError = error{
     InvalidTupleData,
 };
 
-// Message type identifiers from pgoutput protocol
+/// Message type identifiers from the pgoutput protocol.
 pub const MessageType = enum(u8) {
     begin = 'B',
     commit = 'C',
@@ -123,6 +123,7 @@ pub const DeleteMessage = struct {
     }
 };
 
+/// A decoded pgoutput logical replication message.
 pub const PgOutputMessage = union(enum) {
     begin: BeginMessage,
     commit: CommitMessage,
@@ -142,6 +143,7 @@ pub const PgOutputMessage = union(enum) {
     }
 };
 
+/// Parses raw pgoutput bytes into typed PgOutputMessage values.
 pub const PgOutputDecoder = struct {
     allocator: std.mem.Allocator,
 
@@ -153,6 +155,7 @@ pub const PgOutputDecoder = struct {
         };
     }
 
+    /// Decode one pgoutput message into a typed PgOutputMessage.
     pub fn decode(self: *Self, allocator: std.mem.Allocator, data: []const u8) DecoderError!PgOutputMessage {
         self.allocator = allocator; // decode into the caller's (per-batch) allocator
 

--- a/src/source/postgres/relation_registry.zig
+++ b/src/source/postgres/relation_registry.zig
@@ -24,6 +24,7 @@ pub const RelationInfo = struct {
     }
 };
 
+/// Maps relation_id to table metadata, rebuilt in memory from RELATION messages.
 pub const RelationRegistry = struct {
     allocator: std.mem.Allocator,
     relations: std.AutoHashMap(u32, RelationInfo),

--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -10,7 +10,7 @@ pub const ReplicationError = error{
     OutOfMemory,
 };
 
-// Message type identifiers from PostgreSQL replication protocol
+/// Message type identifiers from the PostgreSQL replication protocol.
 pub const MessageType = enum(u8) {
     xlog_data = 'w',
     keepalive = 'k',
@@ -55,6 +55,7 @@ pub const ReplicationMessage = union(enum) {
     }
 };
 
+/// Low-level libpq streaming replication protocol (CopyBoth mode).
 pub const ReplicationProtocol = struct {
     allocator: std.mem.Allocator,
     connection: ?*c.PGconn,

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -189,19 +189,14 @@ pub const PostgresSource = struct {
         };
     }
 
-    /// Extract change from replication message and return LSN for confirmation
-    /// Returns LSN of the message if successfully processed
-    /// Propagates errors (DecodeFailed, ConversionFailed) to caller
-    ///
-    /// LSN is returned even for messages that don't produce ChangeEvents
-    /// (BEGIN/COMMIT/RELATION) - they are still considered "processed"
-    ///
-    /// Error handling strategy (Fail-stop):
-    /// - Decode/convert errors propagate up to main()
-    /// - Application exits with non-zero code
-    /// - Supervisor (systemd/k8s) restarts application
-    /// - PostgreSQL re-sends the same message (LSN not confirmed)
-    /// - If error persists → crash loop → operator intervention required
+    // Extract a change from a replication message and return its LSN for confirmation.
+    // The LSN is returned even for messages that produce no ChangeEvent
+    // (BEGIN/COMMIT/RELATION) - they still count as processed.
+    //
+    // Error handling strategy (fail-stop): decode/convert errors propagate up to main(),
+    // the app exits non-zero, and the supervisor (systemd/k8s) restarts it. The LSN is
+    // not confirmed, so PostgreSQL re-sends the same message; a persistent error becomes
+    // a crash loop that needs operator intervention.
     fn extractChangeFromMessage(self: *Self, io: std.Io, batch_allocator: std.mem.Allocator, msg: replication_protocol.ReplicationMessage, changes: *std.ArrayList(ChangeEvent)) !u64 {
         switch (msg) {
             .xlog_data => |xlog| {

--- a/tests/benchmarks/scripts/collect_results.sh
+++ b/tests/benchmarks/scripts/collect_results.sh
@@ -71,7 +71,7 @@ time_us_of() {
 
 # --- Aggregate: minimum time/run per sub-benchmark across passes -------------
 # Why min: benchmark noise is one-sided (scheduling / cold cache / load only
-# *add* time), so the minimum is the cleanest, least-noisy sample — far more
+# *add* time), so the minimum is the cleanest, least-noisy sample, far more
 # stable than the average for a regression baseline. Memory and allocation
 # counts are deterministic, so they come from the first pass.
 for bench in "${BENCHES[@]}"; do


### PR DESCRIPTION
Applies the comment convention settled in #45 across the rest of the tree so visibility is legible at a glance. Reference: \`src/source/postgres/converter.zig\`.

## What changed
- **\`///\` on public declarations** that were using \`//\` (types, key methods) across domain, serialization, config, kafka, processor, and postgres modules.
- **\`///\` → \`//\` on private declarations** that were misusing doc comments: the \`config\` validators, \`main.initKafkaProducer\`/\`printStatus\`, \`source.extractChangeFromMessage\`.
- **Dropped trivial narration** that only restated the next line (e.g. \`// Validate all streams\`), keeping comments that carry a real contract or *why*.
- Fixed one em-dash in a benchmark script comment (\`/writer\` tell).

## Interpretation (surgical, matching the reference)
The issue says public decls "require" \`///\`, but \`converter.zig\` leaves trivial \`init\`/\`deinit\` bare and the same convention says "prefer no comment." I resolved that the way the reference does: added \`///\` to non-trivial public types and significant functions, and left self-evident ones (\`init\`/\`deinit\`/\`poll\`/\`readU64BigEndian\`, plain data-holder structs) bare. If you'd rather have a \`///\` on *every* public decl, that's a quick follow-up.

Comment-only change; \`make test-unit\` passes.

Closes #56