### PR TITLE
Snapshot the pending LSN before flush to keep feedback behind delivery

### DIFF
--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -73,15 +73,15 @@ fn flushCommitWorker(
 
         iterations = 0;
 
-        producer.flush(constants.CDC.KAFKA_FLUSH_TIMEOUT_MS) catch |err| {
-            std.log.err("Background flush failed: {}", .{err});
-            continue;
-        };
-
         const lsn = pending_lsn.load(.acquire);
         if (lsn == 0) {
             continue;
         }
+
+        producer.flush(constants.CDC.KAFKA_FLUSH_TIMEOUT_MS) catch |err| {
+            std.log.err("Background flush failed: {}", .{err});
+            continue;
+        };
 
         source.sendFeedback(io, lsn) catch |err| {
             std.log.err("Background LSN commit failed: {}", .{err});
@@ -89,11 +89,12 @@ fn flushCommitWorker(
         };
     }
 
+    const lsn = pending_lsn.load(.acquire);
+
     producer.flush(constants.CDC.KAFKA_FLUSH_TIMEOUT_MS) catch |err| {
         std.log.warn("Final background flush failed: {}", .{err});
     };
 
-    const lsn = pending_lsn.load(.acquire);
     if (lsn > 0) {
         source.sendFeedback(io, lsn) catch |err| {
             std.log.warn("Final background LSN commit failed: {}", .{err});


### PR DESCRIPTION
## Problem

Race in `flushCommitWorker`: it read `pending_lsn` *after* `producer.flush()`. The receive loop stores a batch LSN right after enqueueing its messages, so a batch landing during the flush would bump `pending_lsn`, and the worker then confirmed that LSN while the new batch's messages were still queued. A crash in that window lost them: the slot had advanced, Postgres won't re-send.

Invariant: confirmed LSN <= the highest LSN whose messages have been flushed.

## Solution

- Read the `pending_lsn` snapshot before `flush()` and confirm the snapshot after. Its messages were enqueued before its `store(.release)`, so a successful flush (queue drained) guarantees delivery.
- Same reorder in the final flush on graceful shutdown.

Closes #73.