### PR TITLE
Fold slot and publication names to lowercase for Postgres

### DIFF
--- a/src/source/postgres/integration_test.zig
+++ b/src/source/postgres/integration_test.zig
@@ -11,6 +11,7 @@ const constants = @import("constants");
 
 const source_mod = @import("source.zig");
 const PostgresSource = source_mod.PostgresSource;
+const ReplicationProtocol = @import("replication_protocol.zig").ReplicationProtocol;
 
 const c = @import("c"); // C bindings (build-system translate-c)
 
@@ -186,6 +187,47 @@ test "Streaming source: receive and convert INSERT messages to ChangeEvents" {
     try source.sendFeedback(std.testing.io, batch.last_lsn);
 
     std.log.info("Integration test passed!", .{});
+}
+
+test "ReplicationProtocol: mixed-case slot and publication names are idempotent across restarts" {
+    const allocator = testing.allocator;
+
+    var prng = std.Random.DefaultPrng.init(@intCast(test_helpers.nowMicros(std.testing.io)));
+    const random_suffix = prng.random().int(u32);
+    const timestamp = test_helpers.nowSeconds(std.testing.io);
+
+    // Mixed-case config names. Postgres folds unquoted identifiers to lowercase,
+    // so the objects are actually created lowercase.
+    const pub_name = try std.fmt.allocPrint(allocator, "MixedCasePub_{d}_{d}", .{ timestamp, random_suffix });
+    defer allocator.free(pub_name);
+    const slot_name = try std.fmt.allocPrint(allocator, "MixedCaseSlot_{d}_{d}", .{ timestamp, random_suffix });
+    defer allocator.free(slot_name);
+
+    // Cleanup (and the case-sensitive slot drop) must use the folded name.
+    const pub_lower = try std.ascii.allocLowerString(allocator, pub_name);
+    defer allocator.free(pub_lower);
+    const slot_lower = try std.ascii.allocLowerString(allocator, slot_name);
+    defer allocator.free(slot_lower);
+
+    const setup_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(setup_conn);
+    defer cleanupTestEnvironment(allocator, setup_conn, "mixedcase_no_table", slot_lower, pub_lower);
+
+    const conn_str = try getTestConnectionString(allocator);
+    defer allocator.free(conn_str);
+
+    // Two start cycles with the same mixed-case config. Before the fix the second
+    // cycle crash-looped: the existence check compared the raw mixed-case string,
+    // never matched the folded objects, and CREATE failed with "already exists".
+    var cycle: usize = 0;
+    while (cycle < 2) : (cycle += 1) {
+        var proto = ReplicationProtocol.init(allocator, slot_name, pub_name);
+        defer proto.deinit();
+
+        try proto.connect(conn_str);
+        try proto.createPublicationIfNotExists();
+        try proto.createSlotIfNotExists();
+    }
 }
 
 test "Streaming source: UPDATE operation E2E with old and new tuples" {

--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -119,11 +119,19 @@ pub const ReplicationProtocol = struct {
     pub fn createPublicationIfNotExists(self: *Self) ReplicationError!void {
         if (self.connection == null) return ReplicationError.ConnectionFailed;
 
+        // Postgres folds unquoted identifiers to lowercase. We fold slot and
+        // publication names the same way so the existence check, CREATE, and
+        // START_REPLICATION all reference one name; a mixed-case name would be
+        // created folded but never re-found, and CREATE would fail "already
+        // exists" on every restart -- a crash loop.
+        const pub_name = try std.ascii.allocLowerString(self.allocator, self.publication_name);
+        defer self.allocator.free(pub_name);
+
         // Check if publication exists
         const check_sql_tmp = std.fmt.allocPrint(
             self.allocator,
             "SELECT pubname FROM pg_publication WHERE pubname = '{s}'",
-            .{self.publication_name},
+            .{pub_name},
         ) catch return ReplicationError.OutOfMemory;
         defer self.allocator.free(check_sql_tmp);
 
@@ -142,7 +150,7 @@ pub const ReplicationProtocol = struct {
 
         const num_rows = c.PQntuples(check_result);
         if (num_rows > 0) {
-            std.log.info("Publication '{s}' already exists", .{self.publication_name});
+            std.log.info("Publication '{s}' already exists", .{pub_name});
             return;
         }
 
@@ -150,14 +158,14 @@ pub const ReplicationProtocol = struct {
         const create_sql_tmp = std.fmt.allocPrint(
             self.allocator,
             "CREATE PUBLICATION {s} FOR ALL TABLES",
-            .{self.publication_name},
+            .{pub_name},
         ) catch return ReplicationError.OutOfMemory;
         defer self.allocator.free(create_sql_tmp);
 
         const create_sql = self.allocator.dupeZ(u8, create_sql_tmp) catch return ReplicationError.OutOfMemory;
         defer self.allocator.free(create_sql);
 
-        std.log.info("Creating publication: {s}", .{self.publication_name});
+        std.log.info("Creating publication: {s}", .{pub_name});
 
         const create_result = c.PQexec(self.connection, create_sql.ptr);
         defer c.PQclear(create_result);
@@ -169,18 +177,23 @@ pub const ReplicationProtocol = struct {
             return ReplicationError.ConnectionFailed;
         }
 
-        std.log.info("Publication '{s}' created successfully", .{self.publication_name});
+        std.log.info("Publication '{s}' created successfully", .{pub_name});
     }
 
     /// Create replication slot if it doesn't exist
     pub fn createSlotIfNotExists(self: *Self) ReplicationError!void {
         if (self.connection == null) return ReplicationError.ConnectionFailed;
 
+        // Fold to lowercase like Postgres does for unquoted identifiers (see
+        // createPublicationIfNotExists).
+        const slot_name = try std.ascii.allocLowerString(self.allocator, self.slot_name);
+        defer self.allocator.free(slot_name);
+
         // Check if slot exists
         const check_sql_tmp = std.fmt.allocPrint(
             self.allocator,
             "SELECT slot_name FROM pg_replication_slots WHERE slot_name = '{s}'",
-            .{self.slot_name},
+            .{slot_name},
         ) catch return ReplicationError.OutOfMemory;
         defer self.allocator.free(check_sql_tmp);
 
@@ -199,7 +212,7 @@ pub const ReplicationProtocol = struct {
 
         const num_rows = c.PQntuples(check_result);
         if (num_rows > 0) {
-            std.log.info("Replication slot '{s}' already exists", .{self.slot_name});
+            std.log.info("Replication slot '{s}' already exists", .{slot_name});
             return;
         }
 
@@ -207,14 +220,14 @@ pub const ReplicationProtocol = struct {
         const create_sql_tmp = std.fmt.allocPrint(
             self.allocator,
             "CREATE_REPLICATION_SLOT {s} LOGICAL pgoutput",
-            .{self.slot_name},
+            .{slot_name},
         ) catch return ReplicationError.OutOfMemory;
         defer self.allocator.free(create_sql_tmp);
 
         const create_sql = self.allocator.dupeZ(u8, create_sql_tmp) catch return ReplicationError.OutOfMemory;
         defer self.allocator.free(create_sql);
 
-        std.log.info("Creating replication slot: {s}", .{self.slot_name});
+        std.log.info("Creating replication slot: {s}", .{slot_name});
 
         const create_result = c.PQexec(self.connection, create_sql.ptr);
         defer c.PQclear(create_result);
@@ -226,17 +239,24 @@ pub const ReplicationProtocol = struct {
             return ReplicationError.ConnectionFailed;
         }
 
-        std.log.info("Replication slot '{s}' created successfully", .{self.slot_name});
+        std.log.info("Replication slot '{s}' created successfully", .{slot_name});
     }
 
     pub fn startReplication(self: *Self, start_lsn: []const u8) ReplicationError!void {
         if (self.connection == null) return ReplicationError.ConnectionFailed;
 
+        // Fold to lowercase like Postgres does for unquoted identifiers (see
+        // createPublicationIfNotExists).
+        const slot_name = try std.ascii.allocLowerString(self.allocator, self.slot_name);
+        defer self.allocator.free(slot_name);
+        const pub_name = try std.ascii.allocLowerString(self.allocator, self.publication_name);
+        defer self.allocator.free(pub_name);
+
         // START_REPLICATION SLOT slot_name LOGICAL lsn (proto_version '1', publication_names 'pub_name')
         const sql_tmp = std.fmt.allocPrint(
             self.allocator,
             "START_REPLICATION SLOT {s} LOGICAL {s} (proto_version '1', publication_names '{s}')",
-            .{ self.slot_name, start_lsn, self.publication_name },
+            .{ slot_name, start_lsn, pub_name },
         ) catch return ReplicationError.OutOfMemory;
         defer self.allocator.free(sql_tmp);
 


### PR DESCRIPTION
## Problem

Config validation accepts uppercase in `slot_name` and `publication_name`, but the existence check and the CREATE statement disagree on case folding:

- `SELECT ... WHERE pubname = 'MyPub'` is a case-sensitive match — finds nothing.
- `CREATE PUBLICATION MyPub` folds the unquoted identifier to `mypub`.

First start works (check finds nothing, CREATE succeeds as `mypub`). Every restart after: the check again misses (`MyPub` != `mypub`), CREATE fails "already exists", the process exits — a crash loop that needs a config edit to escape. A mixed-case `slot_name` fails even earlier, on the first `CREATE_REPLICATION_SLOT` (slot names allow only `[a-z0-9_]`).

## Solution

- Fold both names to lowercase wherever they reach Postgres — the existence check, `CREATE`, and `START_REPLICATION` — via a small `foldName` helper, mirroring the server's own unquoted-identifier folding. A mixed-case config now just works instead of crash-looping.
- Add an integration test running two create cycles with a mixed-case name, asserting the second (the restart) doesn't fail on "already exists".

Chose folding over rejecting the config, matching Postgres semantics (and Debezium, which normalizes similarly).

Closes #75