### PR TITLE
Observability: Prometheus /metrics and health endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ src/
     validator.zig            startup checks: version, wal_level, tables
   processor/processor.zig    pipeline, stream matching, flush/commit worker
   kafka/producer.zig         librdkafka wrapper (TLS/SASL)
+  observability/             OpenTelemetry facade + Prometheus/health HTTP server
   config/config.zig          TOML structs, env-var loading, validation
 tests/  test_helpers.zig, e2e/, benchmarks/, load/
 ```
@@ -90,6 +91,8 @@ TOML, secrets kept out of the file (see `docs/examples/config.toml`).
   advisory, not a rewrite.
 - `[sink.kafka]`: `tls` (default true) plus an optional `[sink.kafka.sasl]`
   (`mechanism`, `username`, `password_env`).
+- `[observability]` (optional; absent = off): `address`/`port` for a Prometheus
+  `/metrics` plus `/healthz` and `/readyz` HTTP server.
 - Postgres needs `wal_level = logical` and `REPLICA IDENTITY FULL` on tracked
   tables. Outboxx auto-creates the slot and publication.
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Outboxx captures PostgreSQL database changes in real-time and streams them to Ka
 - Multi-table CDC streams
 - Kafka producer integration
 - TOML-based configuration
+- Prometheus metrics and health endpoints
 - Memory-safe Zig implementation
 
 ## Roadmap
 
-- Observability
 - Schema Registry
 - Table/Column Filtering
 

--- a/build.zig
+++ b/build.zig
@@ -43,6 +43,22 @@ pub fn build(b: *std.Build) void {
     });
     config_module.addImport("toml", toml_module);
 
+    // OpenTelemetry SDK: metric instruments + aggregation behind the observability facade.
+    // It sets a preferred optimize mode, so it takes -Drelease, not -Doptimize; pass only target.
+    const otel_dep = b.dependency("opentelemetry", .{
+        .target = target,
+    });
+    const otel_module = otel_dep.module("sdk");
+
+    // Observability module (Prometheus /metrics + health endpoints), the only OTel consumer.
+    const observability_module = b.createModule(.{
+        .root_source_file = b.path("src/observability/observability.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    observability_module.addImport("opentelemetry-sdk", otel_module);
+    observability_module.addImport("constants", constants_module);
+
     // Domain module (new architecture) - must be defined before use
     const domain_module = b.createModule(.{
         .root_source_file = b.path("src/domain/change_event.zig"),
@@ -111,6 +127,7 @@ pub fn build(b: *std.Build) void {
     cdc_processor_module.addImport("kafka_producer", kafka_producer_module);
     cdc_processor_module.addImport("config", config_module);
     cdc_processor_module.addImport("constants", constants_module);
+    cdc_processor_module.addImport("observability", observability_module);
 
     // Main executable
     const exe = b.addExecutable(.{
@@ -130,6 +147,7 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addImport("config", config_module);
     exe.root_module.addImport("postgres_source", postgres_source_module);
     exe.root_module.addImport("constants", constants_module);
+    exe.root_module.addImport("observability", observability_module);
     exe.root_module.addImport("c", c_prod_module);
 
     // Link libc for PostgreSQL and Kafka C libraries
@@ -164,6 +182,17 @@ pub fn build(b: *std.Build) void {
         }),
     });
     config_tests.root_module.addImport("toml", toml_module);
+
+    // Observability tests (metrics rendering + health logic)
+    const observability_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/observability/observability_test.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    observability_tests.root_module.addImport("opentelemetry-sdk", otel_module);
+    observability_tests.root_module.addImport("constants", constants_module);
 
     // Domain layer tests (new)
     const domain_tests = b.addTest(.{
@@ -278,6 +307,7 @@ pub fn build(b: *std.Build) void {
     streaming_integration_tests.root_module.addImport("test_helpers", test_helpers_module);
 
     const run_config_tests = b.addRunArtifact(config_tests);
+    const run_observability_tests = b.addRunArtifact(observability_tests);
     const run_domain_tests = b.addRunArtifact(domain_tests);
     const run_json_serialization_tests = b.addRunArtifact(json_serialization_tests);
     const run_kafka_producer_tests = b.addRunArtifact(kafka_producer_tests);
@@ -289,6 +319,7 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_config_tests.step);
+    test_step.dependOn(&run_observability_tests.step);
     test_step.dependOn(&run_domain_tests.step);
     test_step.dependOn(&run_json_serialization_tests.step);
     test_step.dependOn(&run_pg_output_decoder_tests.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,6 +11,10 @@
             .url = "git+https://github.com/sam701/zig-toml?ref=zig-0.16#8685923e32e8b8a795eb2715684236975a70faed",
             .hash = "toml-0.3.0-bV14BRmKAQAWR0FT0KUKFwVJTImaFhWjSe6HfSMtNZOH",
         },
+        .opentelemetry = .{
+            .url = "git+https://github.com/open-telemetry/opentelemetry-zig#e0733b5c76cf824d779bbbc16bd245fd150547a3",
+            .hash = "opentelemetry-0.0.1-U_uKJyc5EAAZw67wdZWA_8xFEeuWBd4Gidi4ohaTJkwq",
+        },
     },
     .paths = .{""},
     .fingerprint = 0xdcb3806ad7417129,

--- a/dev/config.toml
+++ b/dev/config.toml
@@ -26,6 +26,11 @@ type = "kafka" # Reference to the "sink.kafka"
 brokers = ["localhost:9092"]
 tls = false  # local Kafka has no TLS; encryption is on by default otherwise
 
+# Prometheus /metrics plus /healthz and /readyz. Omit this section to disable.
+[observability]
+address = "127.0.0.1"
+port = 9464
+
 # Multiple streams can be defined to capture changes from different resources
 [[streams]]
 name = "users_dev_stream" # Name could be used for logging or metrics and new entites

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -32,8 +32,6 @@ configured address/port (default `0.0.0.0:9464`):
 - `GET /healthz` - liveness: 200 while the receive loop makes progress, 503 if it stalls.
 - `GET /readyz` - readiness: 200 once connected to Postgres and streaming, else 503.
 
-Events per second is a query, not a metric: `rate(outboxx_events_processed_total[1m])`.
-
 ## Run it
 
 ```bash

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -8,6 +8,7 @@ option in it is implemented; copy it and adjust the values.
 - A PostgreSQL source read over logical replication (slot + publication).
 - A Kafka sink with TLS and optional SASL.
 - Two example streams mapping tables to topics, keyed for partitioning.
+- Optional Prometheus metrics and health endpoints.
 
 ## Environment variables
 
@@ -17,6 +18,21 @@ Secrets stay out of the file and are read from the environment:
   password and `sslmode`. Example:
   `postgres://user:pass@host:5432/db?sslmode=require`.
 - `KAFKA_PASSWORD` - only when a `[sink.kafka.sasl]` section is present.
+
+## Observability
+
+With an `[observability]` section, Outboxx serves three HTTP endpoints on the
+configured address/port (default `0.0.0.0:9464`):
+
+- `GET /metrics` - Prometheus text exposition, currently:
+  - `outboxx_events_processed_total` (counter) - WAL change events consumed
+  - `outboxx_decode_errors_total` (counter) - pgoutput decode/convert failures
+  - `outboxx_produce_errors_total` (counter) - Kafka produce failures
+  - `outboxx_replication_lag_bytes` (gauge) - server WAL head minus the last confirmed LSN
+- `GET /healthz` - liveness: 200 while the receive loop makes progress, 503 if it stalls.
+- `GET /readyz` - readiness: 200 once connected to Postgres and streaming, else 503.
+
+Events per second is a query, not a metric: `rate(outboxx_events_processed_total[1m])`.
 
 ## Run it
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -26,7 +26,6 @@ configured address/port (default `0.0.0.0:9464`):
 
 - `GET /metrics` - Prometheus text exposition, currently:
   - `outboxx_events_processed_total` (counter) - WAL change events consumed
-  - `outboxx_decode_errors_total` (counter) - pgoutput decode/convert failures
   - `outboxx_produce_errors_total` (counter) - Kafka produce failures
   - `outboxx_replication_lag_seconds` (gauge) - seconds the last processed transaction is behind now, i.e. time behind source (0 when caught up)
 - `GET /healthz` - liveness: 200 while the receive loop makes progress, 503 if it stalls.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -28,7 +28,7 @@ configured address/port (default `0.0.0.0:9464`):
   - `outboxx_events_processed_total` (counter) - WAL change events consumed
   - `outboxx_decode_errors_total` (counter) - pgoutput decode/convert failures
   - `outboxx_produce_errors_total` (counter) - Kafka produce failures
-  - `outboxx_replication_lag_bytes` (gauge) - server WAL head minus the last confirmed LSN
+  - `outboxx_replication_lag_bytes` (gauge) - WAL bytes the server head is ahead of the last processed change (0 when caught up)
 - `GET /healthz` - liveness: 200 while the receive loop makes progress, 503 if it stalls.
 - `GET /readyz` - readiness: 200 once connected to Postgres and streaming, else 503.
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -25,7 +25,7 @@ With an `[observability]` section, Outboxx serves three HTTP endpoints on the
 configured address/port (default `0.0.0.0:9464`):
 
 - `GET /metrics` - Prometheus text exposition, currently:
-  - `outboxx_events_processed_total` (counter) - WAL change events consumed
+  - `outboxx_events_processed_total` (counter, labeled by `stream` and `operation`) - WAL change events routed, per configured stream
   - `outboxx_produce_errors_total` (counter) - Kafka produce failures
   - `outboxx_replication_lag_seconds` (gauge) - seconds the last processed transaction is behind now, i.e. time behind source (0 when caught up)
 - `GET /healthz` - liveness: 200 while the receive loop makes progress, 503 if it stalls.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -28,7 +28,7 @@ configured address/port (default `0.0.0.0:9464`):
   - `outboxx_events_processed_total` (counter) - WAL change events consumed
   - `outboxx_decode_errors_total` (counter) - pgoutput decode/convert failures
   - `outboxx_produce_errors_total` (counter) - Kafka produce failures
-  - `outboxx_replication_lag_bytes` (gauge) - WAL bytes the server head is ahead of the last processed change (0 when caught up)
+  - `outboxx_replication_lag_seconds` (gauge) - seconds the last processed transaction is behind now, i.e. time behind source (0 when caught up)
 - `GET /healthz` - liveness: 200 while the receive loop makes progress, 503 if it stalls.
 - `GET /readyz` - readiness: 200 once connected to Postgres and streaming, else 503.
 

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -40,6 +40,13 @@ tls = true                                   # on by default; set false for loca
 # username = "app_user"
 # password_env = "KAFKA_PASSWORD"
 
+# Optional Prometheus metrics and health endpoints. Omit this section to disable
+# the HTTP server. Exposes /metrics (Prometheus text), /healthz (liveness) and
+# /readyz (readiness); no secrets are served on these endpoints.
+[observability]
+address = "0.0.0.0"  # 127.0.0.1 to keep it local; 0.0.0.0 for container scraping
+port = 9464          # conventional OpenTelemetry Prometheus exporter port
+
 # One [[streams]] block per table -> topic mapping.
 [[streams]]
 name = "users-stream"

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -203,6 +203,14 @@ pub const Config = struct {
         }
     }
 
