### PR TITLE
Stop the metrics server on cancel, not just on graceful stop

### DIFF
--- a/src/observability/http.zig
+++ b/src/observability/http.zig
@@ -22,7 +22,11 @@ fn serveImpl(io: std.Io, obs: *Observability, address: []const u8, port: u16, st
 
     while (!stop.load(.monotonic)) {
         var stream = server.accept(io) catch |err| {
-            if (stop.load(.monotonic)) break;
+            // Canceled means the future is being torn down. `stop` is set only on a
+            // graceful shutdown; on a fatal error the future is cancelled without
+            // it, so break on Canceled too -- otherwise the next accept blocks
+            // forever (cancel fires once) and hangs the process exit.
+            if (err == error.Canceled or stop.load(.monotonic)) break;
             std.log.debug("metrics accept failed: {}", .{err});
             continue;
         };


### PR DESCRIPTION
## Problem

On a fatal error the process hung in teardown instead of exiting, so a supervisor never restarted it. Debug tracing pinned it to `metrics_future.cancel`.

The metrics `serve` loop only breaks out of `accept` when the shared `stop` flag is set. That flag is set on a graceful shutdown (SIGINT/SIGTERM), but on a fatal error the future is cancelled *without* it. `cancel` fires once: the first `accept` returns `error.Canceled`, the loop logs it and `continue`s, and the next `accept` blocks forever — so `metrics_future.cancel` awaits a worker that never returns.

## Solution

Break out of the loop on `error.Canceled` regardless of `stop`. A cancelled `accept` means the future is being torn down (graceful or fatal), so the loop must exit either way. Fatal-error teardown now cancels the metrics server promptly and the process fails fast.

Found while load-testing (Postgres dropped the replication connection; outboxx then hung here instead of exiting).