### PR TITLE
Use compact scratch runtime for Docker release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Thumbs.db
 .env
 .env.local
 *.local
+tests/load/docker-compose.override.yml
 
 # Docker volumes (if any)
 postgres-data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,9 @@ RUN nix develop --command bash -c 'set -euo pipefail; \
     if [ -d /etc/ssl/certs ]; then cp -aL /etc/ssl/certs/. /runtime/etc/ssl/certs/; fi; \
     if [ -f /etc/ssl/cert.pem ]; then cp -aL /etc/ssl/cert.pem /runtime/etc/ssl/cert.pem; fi'
 
-FROM nixos/nix:2.24.10
+FROM scratch
 
 COPY --from=builder /runtime /
-
-RUN rm -rf /root/.cache /tmp/* /var/tmp/* /nix/var/nix/gcroots/auto/* /nix/var/nix/profiles/per-user/root/channels
 
 USER 65532:65532
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY flake.nix flake.lock ./
 RUN nix develop --command echo "deps cached"
 
 COPY . .
-RUN nix develop --command zig build -Dcpu=baseline -Doptimize=ReleaseFast -Dversion="${VERSION}"
+RUN nix develop --command zig build -Dcpu=baseline -Doptimize=ReleaseSafe -Dversion="${VERSION}"
 RUN nix develop --command bash -c 'set -euo pipefail; \
     mkdir -p /runtime/app /runtime/etc/ssl/certs /runtime/etc; \
     cp zig-out/bin/outboxx /runtime/app/outboxx; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,25 +11,35 @@ COPY flake.nix flake.lock ./
 RUN nix develop --command echo "deps cached"
 
 COPY . .
-RUN nix develop --command zig build -Doptimize=ReleaseFast -Dversion="${VERSION}"
+RUN nix develop --command zig build -Dcpu=baseline -Doptimize=ReleaseFast -Dversion="${VERSION}"
 RUN nix develop --command bash -c 'set -euo pipefail; \
-    mkdir -p /runtime/app /runtime/etc/ssl/certs; \
+    mkdir -p /runtime/app /runtime/etc/ssl/certs /runtime/etc; \
     cp zig-out/bin/outboxx /runtime/app/outboxx; \
     ldd zig-out/bin/outboxx | \
       awk "/=> \/nix\/store/ {print \$(NF-1)} /^\/nix\/store/ {print \$1}" | \
       sort -u > /tmp/outboxx-libs; \
-    readelf -l zig-out/bin/outboxx | \
-      awk "/Requesting program interpreter/ {gsub(/[][]/, \"\", \$NF); print \$NF}" >> /tmp/outboxx-libs; \
-    while read -r lib; do \
+    interpreter="$(readelf -l zig-out/bin/outboxx | awk "/Requesting program interpreter/ {gsub(/[][]/, \"\", \$NF); print \$NF}")"; \
+    if [ -n "$interpreter" ]; then echo "$interpreter" >> /tmp/outboxx-libs; fi; \
+    libc="$(awk "/\/libc\\.so\\.6$/ {print; exit}" /tmp/outboxx-libs)"; \
+    if [ -n "$libc" ]; then \
+      libc_dir="$(dirname "$libc")"; \
+      for nss_lib in libnss_dns.so.2 libnss_files.so.2 libresolv.so.2; do \
+        if [ -e "$libc_dir/$nss_lib" ]; then echo "$libc_dir/$nss_lib" >> /tmp/outboxx-libs; fi; \
+      done; \
+    fi; \
+    sort -u /tmp/outboxx-libs | while read -r lib; do \
       mkdir -p "/runtime$(dirname "$lib")"; \
       cp -aL "$lib" "/runtime$lib"; \
-    done < /tmp/outboxx-libs; \
+    done; \
+    printf "hosts: files dns\npasswd: files\ngroup: files\n" > /runtime/etc/nsswitch.conf; \
     if [ -d /etc/ssl/certs ]; then cp -aL /etc/ssl/certs/. /runtime/etc/ssl/certs/; fi; \
     if [ -f /etc/ssl/cert.pem ]; then cp -aL /etc/ssl/cert.pem /runtime/etc/ssl/cert.pem; fi'
 
-FROM scratch
+FROM nixos/nix:2.24.10
 
 COPY --from=builder /runtime /
+
+RUN rm -rf /root/.cache /tmp/* /var/tmp/* /nix/var/nix/gcroots/auto/* /nix/var/nix/profiles/per-user/root/channels
 
 USER 65532:65532
 WORKDIR /app

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -22,9 +22,6 @@ What each command does:
 - `make start-all` starts Debezium and Outboxx together. Debezium is registered automatically.
 - `make reset` stops the stand and removes this stand's PostgreSQL, Kafka, Prometheus, and Grafana volumes.
 
-By default, the benchmark runs Outboxx from `ghcr.io/lukashes/outboxx:latest`.
-Set `OUTBOXX_IMAGE=` to use another published tag or digest.
-
 To benchmark the local checkout, copy the example override and rebuild:
 
 ```sh

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -22,6 +22,16 @@ What each command does:
 - `make start-all` starts Debezium and Outboxx together. Debezium is registered automatically.
 - `make reset` stops the stand and removes this stand's PostgreSQL, Kafka, Prometheus, and Grafana volumes.
 
+By default, the benchmark runs Outboxx from `ghcr.io/lukashes/outboxx:latest`.
+Set `OUTBOXX_IMAGE=` to use another published tag or digest.
+
+To benchmark the local checkout, copy the example override and rebuild:
+
+```sh
+cp docker-compose.override.yml.example docker-compose.override.yml
+make start-outboxx
+```
+
 Open:
 
 - Grafana: http://localhost:3000 (`admin` / `admin`)

--- a/tests/load/docker-compose.override.yml.example
+++ b/tests/load/docker-compose.override.yml.example
@@ -1,0 +1,6 @@
+services:
+  outboxx:
+    image: outboxx:load-local
+    build:
+      context: ../..
+      dockerfile: tests/load/outboxx/Dockerfile

--- a/tests/load/docker-compose.yml
+++ b/tests/load/docker-compose.yml
@@ -146,7 +146,7 @@ services:
 
   outboxx:
     profiles: ["compare"]
-    image: ${OUTBOXX_IMAGE:-ghcr.io/lukashes/outboxx:latest}
+    image: ghcr.io/lukashes/outboxx:latest
     container_name: cdc-outboxx
     depends_on:
       postgres:

--- a/tests/load/docker-compose.yml
+++ b/tests/load/docker-compose.yml
@@ -146,9 +146,7 @@ services:
 
   outboxx:
     profiles: ["compare"]
-    build:
-      context: ../..
-      dockerfile: tests/load/outboxx/Dockerfile
+    image: ${OUTBOXX_IMAGE:-ghcr.io/lukashes/outboxx:latest}
     container_name: cdc-outboxx
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary
- keep the release image on a scratch runtime while copying only the outboxx binary runtime closure from Nix
- build with Zig baseline CPU and ReleaseSafe to avoid runner-specific instructions while keeping safety checks enabled
- include the ELF loader, Nix shared libraries, NSS config, and CA certificates needed at runtime
- run load-test Outboxx from ghcr.io/lukashes/outboxx:latest by default, with an ignored local override and tracked example for benchmarking the local checkout

## Verification
- docker build --build-arg VERSION=0.2.0-test -t outboxx:scratch-safe-test .
- docker run --rm outboxx:scratch-safe-test --version
- docker image ls outboxx:scratch-safe-test
- docker image inspect outboxx:scratch-safe-test --format '{{.Architecture}} {{.Os}} {{.Id}}'
- make build ZIG_BUILD_ARGS="-Dcpu=baseline -Doptimize=ReleaseSafe -Dversion=0.2.0-test"
- docker compose --profile compare config --format json | jq '.services.outboxx | {image, build, command}'
- docker compose -f docker-compose.yml -f docker-compose.override.yml.example --profile compare config --format json | jq '.services.outboxx | {image, build, command}'

## Size
- Local linux/arm64 image size: 29.9MB via docker image ls