### PR TITLE
Skip unhandled pgoutput messages instead of crash-looping

### DIFF
--- a/src/source/postgres/converter.zig
+++ b/src/source/postgres/converter.zig
@@ -34,11 +34,12 @@ pub const Converter = struct {
     }
 
     /// Convert one decoded pgoutput message to a ChangeEvent, or null when it
-    /// carries no row change (BEGIN, COMMIT, RELATION). RELATION updates the
-    /// registry in place; data messages read column types from it.
+    /// carries no row change (BEGIN, COMMIT, RELATION, or a skipped type).
+    /// RELATION updates the registry in place; data messages read column types
+    /// from it.
     pub fn convert(self: *Self, io: std.Io, allocator: std.mem.Allocator, pg_msg: PgOutputMessage) !?ChangeEvent {
         switch (pg_msg) {
-            .begin, .commit => return null,
+            .begin, .commit, .skip => return null,
             .relation => |rel| {
                 try self.registry.register(rel);
                 return null;
@@ -261,6 +262,15 @@ test "convert: BEGIN and COMMIT yield no event" {
     var commit = PgOutputMessage{ .commit = .{ .flags = 0, .commit_lsn = 0, .end_lsn = 0, .commit_time = 0 } };
     defer commit.deinit(allocator);
     try testing.expect((try converter.convert(std.testing.io, allocator, commit)) == null);
+}
+
+test "convert: skipped message type yields no event" {
+    const allocator = testing.allocator;
+
+    var converter = Converter.init(allocator);
+    defer converter.deinit();
+
+    try testing.expect((try converter.convert(std.testing.io, allocator, .skip)) == null);
 }
 
 test "convert INSERT: basic message to ChangeEvent" {

--- a/src/source/postgres/pg_output_decoder.zig
+++ b/src/source/postgres/pg_output_decoder.zig
@@ -131,10 +131,13 @@ pub const PgOutputMessage = union(enum) {
     insert: InsertMessage,
     update: UpdateMessage,
     delete: DeleteMessage,
+    /// A message type we consume but don't turn into a change event (truncate,
+    /// type, origin). Its LSN is still confirmed, like BEGIN/COMMIT.
+    skip,
 
     pub fn deinit(self: *PgOutputMessage, allocator: std.mem.Allocator) void {
         switch (self.*) {
-            .begin, .commit => {},
+            .begin, .commit, .skip => {},
             .relation => |*rel| rel.deinit(allocator),
             .insert => |*ins| ins.deinit(allocator),
             .update => |*upd| upd.deinit(allocator),
@@ -172,6 +175,16 @@ pub const PgOutputDecoder = struct {
             .insert => return PgOutputMessage{ .insert = try self.decodeInsert(data[1..]) },
             .update => return PgOutputMessage{ .update = try self.decodeUpdate(data[1..]) },
             .delete => return PgOutputMessage{ .delete = try self.decodeDelete(data[1..]) },
+            // Consume the types that carry no row change we emit, so their LSN is
+            // confirmed instead of crash-looping the pipeline.
+            .truncate => {
+                std.log.info("Detected TRUNCATE on source", .{});
+                return .skip;
+            },
+            .data_type, .origin => {
+                std.log.debug("Skipping pgoutput message type: {c}", .{data[0]});
+                return .skip;
+            },
             else => {
                 std.log.warn("Unknown pgoutput message type: {c} (0x{x})", .{ @as(u8, @intFromEnum(msg_type)), @as(u8, @intFromEnum(msg_type)) });
                 return DecoderError.UnknownMessageType;

--- a/src/source/postgres/pg_output_decoder_test.zig
+++ b/src/source/postgres/pg_output_decoder_test.zig
@@ -350,6 +350,19 @@ test "PgOutputDecoder: invalid message type" {
     try testing.expectError(decoder_mod.DecoderError.UnknownMessageType, result);
 }
 
+test "PgOutputDecoder: truncate, type and origin decode to skip" {
+    const allocator = testing.allocator;
+    var pg_decoder = PgOutputDecoder.init(allocator);
+
+    // Only the leading type byte matters: the body is never parsed for these.
+    for ([_]u8{ 'T', 'Y', 'O' }) |type_byte| {
+        const data = [_]u8{ type_byte, 0xDE, 0xAD, 0xBE, 0xEF };
+        var msg = try pg_decoder.decode(allocator, &data);
+        defer msg.deinit(allocator);
+        try testing.expect(msg == .skip);
+    }
+}
+
 test "PgOutputDecoder: unchanged TOAST column decodes to null (no value sent)" {
     const allocator = testing.allocator;
     var pg_decoder = PgOutputDecoder.init(allocator);


### PR DESCRIPTION
## Problem

The decoder handled only Begin/Commit/Relation/Insert/Update/Delete; every other pgoutput message returned `UnknownMessageType` → `DecodeFailed` → process exit. The LSN was never confirmed, so Postgres re-sent the same message on restart — a permanent crash loop until an operator dropped the slot.

Realistic triggers:
- `T` (Truncate): the publication is `FOR ALL TABLES` with the default `publish` including `truncate`, so a `TRUNCATE` of *any* table killed the pipeline.
- `Y` (Type): sent for non-builtin column types (enum, domain, composite) — a tracked table with an enum column broke on its first change.
- `O` (Origin): rarer, same effect.

## Solution

- Add a `skip` variant to `PgOutputMessage`; the converter maps it to no change event, so the LSN is confirmed like BEGIN/COMMIT.
- Decode `T`/`Y`/`O` into `skip`. `Y`/`O` log at debug; `TRUNCATE` logs at info (we don't propagate it downstream — matches Debezium's default `skipped.operations=t`).
- Truly unknown message types still fail fast.
- Unit tests for `T`/`Y`/`O` → skip and skip → null.

Closes #71