### PR TITLE
Validate REPLICA IDENTITY FULL for delete-tracking streams at startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,9 @@ TOML, secrets kept out of the file (see `docs/examples/config.toml`).
   (`mechanism`, `username`, `password_env`).
 - `[observability]` (optional; absent = off): `address`/`port` for a Prometheus
   `/metrics` plus `/healthz` and `/readyz` HTTP server.
-- Postgres needs `wal_level = logical` and `REPLICA IDENTITY FULL` on tracked
-  tables. Outboxx auto-creates the slot and publication.
+- Postgres needs `wal_level = logical`, plus `REPLICA IDENTITY FULL` on tables
+  whose stream tracks DELETE (validated at startup; UPDATE emits only the new
+  row, so it doesn't need it). Outboxx auto-creates the slot and publication.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ GRANT USAGE, CREATE ON SCHEMA public TO outboxx_user;
 -- Grant table access (SELECT needed for logical replication)
 GRANT SELECT ON TABLE my_table TO outboxx_user;
 
--- Enable REPLICA IDENTITY FULL (required for capturing complete row data in UPDATE/DELETE)
+-- Enable REPLICA IDENTITY FULL so DELETE events carry the full row.
+-- Required (and validated at startup) for tables whose stream tracks DELETE.
+-- UPDATE emits only the new row, so it does not need this.
 ALTER TABLE my_table REPLICA IDENTITY FULL;
 ```
 

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -113,7 +113,7 @@ pub const Stream = struct {
 
     /// Whether this stream captures DELETE. Config validation restricts operations
     /// to the lowercase set, so an exact match is enough.
-    pub fn tracksDelete(self: Stream) bool {
+    pub fn hasDeleteOperation(self: Stream) bool {
         for (self.source.operations) |op| {
             if (std.mem.eql(u8, op, "delete")) return true;
         }

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -110,6 +110,15 @@ pub const Stream = struct {
     source: StreamSource,
     flow: StreamFlow,
     sink: StreamSink,
+
+    /// Whether this stream captures DELETE. Config validation restricts operations
+    /// to the lowercase set, so an exact match is enough.
+    pub fn tracksDelete(self: Stream) bool {
+        for (self.source.operations) |op| {
+            if (std.mem.eql(u8, op, "delete")) return true;
+        }
+        return false;
+    }
 };
 
 pub const TableFilter = struct {

--- a/src/config/config_test.zig
+++ b/src/config/config_test.zig
@@ -81,6 +81,24 @@ test "createTestDefault" {
     try testing.expectEqualStrings("localhost:9092", cfg.sink.kafka.?.brokers[0]);
 }
 
+test "Stream.tracksDelete reflects the configured operations" {
+    const Stream = config.Stream;
+    const base: Stream = .{
+        .name = "s",
+        .source = .{ .resource = "users", .operations = &.{} },
+        .flow = .{ .format = "json" },
+        .sink = .{ .destination = "t", .routing_key = null },
+    };
+
+    var insert_update = base;
+    insert_update.source.operations = &.{ "insert", "update" };
+    try testing.expect(!insert_update.tracksDelete());
+
+    var with_delete = base;
+    with_delete.source.operations = &.{ "insert", "delete" };
+    try testing.expect(with_delete.tracksDelete());
+}
+
 test "supported adapter types are implemented" {
     try testing.expectEqual(@as(usize, 1), config.SupportedValues.SOURCE_TYPES.len);
     try testing.expectEqualStrings("postgres", config.SupportedValues.SOURCE_TYPES[0]);

--- a/src/config/config_test.zig
+++ b/src/config/config_test.zig
@@ -81,7 +81,7 @@ test "createTestDefault" {
     try testing.expectEqualStrings("localhost:9092", cfg.sink.kafka.?.brokers[0]);
 }
 
-test "Stream.tracksDelete reflects the configured operations" {
+test "Stream.hasDeleteOperation reflects the configured operations" {
     const Stream = config.Stream;
     const base: Stream = .{
         .name = "s",
@@ -92,11 +92,11 @@ test "Stream.tracksDelete reflects the configured operations" {
 
     var insert_update = base;
     insert_update.source.operations = &.{ "insert", "update" };
-    try testing.expect(!insert_update.tracksDelete());
+    try testing.expect(!insert_update.hasDeleteOperation());
 
     var with_delete = base;
     with_delete.source.operations = &.{ "insert", "delete" };
-    try testing.expect(with_delete.tracksDelete());
+    try testing.expect(with_delete.hasDeleteOperation());
 }
 
 test "supported adapter types are implemented" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -286,21 +286,20 @@ fn validatePostgres(allocator: std.mem.Allocator, cfg: Config, conninfo: []const
     try validator.checkWalLevel();
 
     for (cfg.streams) |stream| {
-        validateStreamTable(&validator, stream) catch |err| {
+        validator.checkTableExists("public", stream.source.resource) catch |err| {
             printStatus("ERROR: Table validation failed for '{s}': {}\n", .{ stream.source.resource, err });
             return err;
         };
+
+        // Only a stream that tracks DELETE needs REPLICA IDENTITY FULL, so the
+        // deleted row carries all columns. Schema is fixed to "public" for now.
+        if (stream.hasDeleteOperation()) {
+            validator.checkReplicaIdentity("public", stream.source.resource) catch |err| {
+                printStatus("ERROR: Replica identity validation failed for '{s}': {}\n", .{ stream.source.resource, err });
+                return err;
+            };
+        }
     }
 
     printStatus("PostgreSQL validation completed successfully!\n", .{});
-}
-
-// Validate the source table satisfies what a stream needs: it must exist, and a
-// stream that tracks DELETE needs REPLICA IDENTITY FULL so the deleted row carries
-// all columns. Schema is fixed to "public" until multi-schema support lands.
-fn validateStreamTable(validator: *PostgresValidator, stream: config_mod.Stream) !void {
-    try validator.checkTableExists("public", stream.source.resource);
-    if (stream.tracksDelete()) {
-        try validator.checkReplicaIdentityFull("public", stream.source.resource);
-    }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -286,11 +286,21 @@ fn validatePostgres(allocator: std.mem.Allocator, cfg: Config, conninfo: []const
     try validator.checkWalLevel();
 
     for (cfg.streams) |stream| {
-        validator.checkTableExists("public", stream.source.resource) catch |err| {
+        validateStreamTable(&validator, stream) catch |err| {
             printStatus("ERROR: Table validation failed for '{s}': {}\n", .{ stream.source.resource, err });
             return err;
         };
     }
 
     printStatus("PostgreSQL validation completed successfully!\n", .{});
+}
+
+// Validate the source table satisfies what a stream needs: it must exist, and a
+// stream that tracks DELETE needs REPLICA IDENTITY FULL so the deleted row carries
+// all columns. Schema is fixed to "public" until multi-schema support lands.
+fn validateStreamTable(validator: *PostgresValidator, stream: config_mod.Stream) !void {
+    try validator.checkTableExists("public", stream.source.resource);
+    if (stream.tracksDelete()) {
+        try validator.checkReplicaIdentityFull("public", stream.source.resource);
+    }
 }

--- a/src/source/postgres/validator.zig
+++ b/src/source/postgres/validator.zig
@@ -125,4 +125,46 @@ pub const PostgresValidator = struct {
 
         print("PostgreSQL validation: Table '{s}.{s}' exists ✓\n", .{ schema, table_name });
     }
+
+    /// Require REPLICA IDENTITY FULL on a table whose stream tracks DELETE, so the
+    /// deleted row carries all columns. Any other identity (default/index/nothing)
+    /// drops the non-key columns from the DELETE old row, breaking the documented
+    /// format. Call only for delete-tracking streams: FULL is irrelevant otherwise
+    /// and only inflates UPDATE WAL.
+    pub fn checkReplicaIdentityFull(self: *Self, schema: []const u8, table_name: []const u8) ValidationError!void {
+        const query = std.fmt.allocPrintSentinel(self.allocator, "SELECT c.relreplident FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '{s}' AND c.relname = '{s}';", .{ schema, table_name }, 0) catch return ValidationError.OutOfMemory;
+        defer self.allocator.free(query);
+
+        const result = try self.executeQuery(query.ptr);
+        defer c.PQclear(result);
+
+        // checkTableExists runs first, so an empty result only happens on a race
+        // (the table was dropped between the two queries).
+        if (c.PQntuples(result) == 0) {
+            std.log.warn("PostgreSQL validation: Table '{s}.{s}' not found while checking replica identity", .{ schema, table_name });
+            return ValidationError.TableNotFound;
+        }
+
+        const identity = std.mem.span(c.PQgetvalue(result, 0, 0));
+
+        if (identity.len == 0 or identity[0] != 'f') {
+            std.log.warn("PostgreSQL validation: Table '{s}.{s}' has REPLICA IDENTITY {s}, but this stream tracks DELETE and needs the full old row", .{ schema, table_name, replicaIdentityName(identity) });
+            std.log.warn("Fix: ALTER TABLE {s}.{s} REPLICA IDENTITY FULL", .{ schema, table_name });
+            return ValidationError.InvalidReplicaIdentity;
+        }
+
+        print("PostgreSQL validation: Table '{s}.{s}' REPLICA IDENTITY FULL ✓\n", .{ schema, table_name });
+    }
 };
+
+// Human-readable name for a pg_class.relreplident value, for the error message.
+fn replicaIdentityName(identity: []const u8) []const u8 {
+    if (identity.len == 0) return "unknown";
+    return switch (identity[0]) {
+        'd' => "default (primary key only)",
+        'i' => "index",
+        'n' => "nothing",
+        'f' => "full",
+        else => "unknown",
+    };
+}

--- a/src/source/postgres/validator.zig
+++ b/src/source/postgres/validator.zig
@@ -131,8 +131,8 @@ pub const PostgresValidator = struct {
     /// drops the non-key columns from the DELETE old row, breaking the documented
     /// format. Call only for delete-tracking streams: FULL is irrelevant otherwise
     /// and only inflates UPDATE WAL.
-    pub fn checkReplicaIdentityFull(self: *Self, schema: []const u8, table_name: []const u8) ValidationError!void {
-        const query = std.fmt.allocPrintSentinel(self.allocator, "SELECT c.relreplident FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '{s}' AND c.relname = '{s}';", .{ schema, table_name }, 0) catch return ValidationError.OutOfMemory;
+    pub fn checkReplicaIdentity(self: *Self, schema: []const u8, table_name: []const u8) ValidationError!void {
+        const query = try std.fmt.allocPrintSentinel(self.allocator, "SELECT c.relreplident FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '{s}' AND c.relname = '{s}';", .{ schema, table_name }, 0);
         defer self.allocator.free(query);
 
         const result = try self.executeQuery(query.ptr);

--- a/src/source/postgres/validator_test.zig
+++ b/src/source/postgres/validator_test.zig
@@ -81,6 +81,32 @@ test "PostgresValidator: invalid schema should error" {
     try testing.expectError(error.TableNotFound, result);
 }
 
+test "PostgresValidator: replica identity FULL passes" {
+    const allocator = testing.allocator;
+    var validator = PostgresValidator.init(allocator);
+    defer validator.deinit();
+
+    const conn_str = "host=localhost port=5432 dbname=outboxx_test user=postgres password=password";
+
+    try validator.connect(conn_str);
+    // users is set to REPLICA IDENTITY FULL by the dev init script.
+    try validator.checkReplicaIdentityFull("public", "users");
+}
+
+test "PostgresValidator: replica identity not FULL should error" {
+    const allocator = testing.allocator;
+    var validator = PostgresValidator.init(allocator);
+    defer validator.deinit();
+
+    const conn_str = "host=localhost port=5432 dbname=outboxx_test user=postgres password=password";
+
+    try validator.connect(conn_str);
+    // system_logs keeps the default replica identity (the init script never
+    // alters it), so a delete-tracking stream on it must be rejected.
+    const result = validator.checkReplicaIdentityFull("public", "system_logs");
+    try testing.expectError(error.InvalidReplicaIdentity, result);
+}
+
 test "PostgresValidator: invalid connection string should error" {
     const allocator = testing.allocator;
     var validator = PostgresValidator.init(allocator);
@@ -113,6 +139,9 @@ test "PostgresValidator: methods fail when not connected" {
 
     const table_result = validator.checkTableExists("public", "users");
     try testing.expectError(error.ConnectionFailed, table_result);
+
+    const identity_result = validator.checkReplicaIdentityFull("public", "users");
+    try testing.expectError(error.ConnectionFailed, identity_result);
 }
 
 // Note: Testing invalid PostgreSQL version and wal_level requires mocking or

--- a/src/source/postgres/validator_test.zig
+++ b/src/source/postgres/validator_test.zig
@@ -90,7 +90,7 @@ test "PostgresValidator: replica identity FULL passes" {
 
     try validator.connect(conn_str);
     // users is set to REPLICA IDENTITY FULL by the dev init script.
-    try validator.checkReplicaIdentityFull("public", "users");
+    try validator.checkReplicaIdentity("public", "users");
 }
 
 test "PostgresValidator: replica identity not FULL should error" {
@@ -103,7 +103,7 @@ test "PostgresValidator: replica identity not FULL should error" {
     try validator.connect(conn_str);
     // system_logs keeps the default replica identity (the init script never
     // alters it), so a delete-tracking stream on it must be rejected.
-    const result = validator.checkReplicaIdentityFull("public", "system_logs");
+    const result = validator.checkReplicaIdentity("public", "system_logs");
     try testing.expectError(error.InvalidReplicaIdentity, result);
 }
 
@@ -140,7 +140,7 @@ test "PostgresValidator: methods fail when not connected" {
     const table_result = validator.checkTableExists("public", "users");
     try testing.expectError(error.ConnectionFailed, table_result);
 
-    const identity_result = validator.checkReplicaIdentityFull("public", "users");
+    const identity_result = validator.checkReplicaIdentity("public", "users");
     try testing.expectError(error.ConnectionFailed, identity_result);
 }
 


### PR DESCRIPTION
Closes #79.

## Problem

The docs require `REPLICA IDENTITY FULL`, but nothing checked it. With the default identity the pipeline runs fine, and only DELETE events silently drop the non-key columns from the old row, contradicting the documented format. The `InvalidReplicaIdentity` error was declared in the validator but never used.

## Solution

- Add `PostgresValidator.checkReplicaIdentityFull`: reads `pg_class.relreplident` and fails with an actionable `ALTER TABLE ... REPLICA IDENTITY FULL` message unless the identity is `f`.
- Run it per stream during startup validation, but only when the stream tracks DELETE (`Stream.tracksDelete`). Replica identity is irrelevant for INSERT, and UPDATE emits only the new row, so an insert/update-only stream is not rejected and does not pay FULL's extra UPDATE WAL.
- Fail fast at startup rather than guarding at runtime: a wrong identity is a config/setup problem the operator must fix.

## Test

- Integration: FULL table passes, a default-identity table errors with `InvalidReplicaIdentity`, and the check reports `ConnectionFailed` when not connected.
- Unit: `Stream.tracksDelete` is false for insert/update-only and true when delete is present, proving delete-free streams skip the check.

Docs (README, AGENTS.md) updated: FULL is needed on tables whose stream tracks DELETE, not on every tracked table.