### PR TITLE
Add manual Docker image publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,21 +1,17 @@
-# Build outputs and caches (zig fetches deps fresh during the image build)
-zig-out/
-zig-cache/
-.zig-cache/
-zig-pkg/
-
-# VCS and local tooling
-.git/
-.direnv/
-.claude/
-
-# Local data and artifacts
-postgres-data/
-build/
-dist/
-target/
+.git
+.direnv
+.zig-cache
+zig-cache
+zig-out
+dist
+build
+target
+*.tmp
+*.temp
 *.log
-
-# OS junk
-**/.DS_Store
-Thumbs.db
+.DS_Store
+CLAUDE.local.md
+.claude
+.idea
+dev/outboxx_article_v3.md
+dev/kafka-tls/certs

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,8 +10,6 @@ target
 *.temp
 *.log
 .DS_Store
-CLAUDE.local.md
-.claude
 .idea
 dev/outboxx_article_v3.md
 dev/kafka-tls/certs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Publish Docker Image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/lukashes/outboxx
+
+jobs:
+  docker-image:
+    name: Docker image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Read version
+        id: version
+        run: |
+          version="$(awk -F'"' '/\.version =/ {print $2; exit}' build.zig.zon)"
+          if [ -z "$version" ]; then
+            echo "failed to read .version from build.zig.zon" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build image
+        env:
+          ARCH: ${{ matrix.arch }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker build \
+            --build-arg VERSION="${VERSION}" \
+            --label "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \
+            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            --label "org.opencontainers.image.version=${VERSION}" \
+            --tag "${IMAGE_NAME}:${VERSION}-${ARCH}" \
+            --tag "${IMAGE_NAME}:${VERSION}-${{ github.run_number }}-${ARCH}" \
+            --tag "${IMAGE_NAME}:sha-${GITHUB_SHA::12}-${ARCH}" \
+            .
+          docker run --rm "${IMAGE_NAME}:${VERSION}-${ARCH}" --version
+
+      - name: Push image
+        env:
+          ARCH: ${{ matrix.arch }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          docker push "${IMAGE_NAME}:${VERSION}-${ARCH}"
+          docker push "${IMAGE_NAME}:${VERSION}-${{ github.run_number }}-${ARCH}"
+          docker push "${IMAGE_NAME}:sha-${GITHUB_SHA::12}-${ARCH}"
+
+  publish:
+    name: Publish multi-arch tags
+    runs-on: ubuntu-24.04
+    needs: docker-image
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Read version
+        id: version
+        run: |
+          version="$(awk -F'"' '/\.version =/ {print $2; exit}' build.zig.zon)"
+          if [ -z "$version" ]; then
+            echo "failed to read .version from build.zig.zon" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Publish multi-arch image tags
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          for tag in "${VERSION}" "v${VERSION}" "${VERSION}-${{ github.run_number }}" "latest" "sha-${GITHUB_SHA::12}"; do
+            docker buildx imagetools create \
+              --tag "${IMAGE_NAME}:${tag}" \
+              "${IMAGE_NAME}:${VERSION}-amd64" \
+              "${IMAGE_NAME}:${VERSION}-arm64"
+          done
+
+      - name: Report image digest
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          digest="$(docker buildx imagetools inspect "${IMAGE_NAME}:${VERSION}" | awk '/^Digest:/ {print $2; exit}')"
+          {
+            echo "## Published image"
+            echo
+            echo "- Image: \`${IMAGE_NAME}:${VERSION}\`"
+            echo "- Digest: \`${IMAGE_NAME}@${digest}\`"
+            echo "- Build tag: \`${IMAGE_NAME}:${VERSION}-${{ github.run_number }}\`"
+            echo "- Commit tag: \`${IMAGE_NAME}:sha-${GITHUB_SHA::12}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -45,10 +45,6 @@ test_results/
 docs/build/
 docs/draft/
 
-# Claude Code assistant files
-CLAUDE.local.md
-.claude/
-
 # Direnv
 .direnv
 .envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to Outboxx are documented here.
+
+## Unreleased
+
+### Added
+
+- Release workflow for tags matching `v*.*.*`.
+- Manual GitHub Actions workflow that publishes a multi-stage GHCR image for
+  `linux/amd64` and `linux/arm64` using the version from `build.zig.zon`.
+- `outboxx --version` and `outboxx --help` for release smoke checks.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
 
 WORKDIR /src
 
-# Cache the Nix dev shell before copying the full repository.
+# Cache the Nix build environment before copying the full repository.
 COPY flake.nix flake.lock ./
 RUN nix develop --command echo "deps cached"
 
 COPY . .
-RUN nix develop --command zig build -Doptimize=ReleaseSafe -Dversion="${VERSION}"
+RUN nix develop --command zig build -Doptimize=ReleaseFast -Dversion="${VERSION}"
 RUN nix develop --command bash -c 'set -euo pipefail; \
     mkdir -p /runtime/app /runtime/etc/ssl/certs; \
     cp zig-out/bin/outboxx /runtime/app/outboxx; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM nixos/nix:2.24.10 AS builder
+
+ARG VERSION=0.2.0
+
+RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+
+WORKDIR /src
+
+# Cache the Nix dev shell before copying the full repository.
+COPY flake.nix flake.lock ./
+RUN nix develop --command echo "deps cached"
+
+COPY . .
+RUN nix develop --command zig build -Doptimize=ReleaseSafe -Dversion="${VERSION}"
+RUN nix develop --command bash -c 'set -euo pipefail; \
+    mkdir -p /runtime/app /runtime/etc/ssl/certs; \
+    cp zig-out/bin/outboxx /runtime/app/outboxx; \
+    ldd zig-out/bin/outboxx | \
+      awk "/=> \/nix\/store/ {print \$(NF-1)} /^\/nix\/store/ {print \$1}" | \
+      sort -u > /tmp/outboxx-libs; \
+    readelf -l zig-out/bin/outboxx | \
+      awk "/Requesting program interpreter/ {gsub(/[][]/, \"\", \$NF); print \$NF}" >> /tmp/outboxx-libs; \
+    while read -r lib; do \
+      mkdir -p "/runtime$(dirname "$lib")"; \
+      cp -aL "$lib" "/runtime$lib"; \
+    done < /tmp/outboxx-libs; \
+    if [ -d /etc/ssl/certs ]; then cp -aL /etc/ssl/certs/. /runtime/etc/ssl/certs/; fi; \
+    if [ -f /etc/ssl/cert.pem ]; then cp -aL /etc/ssl/cert.pem /runtime/etc/ssl/cert.pem; fi'
+
+FROM scratch
+
+COPY --from=builder /runtime /
+
+USER 65532:65532
+WORKDIR /app
+ENTRYPOINT ["/app/outboxx"]

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SHELL := $(CURDIR)/.make-shell
 # Number of passes for bench-save / bench-compare (the minimum time/run is
 # kept). Override e.g. `make bench-save BENCH_RUNS=9`.
 export BENCH_RUNS ?= 5
+ZIG_BUILD_ARGS ?=
 
 # Helper function for running commands with spinner
 # Captures both stdout and stderr, shows full output on failure
@@ -70,8 +71,8 @@ help:
 # Build the project
 build:
 # macro-prefix-map is not supported at darwin
-	@echo "zig build"
-	@zig build
+	@echo "zig build $(ZIG_BUILD_ARGS)"
+	@zig build $(ZIG_BUILD_ARGS)
 
 # Run the application against the dev config. POSTGRES_URL falls back to the local
 # dev database; override it to point elsewhere. Needs services up (make env-up).

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ ALTER TABLE my_table REPLICA IDENTITY FULL;
 
 ### 2. Running Outboxx
 
+Run the published Docker image:
+
+```bash
+export POSTGRES_URL="postgres://user:your_password@host:5432/dbname?sslmode=require"
+docker run --rm \
+  -e POSTGRES_URL \
+  -v "$PWD/config.toml:/config.toml:ro" \
+  ghcr.io/lukashes/outboxx:latest \
+  --config /config.toml
+```
+
+For local development builds:
+
 ```bash
 # Build the application
 make build
@@ -112,6 +125,13 @@ make build
 export POSTGRES_URL="postgres://user:your_password@host:5432/dbname?sslmode=require"
 ./zig-out/bin/outboxx --config config.toml
 ```
+
+Release images are published manually from GitHub Actions. The workflow reads
+the version from `build.zig.zon`, publishes `linux/amd64` and `linux/arm64`, and
+writes the immutable image digest to the run summary. The image uses a Nix
+builder and a small scratch runtime containing only the binary, its runtime
+libraries, and CA certificates. On macOS, run the Linux image through Docker or
+another Linux VM/container runtime.
 
 ### 3. Production Deployment
 

--- a/README.md
+++ b/README.md
@@ -126,13 +126,6 @@ export POSTGRES_URL="postgres://user:your_password@host:5432/dbname?sslmode=requ
 ./zig-out/bin/outboxx --config config.toml
 ```
 
-Release images are published manually from GitHub Actions. The workflow reads
-the version from `build.zig.zon`, publishes `linux/amd64` and `linux/arm64`, and
-writes the immutable image digest to the run summary. The image uses a Nix
-builder and a small scratch runtime containing only the binary, its runtime
-libraries, and CA certificates. On macOS, run the Linux image through Docker or
-another Linux VM/container runtime.
-
 ### 3. Production Deployment
 
 ⚠️ **Outboxx requires a process supervisor** (systemd, Kubernetes, Docker restart policy, supervisord) as it uses fail-fast error handling. PostgreSQL replication slots preserve state across restarts.

--- a/build.zig
+++ b/build.zig
@@ -11,12 +11,22 @@ pub fn build(b: *std.Build) void {
         "Prioritize performance, safety, or binary size (default: ReleaseFast)",
     ) orelse .ReleaseFast;
 
+    const version = b.option(
+        []const u8,
+        "version",
+        "Version string embedded into the outboxx binary",
+    ) orelse "0.2.0";
+
+    const build_options = b.addOptions();
+    build_options.addOption([]const u8, "version", version);
+
     // Constants module (application-wide constants)
     const constants_module = b.createModule(.{
         .root_source_file = b.path("src/constants.zig"),
         .target = target,
         .optimize = optimize,
     });
+    constants_module.addOptions("build_options", build_options);
 
     // TOML parser dependency (parses config straight into Zig structs)
     const toml_dep = b.dependency("toml", .{

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -1,6 +1,7 @@
 const builtin = @import("builtin");
+const build_options = @import("build_options");
 
-pub const VERSION = "0.2.0";
+pub const VERSION = build_options.version;
 pub const APP_NAME = "Outboxx";
 pub const DESCRIPTION = "PostgreSQL Change Data Capture with Kafka";
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,6 +14,17 @@ pub const CliError = error{
     NoConfigPath,
 };
 
+const CliAction = enum {
+    run,
+    help,
+    version,
+};
+
+const Cli = struct {
+    action: CliAction = .run,
+    config_path: ?[]const u8 = null,
+};
+
 var shutdown_requested = std.atomic.Value(bool).init(false);
 
 // Stdout writes need an Io; kept here so printStatus/printBanner stay
@@ -43,13 +54,27 @@ fn run(init: std.process.Init) !void {
         }
     };
 
+    const cli = try parseCli(init.minimal.args, allocator);
+    defer if (cli.config_path) |path| allocator.free(path);
+
+    switch (cli.action) {
+        .help => {
+            printHelp();
+            return;
+        },
+        .version => {
+            printVersion();
+            return;
+        },
+        .run => {},
+    }
+
     printBanner();
 
-    const config_file_path = try parseConfigPath(init.minimal.args, allocator) orelse {
+    const config_file_path = cli.config_path orelse {
         std.log.warn("config file is required. Use --config <path>", .{});
         return CliError.NoConfigPath;
     };
-    defer allocator.free(config_file_path);
 
     printStatus("Loading configuration from: {s}\n", .{config_file_path});
     var parsed = try Config.loadFromTomlFile(init.io, allocator, config_file_path);
@@ -163,20 +188,52 @@ fn printBanner() void {
     printStatus("Build: {s}\n\n", .{@tagName(constants.BUILD_MODE)});
 }
 
-fn parseConfigPath(args: std.process.Args, allocator: std.mem.Allocator) !?[]const u8 {
+fn printVersion() void {
+    printStatus("outboxx {s}\n", .{constants.VERSION});
+}
+
+fn printHelp() void {
+    printStatus(
+        \\Outboxx - PostgreSQL Change Data Capture with Kafka
+        \\
+        \\Usage:
+        \\  outboxx --config <path>
+        \\  outboxx --version
+        \\  outboxx --help
+        \\
+        \\Options:
+        \\  --config, -c <path>  TOML configuration file
+        \\  --version           Print version and exit
+        \\  --help, -h          Print this help and exit
+        \\
+    , .{});
+}
+
+fn parseCli(args: std.process.Args, allocator: std.mem.Allocator) !Cli {
     var it = args.iterate();
     defer it.deinit();
 
+    var cli = Cli{};
+
     _ = it.next(); // skip executable name (argv[0])
     while (it.next()) |arg| {
-        if (std.mem.eql(u8, arg, "--config")) {
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            cli.action = .help;
+            return cli;
+        }
+        if (std.mem.eql(u8, arg, "--version")) {
+            cli.action = .version;
+            return cli;
+        }
+        if (std.mem.eql(u8, arg, "--config") or std.mem.eql(u8, arg, "-c")) {
             if (it.next()) |path| {
-                return try allocator.dupe(u8, path);
+                if (cli.config_path) |old_path| allocator.free(old_path);
+                cli.config_path = try allocator.dupe(u8, path);
             }
         }
     }
 
-    return null;
+    return cli;
 }
 
 fn printConfigInfo(cfg: Config) void {


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow to publish multi-arch GHCR images
- read the image version from build.zig.zon and report the immutable digest in the workflow summary
- add a multi-stage Dockerfile with a scratch runtime and add --version/--help for smoke checks

## Verification
- make lint
- make build ZIG_BUILD_ARGS="-Dversion=0.2.0-test"
- make test-unit
- docker build --build-arg VERSION=0.2.0-test -t outboxx:multistage-test .
- docker run --rm outboxx:multistage-test --version