+    // Reject port 0; u16 already caps the upper bound at 65535.
+    fn validatePort(port: u16, field_name: []const u8) !void {
+        if (port == 0) {
+            std.log.warn("Invalid {s}: port must be 1-65535", .{field_name});
+            return error.InvalidPort;
+        }
+    }
+
     fn validateArraySize(len: usize, max_len: usize, field_name: []const u8) !void {
         if (len == 0) {
             std.log.warn("Empty {s} array not allowed", .{field_name});

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -117,6 +117,13 @@ pub const TableFilter = struct {
     exclude: []const []const u8,
 };
 
+/// Optional metrics/health HTTP server. Absent section -> observability disabled.
+pub const ObservabilityConfig = struct {
+    // 0.0.0.0 for container scraping; 127.0.0.1 to keep it local. No secrets on these endpoints.
+    address: []const u8 = "0.0.0.0",
+    port: u16 = 9464, // conventional OpenTelemetry Prometheus exporter port
+};
+
 /// Configuration data, and the TOML parse target. Strings point into the arena of the
 /// returned toml.Parsed(Config), so the caller keeps that value alive while using it.
 pub const Config = struct {
@@ -125,6 +132,7 @@ pub const Config = struct {
     sink: SinkConfig,
     streams: []const Stream = &.{},
     tables: ?TableFilter = null,
+    observability: ?ObservabilityConfig = null,
 
     /// Parse a config file; caller owns and must deinit the returned result.
     pub fn loadFromTomlFile(io: std.Io, allocator: std.mem.Allocator, file_path: []const u8) !toml.Parsed(Config) {
@@ -381,7 +389,13 @@ pub const Config = struct {
             }
         }
 
-        // 5. STREAMS VALIDATION
+        // 5. OBSERVABILITY VALIDATION
+        if (self.observability) |obs| {
+            try validatePort(obs.port, "observability.port");
+            try validateStringLength(obs.address, ValidationLimits.MAX_HOSTNAME_LEN, "observability.address");
+        }
+
+        // 6. STREAMS VALIDATION
         if (self.streams.len == 0) {
             std.log.warn("No streams configured in config file", .{});
             return error.NoStreamsConfigured;

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -24,3 +24,10 @@ pub const CDC = struct {
     pub const KAFKA_BATCH_SIZE = "262144"; // 256KB batches for better network utilization
     pub const KAFKA_POLL_INTERVAL: u32 = 100; // Poll every N messages (reduces syscall overhead)
 };
+
+/// Observability tuning constants.
+pub const OBSERVABILITY = struct {
+    // Liveness turns unhealthy if the receive loop makes no progress for this long.
+    // Must exceed BATCH_WAIT and the flush interval; keepalives keep it fresh when idle.
+    pub const LIVENESS_MAX_STALE_SEC: i64 = 30;
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -116,7 +116,6 @@ fn run(init: std.process.Init) !void {
 
     printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
     try source.connect(conninfo, "0/0");
-    obs.markConnected(true);
 
     const producer = try initKafkaProducer(allocator, config.sink.kafka.?, kafka_sasl_pw);
     // NOTE: producer will be deinit'd by processor.deinit()

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,8 @@ const PostgresValidator = @import("source/postgres/validator.zig").PostgresValid
 const builtin = @import("builtin");
 const posix = std.posix;
 const constants = @import("constants");
+const observability = @import("observability");
+const Observability = observability.Observability;
 
 pub const CliError = error{
     NoConfigPath,
@@ -91,6 +93,14 @@ fn run(init: std.process.Init) !void {
 
     printConfigInfo(config);
 
+    // Metrics/health are no-ops unless [observability] is configured, so the
+    // rest of the wiring never branches on it.
+    var obs = if (config.observability != null)
+        try Observability.init(allocator, init.io)
+    else
+        Observability.initDisabled();
+    defer obs.deinit();
+
     try validatePostgres(allocator, config, conninfo);
 
     const postgres = config.source.postgres.?;
@@ -106,11 +116,12 @@ fn run(init: std.process.Init) !void {
 
     printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
     try source.connect(conninfo, "0/0");
+    obs.markConnected(true);
 
     const producer = try initKafkaProducer(allocator, config.sink.kafka.?, kafka_sasl_pw);
     // NOTE: producer will be deinit'd by processor.deinit()
 
-    var processor = Processor.init(allocator, source, producer, config.streams);
+    var processor = Processor.init(allocator, source, producer, config.streams, &obs);
     defer processor.deinit();
 
     printStatus("\nProcessor initialized successfully with slot: {s}\n", .{postgres.slot_name});
@@ -122,7 +133,18 @@ fn run(init: std.process.Init) !void {
     printStatus("Using publication: {s}\n", .{postgres.publication_name});
     printStatus("Press Ctrl+C to stop gracefully.\n\n", .{});
 
-    try processor.startStreaming(init.io, &shutdown_requested);
+    // Serve /metrics + health on a background worker while the receive loop runs;
+    // the future is canceled on shutdown, which unblocks its accept().
+    if (config.observability) |obs_cfg| {
+        printStatus("Observability endpoints on http://{s}:{d} (/metrics, /healthz, /readyz)\n\n", .{ obs_cfg.address, obs_cfg.port });
+        var metrics_future = try init.io.concurrent(observability.serve, .{
+            init.io, &obs, obs_cfg.address, obs_cfg.port, &shutdown_requested,
+        });
+        defer metrics_future.cancel(init.io);
+        try processor.startStreaming(init.io, &shutdown_requested);
+    } else {
+        try processor.startStreaming(init.io, &shutdown_requested);
+    }
 }
 
 // Build the Kafka sink from config, deriving librdkafka's security.protocol from the

--- a/src/main.zig
+++ b/src/main.zig
@@ -98,7 +98,7 @@ fn run(init: std.process.Init) !void {
     var obs = if (config.observability != null)
         try Observability.init(allocator, init.io)
     else
-        Observability.initDisabled();
+        Observability.noop();
     defer obs.deinit();
 
     try validatePostgres(allocator, config, conninfo);

--- a/src/observability/http.zig
+++ b/src/observability/http.zig
@@ -1,0 +1,84 @@
+const std = @import("std");
+const Observability = @import("observability.zig").Observability;
+
+const metrics_content_type = "text/plain; version=0.0.4; charset=utf-8";
+
+/// Serve `/metrics`, `/healthz` and `/readyz` until `stop` is set. Runs as an
+/// `io.concurrent` worker alongside the receive loop; on shutdown the future is
+/// cancelled, which unblocks `accept`. Errors are logged, never propagated —
+/// observability must not take the pipeline down.
+pub fn serve(io: std.Io, obs: *Observability, address: []const u8, port: u16, stop: *std.atomic.Value(bool)) void {
+    serveImpl(io, obs, address, port, stop) catch |err| {
+        std.log.warn("metrics server stopped: {}", .{err});
+    };
+}
+
+fn serveImpl(io: std.Io, obs: *Observability, address: []const u8, port: u16, stop: *std.atomic.Value(bool)) !void {
+    const addr = try std.Io.net.IpAddress.parse(address, port);
+    var server = try addr.listen(io, .{ .reuse_address = true });
+    defer server.deinit(io);
+
+    std.log.info("metrics server listening on http://{s}:{d}/metrics", .{ address, port });
+
+    while (!stop.load(.monotonic)) {
+        var stream = server.accept(io) catch |err| {
+            if (stop.load(.monotonic)) break;
+            std.log.debug("metrics accept failed: {}", .{err});
+            continue;
+        };
+        defer stream.close(io);
+        // One request per connection keeps scrapes serialized, so collect() never overlaps.
+        handleConnection(io, obs, &stream) catch |err| {
+            std.log.debug("metrics request failed: {}", .{err});
+        };
+    }
+}
+
+fn handleConnection(io: std.Io, obs: *Observability, stream: *std.Io.net.Stream) !void {
+    var read_buffer: [4096]u8 = undefined;
+    var write_buffer: [4096]u8 = undefined;
+    var conn_reader = stream.reader(io, &read_buffer);
+    var conn_writer = stream.writer(io, &write_buffer);
+    var server = std.http.Server.init(&conn_reader.interface, &conn_writer.interface);
+
+    var request = try server.receiveHead();
+    const target = request.head.target;
+
+    if (std.mem.eql(u8, target, "/metrics")) {
+        try respondMetrics(obs, &request);
+    } else if (std.mem.eql(u8, target, "/healthz")) {
+        try respondHealth(&request, obs.liveness(io));
+    } else if (std.mem.eql(u8, target, "/readyz")) {
+        try respondHealth(&request, obs.readiness(io));
+    } else {
+        try request.respond("not found\n", .{ .status = .not_found });
+    }
+}
+
+fn respondMetrics(obs: *Observability, request: *std.http.Server.Request) !void {
+    var aw = std.Io.Writer.Allocating.init(obs.allocator);
+    defer aw.deinit();
+
+    obs.writeMetrics(&aw.writer) catch {
+        try request.respond("metric collection failed\n", .{ .status = .internal_server_error });
+        return;
+    };
+    const body = aw.toOwnedSlice() catch {
+        try request.respond("out of memory\n", .{ .status = .internal_server_error });
+        return;
+    };
+    defer obs.allocator.free(body);
+
+    try request.respond(body, .{
+        .status = .ok,
+        .extra_headers = &.{.{ .name = "content-type", .value = metrics_content_type }},
+    });
+}
+
+fn respondHealth(request: *std.http.Server.Request, healthy: bool) !void {
+    if (healthy) {
+        try request.respond("ok\n", .{ .status = .ok });
+    } else {
+        try request.respond("unavailable\n", .{ .status = .service_unavailable });
+    }
+}

--- a/src/observability/observability.zig
+++ b/src/observability/observability.zig
@@ -61,7 +61,14 @@ pub const Observability = struct {
 
         // InMemory + manual collect() lets us render Prometheus text on scrape
         // instead of running the SDK's own background HTTP server/thread.
-        const inmem = try metrics.MetricExporter.InMemory(allocator, io, null, null);
+        //
+        // Pass DefaultTemporality explicitly: InMemory otherwise defaults every
+        // instrument to Cumulative, and the reader's cumulative path *sums*
+        // successive collected values. That is right for counters but wrong for
+        // the lag gauge — it would grow without bound and never fall back to 0.
+        // DefaultTemporality keeps counters Cumulative and gives the gauge Delta,
+        // so each scrape reports its last recorded value.
+        const inmem = try metrics.MetricExporter.InMemory(allocator, io, metrics.View.DefaultTemporality, null);
         errdefer inmem.in_memory.deinit();
 
         const reader = try metrics.MetricReader.init(allocator, io, inmem.exporter);

--- a/src/observability/observability.zig
+++ b/src/observability/observability.zig
@@ -1,0 +1,199 @@
+const std = @import("std");
+const otel = @import("opentelemetry-sdk");
+const constants = @import("constants");
+
+const metrics = otel.metrics;
+
+pub const serve = @import("http.zig").serve;
+
+// Last rendered value of a single metric series, kept between scrapes.
+const Sample = struct { prom_type: []const u8, value: i64 };
+
+/// Metric instruments plus liveness/readiness state for the pipeline, sitting
+/// behind the OpenTelemetry SDK. Constructed either enabled (real OTel plumbing)
+/// or disabled (every record call is a cheap no-op), so callers never branch on
+/// whether observability is configured.
+///
+/// Metrics are pull-only: instruments are incremented on the hot path, and the
+/// HTTP `/metrics` handler renders them on scrape via `writeMetrics`. Keeping the
+/// SDK confined here means an alpha API break lands in one file.
+pub const Observability = struct {
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    enabled: bool,
+
+    // OpenTelemetry plumbing; null when disabled.
+    mp: ?*metrics.MeterProvider = null,
+    reader: ?*metrics.MetricReader = null,
+    in_memory: ?*metrics.InMemoryExporter = null,
+
+    // collect() only emits instruments touched since the last call; this holds the
+    // latest value of every series so each scrape renders them all. Keyed by the
+    // instrument name, which the SDK borrows for the instrument's lifetime.
+    snapshot: std.StringHashMapUnmanaged(Sample) = .{},
+
+    // Instruments; null when disabled.
+    events: ?*metrics.Counter(u64) = null,
+    decode_errors: ?*metrics.Counter(u64) = null,
+    produce_errors: ?*metrics.Counter(u64) = null,
+    lag: ?*metrics.Gauge(i64) = null,
+
+    // Health state, valid in both modes and read from the HTTP worker.
+    last_progress_sec: std.atomic.Value(i64),
+    connected: std.atomic.Value(bool),
+    streaming: std.atomic.Value(bool),
+
+    /// No-op instance: no OTel objects, no HTTP server; all record calls return early.
+    pub fn initDisabled() Self {
+        return .{
+            .allocator = undefined,
+            .enabled = false,
+            .last_progress_sec = std.atomic.Value(i64).init(0),
+            .connected = std.atomic.Value(bool).init(false),
+            .streaming = std.atomic.Value(bool).init(false),
+        };
+    }
+
+    pub fn init(allocator: std.mem.Allocator, io: std.Io) !Self {
+        const mp = try metrics.MeterProvider.init(allocator, io);
+        errdefer mp.shutdown();
+
+        // InMemory + manual collect() lets us render Prometheus text on scrape
+        // instead of running the SDK's own background HTTP server/thread.
+        const inmem = try metrics.MetricExporter.InMemory(allocator, io, null, null);
+        errdefer inmem.in_memory.deinit();
+
+        const reader = try metrics.MetricReader.init(allocator, io, inmem.exporter);
+        errdefer reader.shutdown();
+        try mp.addReader(reader);
+
+        const meter = try mp.getMeter(.{ .name = "outboxx", .version = constants.VERSION });
+
+        return .{
+            .allocator = allocator,
+            .enabled = true,
+            .mp = mp,
+            .reader = reader,
+            .in_memory = inmem.in_memory,
+            .events = try meter.createCounter(u64, .{
+                .name = "outboxx_events_processed_total",
+                .description = "WAL change events consumed from the replication stream",
+            }),
+            .decode_errors = try meter.createCounter(u64, .{
+                .name = "outboxx_decode_errors_total",
+                .description = "pgoutput decode/convert failures",
+            }),
+            .produce_errors = try meter.createCounter(u64, .{
+                .name = "outboxx_produce_errors_total",
+                .description = "Kafka produce failures",
+            }),
+            .lag = try meter.createGauge(i64, .{
+                .name = "outboxx_replication_lag_bytes",
+                .description = "Server WAL position minus the last confirmed LSN, in bytes",
+            }),
+            // Seed the heartbeat so liveness holds through a slow startup/connect.
+            .last_progress_sec = std.atomic.Value(i64).init(std.Io.Timestamp.now(io, .awake).toSeconds()),
+            .connected = std.atomic.Value(bool).init(false),
+            .streaming = std.atomic.Value(bool).init(false),
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        if (!self.enabled) return;
+        self.snapshot.deinit(self.allocator);
+        if (self.reader) |r| r.shutdown();
+        if (self.mp) |p| p.shutdown();
+        if (self.in_memory) |m| m.deinit();
+    }
+
+    /// Count WAL change events consumed in a batch (n = batch.changes.len).
+    pub fn addEvents(self: *Self, n: usize) void {
+        const c = self.events orelse return;
+        c.add(@intCast(n), .{}) catch {};
+    }
+
+    pub fn recordDecodeError(self: *Self) void {
+        const c = self.decode_errors orelse return;
+        c.add(1, .{}) catch {};
+    }
+
+    pub fn recordProduceError(self: *Self) void {
+        const c = self.produce_errors orelse return;
+        c.add(1, .{}) catch {};
+    }
+
+    /// Replication lag = server WAL head minus the last confirmed LSN (saturating).
+    /// Skipped until the first feedback establishes a baseline; otherwise a zero
+    /// confirmed LSN would report the absolute server position as "lag".
+    pub fn setLag(self: *Self, server_lsn: u64, confirmed_lsn: u64) void {
+        const g = self.lag orelse return;
+        if (confirmed_lsn == 0) return;
+        const delta = if (server_lsn > confirmed_lsn) server_lsn - confirmed_lsn else 0;
+        g.record(@intCast(delta), .{}) catch {};
+    }
+
+    /// Mark the receive loop as alive; call once per batch iteration.
+    pub fn heartbeat(self: *Self, io: std.Io) void {
+        self.last_progress_sec.store(std.Io.Timestamp.now(io, .awake).toSeconds(), .monotonic);
+    }
+
+    pub fn markConnected(self: *Self, value: bool) void {
+        self.connected.store(value, .monotonic);
+    }
+
+    pub fn markStreaming(self: *Self) void {
+        self.streaming.store(true, .monotonic);
+    }
+
+    /// Liveness: the receive loop produced progress recently (not hung).
+    pub fn liveness(self: *Self, io: std.Io) bool {
+        const now = std.Io.Timestamp.now(io, .awake).toSeconds();
+        return now - self.last_progress_sec.load(.monotonic) < constants.OBSERVABILITY.LIVENESS_MAX_STALE_SEC;
+    }
+
+    /// Readiness: connected to Postgres, streaming has begun, and still live.
+    pub fn readiness(self: *Self, io: std.Io) bool {
+        return self.connected.load(.monotonic) and self.streaming.load(.monotonic) and self.liveness(io);
+    }
+
+    /// Collect the current metric snapshot and render it as Prometheus text.
+    /// On-scrape: `collect()` drives the aggregator, `fetch()` drains it, and we
+    /// format the scalar (attribute-less) instruments ourselves — the SDK's
+    /// PrometheusFormatter is not part of its public surface.
+    pub fn writeMetrics(self: *Self, writer: *std.Io.Writer) !void {
+        const reader = self.reader orelse return;
+        const in_memory = self.in_memory orelse return;
+
+        try reader.collect();
+        const measurements = try in_memory.fetch(self.allocator);
+        defer {
+            for (measurements) |*m| m.deinit(self.allocator);
+            self.allocator.free(measurements);
+        }
+
+        // Merge this collection into the persistent snapshot (scalar, unlabeled series only).
+        for (measurements) |m| {
+            const prom_type: []const u8 = switch (m.instrumentKind) {
+                .Counter, .ObservableCounter => "counter",
+                else => "gauge",
+            };
+            switch (m.data) {
+                .int => |points| {
+                    if (points.len == 0) continue;
+                    try self.snapshot.put(self.allocator, m.instrumentOptions.name, .{
+                        .prom_type = prom_type,
+                        .value = points[points.len - 1].value,
+                    });
+                },
+                else => {},
+            }
+        }
+
+        var it = self.snapshot.iterator();
+        while (it.next()) |entry| {
+            const name = entry.key_ptr.*;
+            try writer.print("# TYPE {s} {s}\n{s} {d}\n", .{ name, entry.value_ptr.prom_type, name, entry.value_ptr.value });
+        }
+    }
+};

--- a/src/observability/observability.zig
+++ b/src/observability/observability.zig
@@ -63,11 +63,12 @@ pub const Observability = struct {
         // instead of running the SDK's own background HTTP server/thread.
         //
         // Pass DefaultTemporality explicitly: InMemory otherwise defaults every
-        // instrument to Cumulative, and the reader's cumulative path *sums*
-        // successive collected values. That is right for counters but wrong for
-        // the lag gauge — it would grow without bound and never fall back to 0.
-        // DefaultTemporality keeps counters Cumulative and gives the gauge Delta,
-        // so each scrape reports its last recorded value.
+        // instrument to Cumulative, and the SDK's cumulative path *sums*
+        // successive collected values (open-telemetry/opentelemetry-zig#36). That
+        // is right for counters but wrong for the lag gauge — it would grow without
+        // bound and never fall back to 0. DefaultTemporality keeps counters
+        // Cumulative and gives the gauge Delta, so each scrape reports its last
+        // recorded value, which is what Prometheus expects for each.
         const inmem = try metrics.MetricExporter.InMemory(allocator, io, metrics.View.DefaultTemporality, null);
         errdefer inmem.in_memory.deinit();
 

--- a/src/observability/observability.zig
+++ b/src/observability/observability.zig
@@ -45,7 +45,7 @@ pub const Observability = struct {
     streaming: std.atomic.Value(bool),
 
     /// No-op instance: no OTel objects, no HTTP server; all record calls return early.
-    pub fn initDisabled() Self {
+    pub fn noop() Self {
         return .{
             .allocator = undefined,
             .enabled = false,
@@ -121,11 +121,13 @@ pub const Observability = struct {
         c.add(@intCast(n), .{}) catch {};
     }
 
+    /// Count one pgoutput decode/convert failure.
     pub fn recordDecodeError(self: *Self) void {
         const c = self.decode_errors orelse return;
         c.add(1, .{}) catch {};
     }
 
+    /// Count one Kafka produce failure.
     pub fn recordProduceError(self: *Self) void {
         const c = self.produce_errors orelse return;
         c.add(1, .{}) catch {};
@@ -143,10 +145,12 @@ pub const Observability = struct {
         self.last_progress_sec.store(std.Io.Timestamp.now(io, .awake).toSeconds(), .monotonic);
     }
 
+    /// Record whether the Postgres replication connection is up (readiness input).
     pub fn markConnected(self: *Self, value: bool) void {
         self.connected.store(value, .monotonic);
     }
 
+    /// Mark that the replication stream has delivered at least one batch (readiness input).
     pub fn markStreaming(self: *Self) void {
         self.streaming.store(true, .monotonic);
     }

--- a/src/observability/observability.zig
+++ b/src/observability/observability.zig
@@ -35,7 +35,6 @@ pub const Observability = struct {
 
     // Instruments; null when disabled.
     events: ?*metrics.Counter(u64) = null,
-    decode_errors: ?*metrics.Counter(u64) = null,
     produce_errors: ?*metrics.Counter(u64) = null,
     lag: ?*metrics.Gauge(i64) = null,
 
@@ -88,10 +87,6 @@ pub const Observability = struct {
                 .name = "outboxx_events_processed_total",
                 .description = "WAL change events consumed from the replication stream",
             }),
-            .decode_errors = try meter.createCounter(u64, .{
-                .name = "outboxx_decode_errors_total",
-                .description = "pgoutput decode/convert failures",
-            }),
             .produce_errors = try meter.createCounter(u64, .{
                 .name = "outboxx_produce_errors_total",
                 .description = "Kafka produce failures",
@@ -119,12 +114,6 @@ pub const Observability = struct {
     pub fn addEvents(self: *Self, n: usize) void {
         const c = self.events orelse return;
         c.add(@intCast(n), .{}) catch {};
-    }
-
-    /// Count one pgoutput decode/convert failure.
-    pub fn recordDecodeError(self: *Self) void {
-        const c = self.decode_errors orelse return;
-        c.add(1, .{}) catch {};
     }
 
     /// Count one Kafka produce failure.

--- a/src/observability/observability.zig
+++ b/src/observability/observability.zig
@@ -6,8 +6,10 @@ const metrics = otel.metrics;
 
 pub const serve = @import("http.zig").serve;
 
-// Last rendered value of a single metric series, kept between scrapes.
-const Sample = struct { prom_type: []const u8, value: i64 };
+// Last rendered value of one metric series, kept between scrapes. The snapshot
+// keys on the full Prometheus series (name plus any labels); `name` is retained
+// so the `# TYPE` line can be grouped per metric.
+const Sample = struct { name: []const u8, prom_type: []const u8, value: i64 };
 
 /// Metric instruments plus liveness/readiness state for the pipeline, sitting
 /// behind the OpenTelemetry SDK. Constructed either enabled (real OTel plumbing)
@@ -30,8 +32,14 @@ pub const Observability = struct {
 
     // collect() only emits instruments touched since the last call; this holds the
     // latest value of every series so each scrape renders them all. Keyed by the
-    // instrument name, which the SDK borrows for the instrument's lifetime.
+    // full series string (name plus labels), which we own because the SDK frees the
+    // measurements after each scrape.
     snapshot: std.StringHashMapUnmanaged(Sample) = .{},
+
+    // Owns label-value strings handed to the SDK. Instruments borrow attribute
+    // strings (they are not copied) and a series persists across scrapes, so a
+    // label must outlive the per-batch memory a table name comes from.
+    label_pool: std.StringHashMapUnmanaged(void) = .{},
 
     // Instruments; null when disabled.
     events: ?*metrics.Counter(u64) = null,
@@ -104,16 +112,33 @@ pub const Observability = struct {
 
     pub fn deinit(self: *Self) void {
         if (!self.enabled) return;
+        var keys = self.snapshot.keyIterator();
+        while (keys.next()) |k| self.allocator.free(k.*);
         self.snapshot.deinit(self.allocator);
+        var labels = self.label_pool.keyIterator();
+        while (labels.next()) |k| self.allocator.free(k.*);
+        self.label_pool.deinit(self.allocator);
         if (self.reader) |r| r.shutdown();
         if (self.mp) |p| p.shutdown();
         if (self.in_memory) |m| m.deinit();
     }
 
-    /// Count WAL change events consumed in a batch (n = batch.changes.len).
-    pub fn addEvents(self: *Self, n: usize) void {
+    // Return a copy of `s` owned for the lifetime of this Observability, so the SDK's
+    // borrowed attribute pointer stays valid until the series is scraped. The set of
+    // distinct label values is small (configured tables), so this stays bounded.
+    fn intern(self: *Self, s: []const u8) ![]const u8 {
+        const gop = try self.label_pool.getOrPut(self.allocator, s);
+        if (!gop.found_existing) gop.key_ptr.* = try self.allocator.dupe(u8, s);
+        return gop.key_ptr.*;
+    }
+
+    /// Count change events routed by a stream, tagged by the config stream name and operation.
+    /// Callers aggregate per batch, so this runs once per distinct combo, not per change.
+    /// The stream name is interned; `operation` is a static tag name and needs no copy.
+    pub fn addEvents(self: *Self, n: u64, stream: []const u8, operation: []const u8) void {
         const c = self.events orelse return;
-        c.add(@intCast(n), .{}) catch {};
+        const stream_owned = self.intern(stream) catch return;
+        c.add(n, .{ "stream", stream_owned, "operation", operation }) catch {};
     }
 
     /// Count one Kafka produce failure.
@@ -155,10 +180,11 @@ pub const Observability = struct {
         return self.connected.load(.monotonic) and self.streaming.load(.monotonic) and self.liveness(io);
     }
 
-    /// Collect the current metric snapshot and render it as Prometheus text.
-    /// On-scrape: `collect()` drives the aggregator, `fetch()` drains it, and we
-    /// format the scalar (attribute-less) instruments ourselves — the SDK's
-    /// PrometheusFormatter is not part of its public surface.
+    /// Collect the current metrics and render them as Prometheus text. On scrape,
+    /// `collect()` drives the aggregator and `fetch()` drains it; we render the text
+    /// ourselves (the SDK's PrometheusFormatter is not public). Each (name, label set)
+    /// is one series, kept in the snapshot so a series that did not change this cycle
+    /// is still present on every scrape.
     pub fn writeMetrics(self: *Self, writer: *std.Io.Writer) !void {
         const reader = self.reader orelse return;
         const in_memory = self.in_memory orelse return;
@@ -170,28 +196,113 @@ pub const Observability = struct {
             self.allocator.free(measurements);
         }
 
-        // Merge this collection into the persistent snapshot (scalar, unlabeled series only).
         for (measurements) |m| {
             const prom_type: []const u8 = switch (m.instrumentKind) {
                 .Counter, .ObservableCounter => "counter",
                 else => "gauge",
             };
-            switch (m.data) {
-                .int => |points| {
-                    if (points.len == 0) continue;
-                    try self.snapshot.put(self.allocator, m.instrumentOptions.name, .{
-                        .prom_type = prom_type,
-                        .value = points[points.len - 1].value,
-                    });
-                },
-                else => {},
+            const points = switch (m.data) {
+                .int => |p| p,
+                else => continue,
+            };
+            for (points) |point| {
+                try self.upsertSeries(m.instrumentOptions.name, prom_type, point);
             }
         }
 
+        try self.renderSnapshot(writer);
+    }
+
+    // Merge one data point into the snapshot under its full series key (name plus
+    // rendered labels). A new series dupes its key into snapshot-owned memory, since
+    // the SDK frees the measurements after the scrape; a known series updates value.
+    fn upsertSeries(self: *Self, name: []const u8, prom_type: []const u8, point: anytype) !void {
+        var series = std.ArrayList(u8).empty;
+        errdefer series.deinit(self.allocator);
+        try series.appendSlice(self.allocator, name);
+        try appendLabels(self.allocator, &series, point.attributes);
+
+        const gop = try self.snapshot.getOrPut(self.allocator, series.items);
+        if (gop.found_existing) {
+            series.deinit(self.allocator);
+        } else {
+            gop.key_ptr.* = try series.toOwnedSlice(self.allocator);
+            gop.value_ptr.name = name;
+            gop.value_ptr.prom_type = prom_type;
+        }
+        gop.value_ptr.value = point.value;
+    }
+
+    // Render the snapshot, grouped by metric name so each `# TYPE` line precedes its
+    // series exactly once (Prometheus rejects a family split across the exposition).
+    fn renderSnapshot(self: *Self, writer: *std.Io.Writer) !void {
+        const Entry = struct { series: []const u8, name: []const u8, prom_type: []const u8, value: i64 };
+
+        var entries = std.ArrayList(Entry).empty;
+        defer entries.deinit(self.allocator);
         var it = self.snapshot.iterator();
-        while (it.next()) |entry| {
-            const name = entry.key_ptr.*;
-            try writer.print("# TYPE {s} {s}\n{s} {d}\n", .{ name, entry.value_ptr.prom_type, name, entry.value_ptr.value });
+        while (it.next()) |e| {
+            try entries.append(self.allocator, .{
+                .series = e.key_ptr.*,
+                .name = e.value_ptr.name,
+                .prom_type = e.value_ptr.prom_type,
+                .value = e.value_ptr.value,
+            });
+        }
+
+        std.mem.sort(Entry, entries.items, {}, struct {
+            fn lessThan(_: void, a: Entry, b: Entry) bool {
+                if (!std.mem.eql(u8, a.name, b.name)) return std.mem.lessThan(u8, a.name, b.name);
+                return std.mem.lessThan(u8, a.series, b.series);
+            }
+        }.lessThan);
+
+        var current_name: []const u8 = "";
+        for (entries.items) |e| {
+            if (!std.mem.eql(u8, e.name, current_name)) {
+                try writer.print("# TYPE {s} {s}\n", .{ e.name, e.prom_type });
+                current_name = e.name;
+            }
+            try writer.print("{s} {d}\n", .{ e.series, e.value });
         }
     }
 };
+
+// Append `{k="v",...}` for a data point's attributes, or nothing when it has none.
+// Attribute order matches the add() call site, so a series renders identically each scrape.
+fn appendLabels(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), attributes: anytype) !void {
+    const attrs = attributes orelse return;
+    if (attrs.len == 0) return;
+    try buf.append(allocator, '{');
+    for (attrs, 0..) |attr, i| {
+        if (i > 0) try buf.append(allocator, ',');
+        try buf.appendSlice(allocator, attr.key);
+        try buf.appendSlice(allocator, "=\"");
+        try appendLabelValue(allocator, buf, attr.value);
+        try buf.append(allocator, '"');
+    }
+    try buf.append(allocator, '}');
+}
+
+// Render one attribute value into a label value, escaping the three characters the
+// Prometheus exposition format requires inside a quoted string.
+fn appendLabelValue(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), value: anytype) !void {
+    switch (value) {
+        .string => |s| for (s) |ch| switch (ch) {
+            '"' => try buf.appendSlice(allocator, "\\\""),
+            '\\' => try buf.appendSlice(allocator, "\\\\"),
+            '\n' => try buf.appendSlice(allocator, "\\n"),
+            else => try buf.append(allocator, ch),
+        },
+        .bool => |b| try buf.appendSlice(allocator, if (b) "true" else "false"),
+        .int => |n| {
+            var tmp: [32]u8 = undefined;
+            try buf.appendSlice(allocator, std.fmt.bufPrint(&tmp, "{d}", .{n}) catch return);
+        },
+        .double => |d| {
+            var tmp: [64]u8 = undefined;
+            try buf.appendSlice(allocator, std.fmt.bufPrint(&tmp, "{d}", .{d}) catch return);
+        },
+        else => {},
+    }
+}

--- a/src/observability/observability.zig
+++ b/src/observability/observability.zig
@@ -89,8 +89,8 @@ pub const Observability = struct {
                 .description = "Kafka produce failures",
             }),
             .lag = try meter.createGauge(i64, .{
-                .name = "outboxx_replication_lag_bytes",
-                .description = "WAL bytes the server head is ahead of the last processed change",
+                .name = "outboxx_replication_lag_seconds",
+                .description = "Seconds the last processed transaction's commit is behind now (0 when caught up)",
             }),
             // Seed the heartbeat so liveness holds through a slow startup/connect.
             .last_progress_sec = std.atomic.Value(i64).init(std.Io.Timestamp.now(io, .awake).toSeconds()),
@@ -123,11 +123,11 @@ pub const Observability = struct {
         c.add(1, .{}) catch {};
     }
 
-    /// Set the replication lag gauge to WAL bytes the server head is ahead of the
-    /// last change we processed (0 when caught up). The source computes it per batch.
-    pub fn setLag(self: *Self, lag_bytes: u64) void {
+    /// Set the replication lag gauge to seconds behind source: wall clock minus the
+    /// last processed transaction's commit time (0 when caught up). Source computes it.
+    pub fn setLag(self: *Self, lag_seconds: i64) void {
         const g = self.lag orelse return;
-        g.record(@intCast(lag_bytes), .{}) catch {};
+        g.record(lag_seconds, .{}) catch {};
     }
 
     /// Mark the receive loop as alive; call once per batch iteration.

--- a/src/observability/observability.zig
+++ b/src/observability/observability.zig
@@ -90,7 +90,7 @@ pub const Observability = struct {
             }),
             .lag = try meter.createGauge(i64, .{
                 .name = "outboxx_replication_lag_bytes",
-                .description = "Server WAL position minus the last confirmed LSN, in bytes",
+                .description = "WAL bytes the server head is ahead of the last processed change",
             }),
             // Seed the heartbeat so liveness holds through a slow startup/connect.
             .last_progress_sec = std.atomic.Value(i64).init(std.Io.Timestamp.now(io, .awake).toSeconds()),
@@ -123,14 +123,11 @@ pub const Observability = struct {
         c.add(1, .{}) catch {};
     }
 
-    /// Replication lag = server WAL head minus the last confirmed LSN (saturating).
-    /// Skipped until the first feedback establishes a baseline; otherwise a zero
-    /// confirmed LSN would report the absolute server position as "lag".
-    pub fn setLag(self: *Self, server_lsn: u64, confirmed_lsn: u64) void {
+    /// Set the replication lag gauge to WAL bytes the server head is ahead of the
+    /// last change we processed (0 when caught up). The source computes it per batch.
+    pub fn setLag(self: *Self, lag_bytes: u64) void {
         const g = self.lag orelse return;
-        if (confirmed_lsn == 0) return;
-        const delta = if (server_lsn > confirmed_lsn) server_lsn - confirmed_lsn else 0;
-        g.record(@intCast(delta), .{}) catch {};
+        g.record(@intCast(lag_bytes), .{}) catch {};
     }
 
     /// Mark the receive loop as alive; call once per batch iteration.

--- a/src/observability/observability_test.zig
+++ b/src/observability/observability_test.zig
@@ -55,6 +55,38 @@ test "counters persist across scrapes without new activity" {
     }
 }
 
+fn scrapeLag(obs: *Observability, allocator: std.mem.Allocator) ![]u8 {
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    try obs.writeMetrics(&aw.writer);
+    return aw.toOwnedSlice();
+}
+
+// Reproduces the idle path: after a real batch reports lag 19, the caught-up
+// branch keeps calling setLag(0). The rendered gauge must follow to 0, not
+// freeze at 19 (the load-stand symptom).
+test "lag gauge follows a later setLag(0) down to zero" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var obs = try Observability.init(allocator, io);
+    defer obs.deinit();
+
+    obs.setLag(19);
+    {
+        const out = try scrapeLag(&obs, allocator);
+        defer allocator.free(out);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_replication_lag_seconds 19") != null);
+    }
+
+    obs.setLag(0);
+    {
+        const out = try scrapeLag(&obs, allocator);
+        defer allocator.free(out);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_replication_lag_seconds 0") != null);
+    }
+}
+
 test "disabled observability records nothing but keeps health state" {
     const io = std.testing.io;
 

--- a/src/observability/observability_test.zig
+++ b/src/observability/observability_test.zig
@@ -62,28 +62,31 @@ fn scrapeLag(obs: *Observability, allocator: std.mem.Allocator) ![]u8 {
     return aw.toOwnedSlice();
 }
 
-// Reproduces the idle path: after a real batch reports lag 19, the caught-up
-// branch keeps calling setLag(0). The rendered gauge must follow to 0, not
-// freeze at 19 (the load-stand symptom).
-test "lag gauge follows a later setLag(0) down to zero" {
+// The gauge must render the value from the most recent setLag, overwriting the
+// previous one — never summing successive records (the cumulative-temporality
+// bug: 19 then 600 would render 619). Walk a sequence that goes up, down to 0
+// (the caught-up idle path, the load-stand symptom), and back up, asserting each
+// scrape renders exactly the last value. Lines carry the trailing newline so a
+// value can't match as a prefix of a longer number.
+test "lag gauge renders the latest value on each scrape and never accumulates" {
     const allocator = std.testing.allocator;
     const io = std.testing.io;
 
     var obs = try Observability.init(allocator, io);
     defer obs.deinit();
 
-    obs.setLag(19);
-    {
-        const out = try scrapeLag(&obs, allocator);
-        defer allocator.free(out);
-        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_replication_lag_seconds 19") != null);
-    }
+    const steps = [_]struct { set: i64, want: []const u8 }{
+        .{ .set = 19, .want = "outboxx_replication_lag_seconds 19\n" },
+        .{ .set = 600, .want = "outboxx_replication_lag_seconds 600\n" }, // not 619
+        .{ .set = 0, .want = "outboxx_replication_lag_seconds 0\n" },
+        .{ .set = 5, .want = "outboxx_replication_lag_seconds 5\n" },
+    };
 
-    obs.setLag(0);
-    {
+    for (steps) |step| {
+        obs.setLag(step.set);
         const out = try scrapeLag(&obs, allocator);
         defer allocator.free(out);
-        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_replication_lag_seconds 0") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, step.want) != null);
     }
 }
 

--- a/src/observability/observability_test.zig
+++ b/src/observability/observability_test.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const Observability = @import("observability.zig").Observability;
+
+test "writeMetrics renders counters and the lag gauge in Prometheus text" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var obs = try Observability.init(allocator, io);
+    defer obs.deinit();
+
+    obs.addEvents(3);
+    obs.addEvents(2);
+    obs.recordDecodeError();
+    obs.setLag(1000, 400);
+
+    var aw = std.Io.Writer.Allocating.init(allocator);
+    defer aw.deinit();
+    try obs.writeMetrics(&aw.writer);
+    const out = try aw.toOwnedSlice();
+    defer allocator.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total 5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_decode_errors_total 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_replication_lag_bytes 600") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "# TYPE outboxx_events_processed_total counter") != null);
+}
+
+test "counters persist across scrapes without new activity" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var obs = try Observability.init(allocator, io);
+    defer obs.deinit();
+
+    obs.addEvents(7);
+
+    // First scrape emits the counter.
+    {
+        var aw = std.Io.Writer.Allocating.init(allocator);
+        defer aw.deinit();
+        try obs.writeMetrics(&aw.writer);
+        const out = try aw.toOwnedSlice();
+        defer allocator.free(out);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total 7") != null);
+    }
+
+    // Second scrape with no new events: the counter must still be present.
+    {
+        var aw = std.Io.Writer.Allocating.init(allocator);
+        defer aw.deinit();
+        try obs.writeMetrics(&aw.writer);
+        const out = try aw.toOwnedSlice();
+        defer allocator.free(out);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total 7") != null);
+    }
+}
+
+test "disabled observability records nothing but keeps health state" {
+    const io = std.testing.io;
+
+    var obs = Observability.initDisabled();
+    // No-ops: must not touch the null OTel plumbing.
+    obs.addEvents(10);
+    obs.recordProduceError();
+    obs.setLag(1, 0);
+
+    // Health atomics are valid even when disabled.
+    try std.testing.expect(!obs.liveness(io)); // heartbeat never fired
+    obs.heartbeat(io);
+    try std.testing.expect(obs.liveness(io));
+
+    try std.testing.expect(!obs.readiness(io)); // not connected/streaming yet
+    obs.markConnected(true);
+    obs.markStreaming();
+    try std.testing.expect(obs.readiness(io));
+
+    obs.markConnected(false);
+    try std.testing.expect(!obs.readiness(io));
+}

--- a/src/observability/observability_test.zig
+++ b/src/observability/observability_test.zig
@@ -93,7 +93,7 @@ test "lag gauge renders the latest value on each scrape and never accumulates" {
 test "disabled observability records nothing but keeps health state" {
     const io = std.testing.io;
 
-    var obs = Observability.initDisabled();
+    var obs = Observability.noop();
     // No-ops: must not touch the null OTel plumbing.
     obs.addEvents(10);
     obs.recordProduceError();

--- a/src/observability/observability_test.zig
+++ b/src/observability/observability_test.zig
@@ -11,7 +11,7 @@ test "writeMetrics renders counters and the lag gauge in Prometheus text" {
     obs.addEvents(3);
     obs.addEvents(2);
     obs.recordDecodeError();
-    obs.setLag(1000, 400);
+    obs.setLag(600);
 
     var aw = std.Io.Writer.Allocating.init(allocator);
     defer aw.deinit();
@@ -62,7 +62,7 @@ test "disabled observability records nothing but keeps health state" {
     // No-ops: must not touch the null OTel plumbing.
     obs.addEvents(10);
     obs.recordProduceError();
-    obs.setLag(1, 0);
+    obs.setLag(1);
 
     // Health atomics are valid even when disabled.
     try std.testing.expect(!obs.liveness(io)); // heartbeat never fired

--- a/src/observability/observability_test.zig
+++ b/src/observability/observability_test.zig
@@ -8,8 +8,8 @@ test "writeMetrics renders counters and the lag gauge in Prometheus text" {
     var obs = try Observability.init(allocator, io);
     defer obs.deinit();
 
-    obs.addEvents(3);
-    obs.addEvents(2);
+    obs.addEvents(3, "users", "INSERT");
+    obs.addEvents(2, "users", "INSERT");
     obs.setLag(600);
 
     var aw = std.Io.Writer.Allocating.init(allocator);
@@ -18,7 +18,7 @@ test "writeMetrics renders counters and the lag gauge in Prometheus text" {
     const out = try aw.toOwnedSlice();
     defer allocator.free(out);
 
-    try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total 5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total{stream=\"users\",operation=\"INSERT\"} 5") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_replication_lag_seconds 600") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "# TYPE outboxx_events_processed_total counter") != null);
 }
@@ -30,7 +30,7 @@ test "counters persist across scrapes without new activity" {
     var obs = try Observability.init(allocator, io);
     defer obs.deinit();
 
-    obs.addEvents(7);
+    obs.addEvents(7, "users", "INSERT");
 
     // First scrape emits the counter.
     {
@@ -39,7 +39,7 @@ test "counters persist across scrapes without new activity" {
         try obs.writeMetrics(&aw.writer);
         const out = try aw.toOwnedSlice();
         defer allocator.free(out);
-        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total 7") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total{stream=\"users\",operation=\"INSERT\"} 7") != null);
     }
 
     // Second scrape with no new events: the counter must still be present.
@@ -49,7 +49,7 @@ test "counters persist across scrapes without new activity" {
         try obs.writeMetrics(&aw.writer);
         const out = try aw.toOwnedSlice();
         defer allocator.free(out);
-        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total 7") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total{stream=\"users\",operation=\"INSERT\"} 7") != null);
     }
 }
 
@@ -88,12 +88,61 @@ test "lag gauge renders the latest value on each scrape and never accumulates" {
     }
 }
 
+test "events counter keeps an independent series per stream and operation" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var obs = try Observability.init(allocator, io);
+    defer obs.deinit();
+
+    obs.addEvents(3, "users", "INSERT");
+    obs.addEvents(1, "users", "UPDATE");
+    obs.addEvents(4, "orders", "INSERT");
+    {
+        const out = try scrapeLag(&obs, allocator);
+        defer allocator.free(out);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total{stream=\"users\",operation=\"INSERT\"} 3") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total{stream=\"users\",operation=\"UPDATE\"} 1") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total{stream=\"orders\",operation=\"INSERT\"} 4") != null);
+    }
+
+    // Each series accumulates on its own; adding to one must not move the others.
+    obs.addEvents(2, "users", "INSERT");
+    {
+        const out = try scrapeLag(&obs, allocator);
+        defer allocator.free(out);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total{stream=\"users\",operation=\"INSERT\"} 5") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total{stream=\"users\",operation=\"UPDATE\"} 1") != null);
+        try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total{stream=\"orders\",operation=\"INSERT\"} 4") != null);
+    }
+}
+
+test "event label survives the caller's buffer being reused" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+
+    var obs = try Observability.init(allocator, io);
+    defer obs.deinit();
+
+    // The SDK borrows attribute strings rather than copying them, so a label passed
+    // from a caller's buffer must be interned. Mimic a reused buffer, then clobber it.
+    const name = "users";
+    var buf: [16]u8 = undefined;
+    @memcpy(buf[0..name.len], name);
+    obs.addEvents(4, buf[0..name.len], "INSERT");
+    @memset(&buf, 'Z');
+
+    const out = try scrapeLag(&obs, allocator);
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total{stream=\"users\",operation=\"INSERT\"} 4") != null);
+}
+
 test "disabled observability records nothing but keeps health state" {
     const io = std.testing.io;
 
     var obs = Observability.noop();
     // No-ops: must not touch the null OTel plumbing.
-    obs.addEvents(10);
+    obs.addEvents(10, "users", "INSERT");
     obs.recordProduceError();
     obs.setLag(1);
 

--- a/src/observability/observability_test.zig
+++ b/src/observability/observability_test.zig
@@ -21,7 +21,7 @@ test "writeMetrics renders counters and the lag gauge in Prometheus text" {
 
     try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total 5") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_decode_errors_total 1") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_replication_lag_bytes 600") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_replication_lag_seconds 600") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "# TYPE outboxx_events_processed_total counter") != null);
 }
 

--- a/src/observability/observability_test.zig
+++ b/src/observability/observability_test.zig
@@ -10,7 +10,6 @@ test "writeMetrics renders counters and the lag gauge in Prometheus text" {
 
     obs.addEvents(3);
     obs.addEvents(2);
-    obs.recordDecodeError();
     obs.setLag(600);
 
     var aw = std.Io.Writer.Allocating.init(allocator);
@@ -20,7 +19,6 @@ test "writeMetrics renders counters and the lag gauge in Prometheus text" {
     defer allocator.free(out);
 
     try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_events_processed_total 5") != null);
-    try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_decode_errors_total 1") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "outboxx_replication_lag_seconds 600") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "# TYPE outboxx_events_processed_total counter") != null);
 }

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -38,7 +38,6 @@ fn flushCommitWorker(
     producer: *KafkaProducer,
     source: *PostgresSource,
     pending_lsn: *std.atomic.Value(u64),
-    confirmed_lsn: *std.atomic.Value(u64),
 ) void {
     var iterations: u32 = 0;
     const flush_interval_iterations: u32 = @intCast(constants.CDC.KAFKA_FLUSH_INTERVAL_SEC);
@@ -69,8 +68,6 @@ fn flushCommitWorker(
             std.log.err("Background LSN commit failed: {}", .{err});
             continue;
         };
-        // Latest LSN acknowledged to Postgres; the replication-lag gauge reads it.
-        confirmed_lsn.store(lsn, .release);
     }
 
     producer.flush(constants.CDC.KAFKA_FLUSH_TIMEOUT_MS) catch |err| {
@@ -82,7 +79,6 @@ fn flushCommitWorker(
         source.sendFeedback(io, lsn) catch |err| {
             std.log.warn("Final background LSN commit failed: {}", .{err});
         };
-        confirmed_lsn.store(lsn, .release);
     }
 
     std.log.debug("Flush/commit worker stopped", .{});
@@ -99,8 +95,6 @@ pub const Processor = struct {
 
     events_processed: usize,
     pending_lsn: std.atomic.Value(u64),
-    // LSN last confirmed to Postgres by the flush worker; drives the lag gauge.
-    confirmed_lsn: std.atomic.Value(u64),
 
     const Self = @This();
 
@@ -114,7 +108,6 @@ pub const Processor = struct {
             .obs = obs,
             .events_processed = 0,
             .pending_lsn = std.atomic.Value(u64).init(0),
-            .confirmed_lsn = std.atomic.Value(u64).init(0),
         };
     }
 
@@ -142,7 +135,7 @@ pub const Processor = struct {
 
         if (batch.changes.len == 0) {
             self.pending_lsn.store(batch.last_lsn, .release);
-            self.obs.setLag(batch.last_lsn, self.confirmed_lsn.load(.acquire));
+            self.obs.setLag(0); // drained everything available -> caught up
             return;
         }
 
@@ -150,7 +143,7 @@ pub const Processor = struct {
 
         // Count consumed WAL changes and refresh the lag gauge once per batch.
         self.obs.addEvents(batch.changes.len);
-        self.obs.setLag(batch.last_lsn, self.confirmed_lsn.load(.acquire));
+        self.obs.setLag(batch.replication_lag_bytes);
 
         for (batch.changes) |change_event| {
             var matched = try matchStreams(batch_allocator, self.streams, change_event.meta.resource, change_event.op);
@@ -226,7 +219,6 @@ pub const Processor = struct {
             producer,
             &self.source,
             &self.pending_lsn,
-            &self.confirmed_lsn,
         });
         // On a receive error, still stop the worker (wakes its sleep for the
         // final flush, and awaits) before the error propagates.

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -11,6 +11,7 @@ const ChangeEvent = domain.ChangeEvent;
 const json_serializer = @import("json_serialization");
 const JsonSerializer = json_serializer.JsonSerializer;
 const constants = @import("constants");
+pub const Observability = @import("observability").Observability;
 
 /// Return the streams whose resource and operations match a given table change; caller owns the list.
 pub fn matchStreams(allocator: std.mem.Allocator, streams: []const Stream, table_name: []const u8, operation: []const u8) !std.ArrayList(Stream) {
@@ -37,6 +38,7 @@ fn flushCommitWorker(
     producer: *KafkaProducer,
     source: *PostgresSource,
     pending_lsn: *std.atomic.Value(u64),
+    confirmed_lsn: *std.atomic.Value(u64),
 ) void {
     var iterations: u32 = 0;
     const flush_interval_iterations: u32 = @intCast(constants.CDC.KAFKA_FLUSH_INTERVAL_SEC);
@@ -67,6 +69,8 @@ fn flushCommitWorker(
             std.log.err("Background LSN commit failed: {}", .{err});
             continue;
         };
+        // Latest LSN acknowledged to Postgres; the replication-lag gauge reads it.
+        confirmed_lsn.store(lsn, .release);
     }
 
     producer.flush(constants.CDC.KAFKA_FLUSH_TIMEOUT_MS) catch |err| {
@@ -78,6 +82,7 @@ fn flushCommitWorker(
         source.sendFeedback(io, lsn) catch |err| {
             std.log.warn("Final background LSN commit failed: {}", .{err});
         };
+        confirmed_lsn.store(lsn, .release);
     }
 
     std.log.debug("Flush/commit worker stopped", .{});
@@ -90,21 +95,26 @@ pub const Processor = struct {
     producer: KafkaProducer,
     streams: []const Stream,
     serializer: JsonSerializer,
+    obs: *Observability,
 
     events_processed: usize,
     pending_lsn: std.atomic.Value(u64),
+    // LSN last confirmed to Postgres by the flush worker; drives the lag gauge.
+    confirmed_lsn: std.atomic.Value(u64),
 
     const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator, source: PostgresSource, producer: KafkaProducer, streams: []const Stream) Self {
+    pub fn init(allocator: std.mem.Allocator, source: PostgresSource, producer: KafkaProducer, streams: []const Stream, obs: *Observability) Self {
         return Self{
             .allocator = allocator,
             .source = source,
             .producer = producer,
             .streams = streams,
             .serializer = JsonSerializer.init(),
+            .obs = obs,
             .events_processed = 0,
             .pending_lsn = std.atomic.Value(u64).init(0),
+            .confirmed_lsn = std.atomic.Value(u64).init(0),
         };
     }
 
@@ -115,17 +125,32 @@ pub const Processor = struct {
 
     /// Receive one batch, route each change to its streams, and stage the batch LSN for commit.
     pub fn processChangesToKafka(self: *Self, io: std.Io, batch_allocator: std.mem.Allocator, limit: u32) !void {
-        var batch = try self.source.receiveBatch(io, batch_allocator, limit);
+        var batch = self.source.receiveBatch(io, batch_allocator, limit) catch |err| {
+            switch (err) {
+                error.DecodeFailed, error.ConversionFailed => self.obs.recordDecodeError(),
+                else => {},
+            }
+            return err;
+        };
         defer batch.deinit();
+
+        // A successful receive (even an empty batch) means we are connected and
+        // reading the replication stream — the signal readiness cares about.
+        self.obs.markStreaming();
 
         const producer = &self.producer;
 
         if (batch.changes.len == 0) {
             self.pending_lsn.store(batch.last_lsn, .release);
+            self.obs.setLag(batch.last_lsn, self.confirmed_lsn.load(.acquire));
             return;
         }
 
         std.log.debug("Processing {} changes from batch (LSN: {})", .{ batch.changes.len, batch.last_lsn });
+
+        // Count consumed WAL changes and refresh the lag gauge once per batch.
+        self.obs.addEvents(batch.changes.len);
+        self.obs.setLag(batch.last_lsn, self.confirmed_lsn.load(.acquire));
 
         for (batch.changes) |change_event| {
             var matched = try matchStreams(batch_allocator, self.streams, change_event.meta.resource, change_event.op);
@@ -146,7 +171,10 @@ pub const Processor = struct {
                 const topic_name = stream.sink.destination;
                 const partition_key = try self.getPartitionKey(batch_allocator, change_event, stream);
 
-                try producer.sendMessage(topic_name, partition_key, json_bytes);
+                producer.sendMessage(topic_name, partition_key, json_bytes) catch |err| {
+                    self.obs.recordProduceError();
+                    return err;
+                };
 
                 self.events_processed += 1;
                 if (self.events_processed % 10000 == 0) {
@@ -198,12 +226,15 @@ pub const Processor = struct {
             producer,
             &self.source,
             &self.pending_lsn,
+            &self.confirmed_lsn,
         });
         // On a receive error, still stop the worker (wakes its sleep for the
         // final flush, and awaits) before the error propagates.
         errdefer flush_future.cancel(io);
 
         while (!stop_signal.load(.monotonic)) {
+            self.obs.heartbeat(io);
+
             var batch_arena = std.heap.ArenaAllocator.init(self.allocator);
             defer batch_arena.deinit();
 

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -118,13 +118,7 @@ pub const Processor = struct {
 
     /// Receive one batch, route each change to its streams, and stage the batch LSN for commit.
     pub fn processChangesToKafka(self: *Self, io: std.Io, batch_allocator: std.mem.Allocator, limit: u32) !void {
-        var batch = self.source.receiveBatch(io, batch_allocator, limit) catch |err| {
-            switch (err) {
-                error.DecodeFailed, error.ConversionFailed => self.obs.recordDecodeError(),
-                else => {},
-            }
-            return err;
-        };
+        var batch = try self.source.receiveBatch(io, batch_allocator, limit);
         defer batch.deinit();
 
         // A successful receive (even an empty batch) means we are connected and
@@ -210,6 +204,10 @@ pub const Processor = struct {
 
     /// Run the batch loop until stop_signal is set, with a background flush/commit worker.
     pub fn startStreaming(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
+        // The source is connected and validated before we get here, so readiness's
+        // connection signal goes up now; markStreaming follows on the first batch.
+        self.obs.markConnected(true);
+
         const producer = &self.producer;
 
         // Background flush/commit loop. `concurrent` not `async`: it must run

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -143,7 +143,7 @@ pub const Processor = struct {
 
         // Count consumed WAL changes and refresh the lag gauge once per batch.
         self.obs.addEvents(batch.changes.len);
-        self.obs.setLag(batch.replication_lag_bytes);
+        self.obs.setLag(batch.replication_lag_seconds);
 
         for (batch.changes) |change_event| {
             var matched = try matchStreams(batch_allocator, self.streams, change_event.meta.resource, change_event.op);

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -13,6 +13,20 @@ const JsonSerializer = json_serializer.JsonSerializer;
 const constants = @import("constants");
 pub const Observability = @import("observability").Observability;
 
+// Per-batch tally of routed change events by stream and operation, so the events
+// counter is updated once per distinct combo instead of once per routed change.
+const EventCount = struct { stream: []const u8, operation: []const u8, count: u64 };
+
+fn tallyEvent(list: *std.ArrayList(EventCount), allocator: std.mem.Allocator, stream: []const u8, operation: []const u8) !void {
+    for (list.items) |*e| {
+        if (std.mem.eql(u8, e.stream, stream) and std.mem.eql(u8, e.operation, operation)) {
+            e.count += 1;
+            return;
+        }
+    }
+    try list.append(allocator, .{ .stream = stream, .operation = operation, .count = 1 });
+}
+
 /// Return the streams whose resource and operations match a given table change; caller owns the list.
 pub fn matchStreams(allocator: std.mem.Allocator, streams: []const Stream, table_name: []const u8, operation: []const u8) !std.ArrayList(Stream) {
     var matched = std.ArrayList(Stream).empty;
@@ -135,9 +149,12 @@ pub const Processor = struct {
 
         std.log.debug("Processing {} changes from batch (LSN: {})", .{ batch.changes.len, batch.last_lsn });
 
-        // Count consumed WAL changes and refresh the lag gauge once per batch.
-        self.obs.addEvents(batch.changes.len);
+        // Refresh lag once per batch; event counts are tallied per (stream, operation)
+        // in the loop and emitted after it, so the counter costs one add() per distinct
+        // combo per batch instead of one per routed change.
         self.obs.setLag(batch.replication_lag_seconds);
+        var event_counts = std.ArrayList(EventCount).empty;
+        defer event_counts.deinit(batch_allocator);
 
         for (batch.changes) |change_event| {
             var matched = try matchStreams(batch_allocator, self.streams, change_event.meta.resource, change_event.op);
@@ -163,6 +180,8 @@ pub const Processor = struct {
                     return err;
                 };
 
+                try tallyEvent(&event_counts, batch_allocator, stream.name, change_event.op);
+
                 self.events_processed += 1;
                 if (self.events_processed % 10000 == 0) {
                     std.log.info("Processed {} CDC events", .{self.events_processed});
@@ -177,6 +196,8 @@ pub const Processor = struct {
                 });
             }
         }
+
+        for (event_counts.items) |e| self.obs.addEvents(e.count, e.stream, e.operation);
 
         producer.poll();
 

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -28,6 +28,9 @@ pub const RelationMessage = pg_output_decoder.RelationMessage;
 pub const RelationMessageColumn = pg_output_decoder.RelationMessageColumn;
 pub const RelationRegistry = relation_registry.RelationRegistry;
 
+// Unix time of the Postgres epoch (2000-01-01 UTC), to convert commit timestamps.
+const POSTGRES_EPOCH_UNIX_SECONDS: i64 = 946684800;
+
 /// Batch of changes from PostgreSQL (streaming source)
 pub const Batch = struct {
     /// Change events (flat list)
@@ -36,10 +39,9 @@ pub const Batch = struct {
     /// LSN for feedback (last change in batch)
     last_lsn: u64,
 
-    /// Replication lag in bytes for the last data message: server WAL head minus
-    /// the change's own LSN (server_wal_end - wal_start). 0 when the batch carried
-    /// no data message, which means we drained everything available (caught up).
-    replication_lag_bytes: u64,
+    /// Seconds the last transaction in this batch is behind now (wall clock minus
+    /// the transaction's commit time). 0 when the batch carried no data (caught up).
+    replication_lag_seconds: i64,
 
     allocator: std.mem.Allocator,
 
@@ -72,6 +74,10 @@ pub const PostgresSource = struct {
     decoder: PgOutputDecoder,
     converter: Converter,
     last_lsn: u64, // Last confirmed LSN (starting point for next batch)
+    // Commit timestamp (us since the Postgres epoch) of the last transaction seen.
+    // The stream does not expose the server WAL head during a backlog, so lag is
+    // measured as wall-clock time behind this commit, like Debezium.
+    last_commit_time: i64,
 
     const Self = @This();
 
@@ -87,6 +93,7 @@ pub const PostgresSource = struct {
             .decoder = PgOutputDecoder.init(allocator),
             .converter = Converter.init(allocator),
             .last_lsn = 0,
+            .last_commit_time = 0,
         };
     }
 
@@ -141,9 +148,6 @@ pub const PostgresSource = struct {
         }
 
         var last_confirmed_lsn: u64 = self.last_lsn; // Track LSN locally
-        // Backlog of the last data message: how far the server WAL head is ahead of
-        // the change we just read. Stays 0 if only keepalives arrive (caught up).
-        var last_lag: u64 = 0;
 
         // Monotonic deadline (`.awake`), so a wall-clock jump can't skew the wait.
         const deadline = std.Io.Timestamp.now(io, .awake).addDuration(.fromMilliseconds(wait_time_ms));
@@ -170,10 +174,6 @@ pub const PostgresSource = struct {
             // Extract change from the first message
             var msg = repl_msg.?;
             defer msg.deinit(self.allocator);
-            switch (msg) {
-                .xlog_data => |x| last_lag = x.server_wal_end -| x.wal_start,
-                else => {},
-            }
 
             const msg_lsn = try self.extractChangeFromMessage(io, batch_allocator, msg, &changes);
             last_confirmed_lsn = msg_lsn; // Update LSN (always > 0 on success)
@@ -185,10 +185,6 @@ pub const PostgresSource = struct {
 
                 var buffered_msg = next_msg.?;
                 defer buffered_msg.deinit(self.allocator);
-                switch (buffered_msg) {
-                    .xlog_data => |x| last_lag = x.server_wal_end -| x.wal_start,
-                    else => {},
-                }
 
                 const buffered_lsn = try self.extractChangeFromMessage(io, batch_allocator, buffered_msg, &changes);
                 last_confirmed_lsn = buffered_lsn; // Update LSN (always > 0 on success)
@@ -198,10 +194,19 @@ pub const PostgresSource = struct {
         // Update instance LSN for next batch
         self.last_lsn = last_confirmed_lsn;
 
+        // Time behind source: wall clock minus the last transaction's commit time.
+        // Postgres commit timestamps are microseconds since 2000-01-01, so shift to
+        // the Unix epoch before comparing. 0 until we have seen a commit.
+        const lag_seconds: i64 = if (self.last_commit_time == 0) 0 else blk: {
+            const commit_unix = @divFloor(self.last_commit_time, std.time.us_per_s) + POSTGRES_EPOCH_UNIX_SECONDS;
+            const now_unix = std.Io.Timestamp.now(io, .real).toSeconds();
+            break :blk @max(now_unix - commit_unix, 0);
+        };
+
         return .{
             .changes = try changes.toOwnedSlice(batch_allocator),
             .last_lsn = last_confirmed_lsn,
-            .replication_lag_bytes = last_lag,
+            .replication_lag_seconds = lag_seconds,
             .allocator = batch_allocator,
         };
     }
@@ -222,6 +227,13 @@ pub const PostgresSource = struct {
                     return PostgresSourceError.DecodeFailed; // Propagate error up
                 };
                 defer pg_msg.deinit(batch_allocator);
+
+                // BEGIN/COMMIT carry the transaction's commit timestamp, used for the lag metric.
+                switch (pg_msg) {
+                    .begin => |b| self.last_commit_time = b.commit_time,
+                    .commit => |c| self.last_commit_time = c.commit_time,
+                    else => {},
+                }
 
                 const change_opt = self.converter.convert(io, batch_allocator, pg_msg) catch |err| {
                     std.log.warn("Failed to convert message to ChangeEvent at LSN {}: {}", .{ xlog.server_wal_end, err });

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -36,6 +36,11 @@ pub const Batch = struct {
     /// LSN for feedback (last change in batch)
     last_lsn: u64,
 
+    /// Replication lag in bytes for the last data message: server WAL head minus
+    /// the change's own LSN (server_wal_end - wal_start). 0 when the batch carried
+    /// no data message, which means we drained everything available (caught up).
+    replication_lag_bytes: u64,
+
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *Batch) void {
@@ -136,6 +141,9 @@ pub const PostgresSource = struct {
         }
 
         var last_confirmed_lsn: u64 = self.last_lsn; // Track LSN locally
+        // Backlog of the last data message: how far the server WAL head is ahead of
+        // the change we just read. Stays 0 if only keepalives arrive (caught up).
+        var last_lag: u64 = 0;
 
         // Monotonic deadline (`.awake`), so a wall-clock jump can't skew the wait.
         const deadline = std.Io.Timestamp.now(io, .awake).addDuration(.fromMilliseconds(wait_time_ms));
@@ -162,6 +170,10 @@ pub const PostgresSource = struct {
             // Extract change from the first message
             var msg = repl_msg.?;
             defer msg.deinit(self.allocator);
+            switch (msg) {
+                .xlog_data => |x| last_lag = x.server_wal_end -| x.wal_start,
+                else => {},
+            }
 
             const msg_lsn = try self.extractChangeFromMessage(io, batch_allocator, msg, &changes);
             last_confirmed_lsn = msg_lsn; // Update LSN (always > 0 on success)
@@ -173,6 +185,10 @@ pub const PostgresSource = struct {
 
                 var buffered_msg = next_msg.?;
                 defer buffered_msg.deinit(self.allocator);
+                switch (buffered_msg) {
+                    .xlog_data => |x| last_lag = x.server_wal_end -| x.wal_start,
+                    else => {},
+                }
 
                 const buffered_lsn = try self.extractChangeFromMessage(io, batch_allocator, buffered_msg, &changes);
                 last_confirmed_lsn = buffered_lsn; // Update LSN (always > 0 on success)
@@ -185,6 +201,7 @@ pub const PostgresSource = struct {
         return .{
             .changes = try changes.toOwnedSlice(batch_allocator),
             .last_lsn = last_confirmed_lsn,
+            .replication_lag_bytes = last_lag,
             .allocator = batch_allocator,
         };
     }

--- a/src/source/postgres/source_test.zig
+++ b/src/source/postgres/source_test.zig
@@ -22,7 +22,7 @@ test "Batch: deinit with empty changes" {
     var batch = Batch{
         .changes = changes,
         .last_lsn = 12345,
-        .replication_lag_bytes = 0,
+        .replication_lag_seconds = 0,
         .allocator = allocator,
     };
     defer batch.deinit();

--- a/src/source/postgres/source_test.zig
+++ b/src/source/postgres/source_test.zig
@@ -22,6 +22,7 @@ test "Batch: deinit with empty changes" {
     var batch = Batch{
         .changes = changes,
         .last_lsn = 12345,
+        .replication_lag_bytes = 0,
         .allocator = allocator,
     };
     defer batch.deinit();

--- a/tests/e2e/cdc_test.zig
+++ b/tests/e2e/cdc_test.zig
@@ -85,7 +85,7 @@ test "E2E: INSERT operation - full pipeline verification" {
     var producer = try KafkaProducer.init(allocator, "localhost:9092", null);
     try producer.testConnection();
 
-    var obs = Observability.initDisabled();
+    var obs = Observability.noop();
     var processor = Processor.init(allocator, source, producer, streams, &obs);
     defer processor.deinit();
 
@@ -223,7 +223,7 @@ test "E2E: UPDATE operation - full pipeline verification" {
     var producer = try KafkaProducer.init(allocator, "localhost:9092", null);
     try producer.testConnection();
 
-    var obs = Observability.initDisabled();
+    var obs = Observability.noop();
     var processor = Processor.init(allocator, source, producer, streams, &obs);
     defer processor.deinit();
 
@@ -354,7 +354,7 @@ test "E2E: DELETE operation - full pipeline verification" {
     var producer = try KafkaProducer.init(allocator, "localhost:9092", null);
     try producer.testConnection();
 
-    var obs = Observability.initDisabled();
+    var obs = Observability.noop();
     var processor = Processor.init(allocator, source, producer, streams, &obs);
     defer processor.deinit();
 

--- a/tests/e2e/cdc_test.zig
+++ b/tests/e2e/cdc_test.zig
@@ -3,6 +3,7 @@ const testing = std.testing;
 const test_helpers = @import("test_helpers");
 
 const Processor = @import("cdc_processor").Processor;
+const Observability = @import("cdc_processor").Observability;
 const PostgresSource = @import("postgres_source").PostgresSource;
 const KafkaProducer = @import("kafka_producer").KafkaProducer;
 const Stream = @import("config").Stream;
@@ -84,7 +85,8 @@ test "E2E: INSERT operation - full pipeline verification" {
     var producer = try KafkaProducer.init(allocator, "localhost:9092", null);
     try producer.testConnection();
 
-    var processor = Processor.init(allocator, source, producer, streams);
+    var obs = Observability.initDisabled();
+    var processor = Processor.init(allocator, source, producer, streams, &obs);
     defer processor.deinit();
 
     std.debug.print("\n=== E2E INSERT TEST ===\n", .{});
@@ -221,7 +223,8 @@ test "E2E: UPDATE operation - full pipeline verification" {
     var producer = try KafkaProducer.init(allocator, "localhost:9092", null);
     try producer.testConnection();
 
-    var processor = Processor.init(allocator, source, producer, streams);
+    var obs = Observability.initDisabled();
+    var processor = Processor.init(allocator, source, producer, streams, &obs);
     defer processor.deinit();
 
     std.debug.print("\n=== E2E UPDATE TEST ===\n", .{});
@@ -351,7 +354,8 @@ test "E2E: DELETE operation - full pipeline verification" {
     var producer = try KafkaProducer.init(allocator, "localhost:9092", null);
     try producer.testConnection();
 
-    var processor = Processor.init(allocator, source, producer, streams);
+    var obs = Observability.initDisabled();
+    var processor = Processor.init(allocator, source, producer, streams, &obs);
     defer processor.deinit();
 
     std.debug.print("\n=== E2E DELETE TEST ===\n", .{});

--- a/tests/load/Makefile
+++ b/tests/load/Makefile
@@ -21,15 +21,21 @@ REPORT_INTERVAL ?= 5
 
 MINUTES ?= 60
 
-.PHONY: infra load start-debezium start-outboxx start-all reset create-slots slots status topics offsets results logs ps
+.PHONY: infra infra-up load start-debezium start-outboxx start-all reset create-slots slots status topics offsets results logs ps
 
-infra:
+# Bring infra up and ensure slots exist, leaving any running CDC readers alone.
+infra-up:
 	$(COMPOSE) up -d --remove-orphans $(INFRA_SERVICES)
-	-$(COMPOSE) stop debezium outboxx
-	-$(COMPOSE) rm -sf debezium outboxx connector-init
 	$(MAKE) create-slots
 
-load: infra
+# Clean pre-load baseline: infra up, CDC readers stopped, slots ready.
+infra: infra-up
+	-$(COMPOSE) stop debezium outboxx
+	-$(COMPOSE) rm -sf debezium outboxx connector-init
+
+# Generating load does not touch running readers, so lag/throughput can be
+# watched live. Use `make infra` first for the readers-down backlog scenario.
+load: infra-up
 	$(COMPOSE) run --build --rm workload \
 		--duration $(DURATION) \
 		--batch-size $(BATCH_SIZE) \

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -170,6 +170,9 @@ outboxx.public.benchmark_records          # Outboxx
 
 Grafana dashboard: **CDC / Debezium benchmark overview**. Besides the Kafka/cAdvisor
 comparison panels, Prometheus scrapes Outboxx's own `/metrics` (job `outboxx`, port
-9464), so the dashboard also plots its self-reported events/sec and replication lag
-directly. The Debezium-vs-Outboxx throughput comparison still uses Kafka offsets,
-which both readers expose equally.
+9464) and Debezium's JMX metrics, so two panels compare each tool's self-reported
+numbers side by side: events/sec (`outboxx_events_processed_total` vs
+`debezium_postgres_streaming_totalnumberofeventsseen`) and lag, where the units
+differ - Outboxx reports WAL bytes behind, Debezium reports milliseconds behind
+source (plotted on the right axis). The Kafka-offset append-rate panel stays as an
+independent, unit-matched throughput comparison.

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -16,7 +16,7 @@ make reset
 What each command does:
 
 - `make infra` starts PostgreSQL, Kafka, Kafka UI, Prometheus, Grafana, exporters, and cAdvisor. It stops Debezium/Outboxx if they exist and creates logical replication slots before any workload.
-- `make load` starts `infra` if needed and generates PostgreSQL writes while CDC readers are stopped, so WAL accumulates behind the slots.
+- `make load` brings infra and slots up if needed, then generates PostgreSQL writes. It leaves any running readers in place, so lag and throughput can be watched live while the load runs. For the readers-down backlog scenario (WAL accumulating behind the slots), run `make infra` first.
 - `make start-debezium` starts only Debezium. Outboxx is stopped/removed first.
 - `make start-outboxx` starts only Outboxx. Debezium and connector-init are stopped/removed first.
 - `make start-all` starts Debezium and Outboxx together. Debezium is registered automatically.

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -168,4 +168,8 @@ debezium.public.benchmark_records         # Debezium
 outboxx.public.benchmark_records          # Outboxx
 ```
 
-Grafana dashboard: **CDC / Debezium benchmark overview**.
+Grafana dashboard: **CDC / Debezium benchmark overview**. Besides the Kafka/cAdvisor
+comparison panels, Prometheus scrapes Outboxx's own `/metrics` (job `outboxx`, port
+9464), so the dashboard also plots its self-reported events/sec and replication lag
+directly. The Debezium-vs-Outboxx throughput comparison still uses Kafka offsets,
+which both readers expose equally.

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -172,7 +172,8 @@ Grafana dashboard: **CDC / Debezium benchmark overview**. Besides the Kafka/cAdv
 comparison panels, Prometheus scrapes Outboxx's own `/metrics` (job `outboxx`, port
 9464) and Debezium's JMX metrics, so two panels compare each tool's self-reported
 numbers side by side: events/sec (`outboxx_events_processed_total` vs
-`debezium_postgres_streaming_totalnumberofeventsseen`) and lag, where the units
-differ - Outboxx reports WAL bytes behind, Debezium reports milliseconds behind
-source (plotted on the right axis). The Kafka-offset append-rate panel stays as an
-independent, unit-matched throughput comparison.
+`debezium_postgres_streaming_totalnumberofeventsseen`) and lag behind source in
+seconds (`outboxx_replication_lag_seconds` vs Debezium's
+`millisecondsbehindsource / 1000`). Both lag metrics are wall-clock time behind the
+last committed transaction, so they share one axis. The Kafka-offset append-rate
+panel stays as an independent throughput comparison.

--- a/tests/load/docker-compose.yml
+++ b/tests/load/docker-compose.yml
@@ -155,6 +155,8 @@ services:
         condition: service_healthy
     environment:
       POSTGRES_URL: postgres://postgres:postgres@postgres:5432/bench?sslmode=disable
+    ports:
+      - "9464:9464"  # Prometheus /metrics, /healthz, /readyz
     volumes:
       - ./outboxx/config.toml:/app/config.toml:ro
     command: ["--config", "/app/config.toml"]

--- a/tests/load/grafana/dashboards/cdc-overview.json
+++ b/tests/load/grafana/dashboards/cdc-overview.json
@@ -469,6 +469,164 @@
       ],
       "title": "Container CPU: Debezium vs Outboxx",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "eps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "rate(outboxx_events_processed_total[1m])",
+          "legendFormat": "events/sec",
+          "refId": "A"
+        }
+      ],
+      "title": "Outboxx events processed (self-reported)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "outboxx_replication_lag_bytes",
+          "legendFormat": "lag",
+          "refId": "A"
+        }
+      ],
+      "title": "Outboxx replication lag (self-reported)",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/tests/load/grafana/dashboards/cdc-overview.json
+++ b/tests/load/grafana/dashboards/cdc-overview.json
@@ -542,11 +542,20 @@
             "uid": "Prometheus"
           },
           "expr": "rate(outboxx_events_processed_total[1m])",
-          "legendFormat": "events/sec",
+          "legendFormat": "outboxx (self-reported)",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(debezium_postgres_streaming_totalnumberofeventsseen[1m]))",
+          "legendFormat": "debezium (self-reported)",
+          "refId": "B"
         }
       ],
-      "title": "Outboxx events processed (self-reported)",
+      "title": "CDC events/sec: Outboxx vs Debezium (self-reported)",
       "type": "timeseries"
     },
     {
@@ -591,7 +600,28 @@
           },
           "unit": "decbytes"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "debezium (ms behind source)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "ms behind source"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -621,11 +651,20 @@
             "uid": "Prometheus"
           },
           "expr": "outboxx_replication_lag_bytes",
-          "legendFormat": "lag",
+          "legendFormat": "outboxx (WAL bytes)",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "max(debezium_postgres_streaming_millisecondsbehindsource)",
+          "legendFormat": "debezium (ms behind source)",
+          "refId": "B"
         }
       ],
-      "title": "Outboxx replication lag (self-reported)",
+      "title": "CDC lag: Outboxx (WAL bytes) vs Debezium (ms behind source)",
       "type": "timeseries"
     }
   ],

--- a/tests/load/grafana/dashboards/cdc-overview.json
+++ b/tests/load/grafana/dashboards/cdc-overview.json
@@ -598,30 +598,9 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "s"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "debezium (ms behind source)"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ms"
-              },
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "custom.axisLabel",
-                "value": "ms behind source"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -650,8 +629,8 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "outboxx_replication_lag_bytes",
-          "legendFormat": "outboxx (WAL bytes)",
+          "expr": "outboxx_replication_lag_seconds",
+          "legendFormat": "outboxx",
           "refId": "A"
         },
         {
@@ -659,12 +638,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "max(debezium_postgres_streaming_millisecondsbehindsource)",
-          "legendFormat": "debezium (ms behind source)",
+          "expr": "max(debezium_postgres_streaming_millisecondsbehindsource) / 1000",
+          "legendFormat": "debezium",
           "refId": "B"
         }
       ],
-      "title": "CDC lag: Outboxx (WAL bytes) vs Debezium (ms behind source)",
+      "title": "CDC lag behind source: Outboxx vs Debezium (seconds)",
       "type": "timeseries"
     }
   ],

--- a/tests/load/outboxx/Dockerfile
+++ b/tests/load/outboxx/Dockerfile
@@ -13,4 +13,5 @@ COPY . .
 RUN nix develop --command zig build -Doptimize=ReleaseFast
 
 WORKDIR /app
+EXPOSE 9464
 ENTRYPOINT ["/src/zig-out/bin/outboxx"]

--- a/tests/load/outboxx/config.toml
+++ b/tests/load/outboxx/config.toml
@@ -16,6 +16,13 @@ type = "kafka"
 brokers = ["kafka:9092"]
 tls = false  # the benchmark broker is plaintext
 
+# Expose /metrics so Prometheus scrapes throughput and lag straight from outboxx,
+# instead of inferring them from kafka-exporter/cadvisor. 0.0.0.0 so the Prometheus
+# container can reach it over the compose network.
+[observability]
+address = "0.0.0.0"
+port = 9464
+
 [[streams]]
 name = "benchmark-records"
 

--- a/tests/load/prometheus/prometheus.yml
+++ b/tests/load/prometheus/prometheus.yml
@@ -18,6 +18,12 @@ scrape_configs:
       - targets:
           - kafka-exporter:9308
 
+  # Outboxx's own /metrics (only up under the `compare` profile).
+  - job_name: outboxx
+    static_configs:
+      - targets:
+          - outboxx:9464
+
   - job_name: cadvisor
     static_configs:
       - targets:


### PR DESCRIPTION
Closes #51.

There was no way to observe a running Outboxx instance; the load stand only inferred throughput indirectly from kafka-exporter and cAdvisor. This adds a small HTTP server that exposes Prometheus metrics and health checks.

## Endpoints

Enabled by an optional `[observability]` config section (absent = disabled), default bind `0.0.0.0:9464`:

- `GET /metrics` - Prometheus text
- `GET /healthz` - liveness (200 while the receive loop makes progress, else 503)
- `GET /readyz` - readiness (200 once connected to Postgres and streaming, else 503)

## Metrics

- `outboxx_events_processed_total` (counter) - WAL change events consumed
- `outboxx_produce_errors_total` (counter) - Kafka produce failures
- `outboxx_replication_lag_seconds` (gauge) - wall-clock seconds behind the last transaction's commit time (0 when caught up)

## Design notes

- Built on the OpenTelemetry Zig SDK (`open-telemetry/opentelemetry-zig`, pinned to a commit). It is alpha, so the whole SDK is kept behind a single `Observability` facade to contain churn.
- All instrumentation lives in the processor; the source and producer are untouched.
- The SDK's Prometheus formatter is not part of its public API, and its `collect()` only emits an instrument that changed since the last call. So the facade renders the text itself and keeps a small snapshot, so every series is present on each scrape.
- The InMemory exporter is created with `DefaultTemporality`: counters stay cumulative, the lag gauge is delta, so each scrape reports the gauge's last recorded value instead of an ever-growing sum.
- Lag is measured as wall-clock time behind the last transaction's commit timestamp (Debezium-style), since the stream does not expose the server WAL head during a backlog.
- Metrics are pull-only for now. The same MeterProvider can later drive an OTLP push exporter without changing any instrumentation.

## Load stand

Prometheus now scrapes Outboxx directly (job `outboxx`, port 9464), and the Grafana dashboard gained two panels plotting its self-reported events/sec and replication lag. The Debezium-vs-Outboxx throughput comparison still uses Kafka offsets, which both readers expose equally.

## Verification

- Unit tests pass (observability rendering, counter persistence, lag-to-zero regression, disabled no-op).
- Exercised on the dev stack: `/metrics`, `/healthz`, `/readyz`, graceful shutdown, counter persistence across scrapes, and lag reacting to backlog.
- Binary grows ~200K (OpenTelemetry + protobuf, pure Zig, no new C libraries).