### PR TITLE
Serialize libpq access to the shared replication connection

### DIFF
--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -61,6 +61,11 @@ pub const ReplicationProtocol = struct {
     connection: ?*c.PGconn,
     slot_name: []const u8,
     publication_name: []const u8,
+    // Serializes libpq access: the flush worker sends feedback on the same
+    // connection the receive loop reads from, and libpq forbids using one
+    // PGconn from two threads. Held only for short non-blocking calls; the
+    // poll() wait runs unlocked.
+    mutex: std.Io.Mutex = .init,
 
     const Self = @This();
 
@@ -278,12 +283,16 @@ pub const ReplicationProtocol = struct {
         std.log.debug("Replication started successfully", .{});
     }
 
-    pub fn receiveMessage(self: *Self, timeout_ms: i32) ReplicationError!?ReplicationMessage {
+    pub fn receiveMessage(self: *Self, io: std.Io, timeout_ms: i32) ReplicationError!?ReplicationMessage {
         if (self.connection == null) return ReplicationError.ConnectionFailed;
 
         // Step 1: Try non-blocking read first
         var buffer: [*c]u8 = undefined;
-        var len = c.PQgetCopyData(self.connection, &buffer, 1); // async=1 (non-blocking)
+        var len = blk: {
+            self.mutex.lockUncancelable(io);
+            defer self.mutex.unlock(io);
+            break :blk c.PQgetCopyData(self.connection, &buffer, 1); // async=1 (non-blocking)
+        };
 
         if (len == 0) {
             // Step 2: No data available - wait for socket to become readable
@@ -313,6 +322,8 @@ pub const ReplicationProtocol = struct {
             }
 
             // Step 4: Socket is readable - consume input
+            self.mutex.lockUncancelable(io);
+            defer self.mutex.unlock(io);
             if (c.PQconsumeInput(self.connection) == 0) {
                 const error_msg = c.PQerrorMessage(self.connection);
                 std.log.warn("Failed to consume input: {s}", .{error_msg});
@@ -330,6 +341,9 @@ pub const ReplicationProtocol = struct {
         }
 
         if (len == -2) {
+            // PQerrorMessage reads connection state, so it needs the lock too.
+            self.mutex.lockUncancelable(io);
+            defer self.mutex.unlock(io);
             const error_msg = c.PQerrorMessage(self.connection);
             std.log.warn("Error reading copy data: {s}", .{error_msg});
             return ReplicationError.ReceiveFailed;
@@ -398,8 +412,11 @@ pub const ReplicationProtocol = struct {
         }
     }
 
-    pub fn sendStatusUpdate(self: *Self, update: StandbyStatusUpdate) ReplicationError!void {
+    pub fn sendStatusUpdate(self: *Self, io: std.Io, update: StandbyStatusUpdate) ReplicationError!void {
         if (self.connection == null) return ReplicationError.ConnectionFailed;
+
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         // Build StandbyStatusUpdate message
         // Format: 'r' + WALWrite(8) + WALFlush(8) + WALApply(8) + ClientTime(8) + ReplyRequested(1)

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -157,7 +157,7 @@ pub const PostgresSource = struct {
             const wait_time: i32 = @intCast(@max(remaining.toMilliseconds(), 0));
 
             // Step 1: Blocking receive (poll() inside)
-            const repl_msg = self.protocol.receiveMessage(wait_time) catch |err| {
+            const repl_msg = self.protocol.receiveMessage(io, wait_time) catch |err| {
                 std.log.warn("Failed to receive replication message: {}", .{err});
                 return PostgresSourceError.ReplicationFailed;
             };
@@ -180,7 +180,7 @@ pub const PostgresSource = struct {
 
             // Step 2: DRAIN all buffered messages (non-blocking)
             while (changes.items.len < limit) {
-                const next_msg = self.protocol.receiveMessage(0) catch break; // 0ms wait time = non-blocking
+                const next_msg = self.protocol.receiveMessage(io, 0) catch break; // 0ms wait time = non-blocking
                 if (next_msg == null) break; // No more buffered data
 
                 var buffered_msg = next_msg.?;
@@ -274,7 +274,7 @@ pub const PostgresSource = struct {
             .reply_requested = false,
         };
 
-        self.protocol.sendStatusUpdate(status) catch |err| {
+        self.protocol.sendStatusUpdate(io, status) catch |err| {
             std.log.warn("Failed to send feedback: {}", .{err});
             return PostgresSourceError.ReplicationFailed;
         };


### PR DESCRIPTION
## Problem

The receive loop and the flush worker share one `PGconn`: the main thread calls `PQgetCopyData`/`PQconsumeInput`, the worker sends standby feedback via `PQputCopyData`/`PQflush`. libpq forbids using one connection from two threads: internal buffers are reallocated with no locking, and a blocked send even reads input from the writer thread (`pqSendSome` calls `pqReadData` on EWOULDBLOCK). Under load this race wedged the connection: `PQflush` stuck in `select()` forever and the process hung instead of failing fast.

## Solution

- Add `std.Io.Mutex` to `ReplicationProtocol`; every libpq call after startup takes it: the receive path, the feedback path, and the `PQerrorMessage` reads on error paths.
- The `poll()` wait stays outside the lock, so feedback never queues behind an idle wait. Contention is negligible: the worker locks once per flush interval to send 34 bytes.
- `lockUncancelable` on purpose: the critical sections are microseconds, and a cancelation point inside a libpq call would let shutdown interrupt the final LSN commit.
- A plain mutex, not RwLock: there is exactly one reader, and "reading" still mutates `PGconn` (buffer reallocs, error state), so shared locking would recreate the race.

Simpler alternative to #92: threading stays as is, only the connection access is serialized.