### PR TITLE
Fail fast on Kafka delivery failures instead of confirming the LSN

### DIFF
--- a/src/kafka/producer.zig
+++ b/src/kafka/producer.zig
@@ -32,8 +32,27 @@ pub const KafkaProducer = struct {
     producer: ?*c.rd_kafka_t,
     allocator: std.mem.Allocator,
     topics: std.StringHashMap(*c.rd_kafka_topic_t),
+    // Heap-allocated so its address stays stable when the struct is moved into
+    // the Processor: it is handed to librdkafka as the delivery-callback opaque.
+    delivery_errors: *std.atomic.Value(u64),
 
     const Self = @This();
+
+    // librdkafka's delivery report, served during poll/flush on the calling
+    // thread. A non-zero err means the message permanently failed, so count it.
+    fn deliveryReportCallback(
+        rk: ?*c.rd_kafka_t,
+        rkmessage: [*c]const c.rd_kafka_message_t,
+        opaque_ctx: ?*anyopaque,
+    ) callconv(.c) void {
+        _ = rk;
+        if (rkmessage == null or opaque_ctx == null) return;
+        if (rkmessage[0].err == c.RD_KAFKA_RESP_ERR_NO_ERROR) return;
+
+        const counter: *std.atomic.Value(u64) = @ptrCast(@alignCast(opaque_ctx.?));
+        _ = counter.fetchAdd(1, .monotonic);
+        std.log.warn("Kafka delivery failed: {s}", .{c.rd_kafka_err2str(rkmessage[0].err)});
+    }
 
     fn logCallback(
         rk: ?*const c.rd_kafka_t,
@@ -97,6 +116,15 @@ pub const KafkaProducer = struct {
         // Set custom log callback for full control over librdkafka logs
         c.rd_kafka_conf_set_log_cb(conf, logCallback);
 
+        // Without dr_msg_cb, librdkafka discards delivery reports and flush()
+        // reports success even for messages that permanently failed. Count them
+        // via the callback opaque so the worker won't confirm unsent data.
+        const delivery_errors = try allocator.create(std.atomic.Value(u64));
+        errdefer allocator.destroy(delivery_errors);
+        delivery_errors.* = std.atomic.Value(u64).init(0);
+        c.rd_kafka_conf_set_dr_msg_cb(conf, deliveryReportCallback);
+        c.rd_kafka_conf_set_opaque(conf, delivery_errors);
+
         // Set bootstrap servers
         try setConfigSlice(allocator, conf, "bootstrap.servers", brokers, &errstr);
 
@@ -138,6 +166,7 @@ pub const KafkaProducer = struct {
             .producer = producer,
             .allocator = allocator,
             .topics = std.StringHashMap(*c.rd_kafka_topic_t).init(allocator),
+            .delivery_errors = delivery_errors,
         };
     }
 
@@ -156,6 +185,9 @@ pub const KafkaProducer = struct {
             c.rd_kafka_destroy(producer);
             std.log.debug("producer.deinit: destroyed", .{});
         }
+
+        // After rd_kafka_destroy: no callback can touch the counter anymore.
+        self.allocator.destroy(self.delivery_errors);
     }
 
     fn getOrCreateTopic(self: *Self, topic_name: []const u8) !*c.rd_kafka_topic_t {
@@ -286,6 +318,27 @@ pub const KafkaProducer = struct {
         }
     }
 
+    /// Count of messages that permanently failed delivery over the producer's
+    /// lifetime, as reported by the delivery callback. Monotonic: a non-zero
+    /// value means the at-least-once guarantee is broken and demands a restart.
+    pub fn deliveryErrorCount(self: *Self) u64 {
+        return self.delivery_errors.load(.monotonic);
+    }
+
+    /// Whether the producer hit an unrecoverable error. Idempotent-producer
+    /// fatal errors surface only here, not on individual messages. Logs the
+    /// librdkafka reason when fatal; the producer must be recreated after.
+    pub fn fatalError(self: *Self) bool {
+        const producer = self.producer orelse return false;
+
+        var errstr: [512]u8 = undefined;
+        const err = c.rd_kafka_fatal_error(producer, &errstr, errstr.len);
+        if (err == c.RD_KAFKA_RESP_ERR_NO_ERROR) return false;
+
+        std.log.err("Kafka producer fatal error: {s}", .{std.mem.sliceTo(&errstr, 0)});
+        return true;
+    }
+
     pub fn testConnection(self: *Self) !void {
         const producer = self.producer orelse return KafkaError.ConnectionTestFailed;
 
@@ -316,15 +369,35 @@ pub const KafkaProducer = struct {
 };
 
 // Unit tests
-test "KafkaProducer initialization" {
+test "delivery callback counts a permanently failed message" {
     const testing = std.testing;
-
-    // This test will only pass if Kafka is running
-    // For now, we just test the structure
     const allocator = testing.allocator;
 
-    // Test that we can create and destroy the producer structure
-    // without actually connecting to Kafka
-    _ = allocator;
-    // Mock tests can be added when a testing framework is set up
+    // Mock cluster to point the producer at; its own rd_kafka_t only hosts it.
+    var errstr: [512]u8 = undefined;
+    const mock_rk = c.rd_kafka_new(c.RD_KAFKA_PRODUCER, c.rd_kafka_conf_new(), &errstr, errstr.len);
+    try testing.expect(mock_rk != null);
+    defer c.rd_kafka_destroy(mock_rk);
+
+    const mcluster = c.rd_kafka_mock_cluster_new(mock_rk, 1);
+    try testing.expect(mcluster != null);
+    defer c.rd_kafka_mock_cluster_destroy(mcluster);
+
+    const bootstraps = std.mem.span(c.rd_kafka_mock_cluster_bootstraps(mcluster));
+    try testing.expect(c.rd_kafka_mock_topic_create(mcluster, "t", 1, 1) == c.RD_KAFKA_RESP_ERR_NO_ERROR);
+
+    // Reject the next Produce with a non-retriable error, so the message fails
+    // delivery at once instead of retrying for delivery.timeout.ms. The ApiKey
+    // for ProduceRequest is 0; RD_KAFKAP_* names are not in the public headers.
+    const produce_api_key: i16 = 0;
+    c.rd_kafka_mock_push_request_errors(mcluster, produce_api_key, 1, c.RD_KAFKA_RESP_ERR_TOPIC_AUTHORIZATION_FAILED);
+
+    var producer = try KafkaProducer.init(allocator, bootstraps, null);
+    defer producer.deinit();
+
+    try producer.sendMessage("t", "k", "{}");
+    // flush serves the delivery callback on this thread, counting the failure.
+    producer.flush(5000) catch {};
+
+    try testing.expect(producer.deliveryErrorCount() > 0);
 }

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -83,6 +83,13 @@ fn flushCommitWorker(
             continue;
         };
 
+        // A drained queue is not a delivered queue: a message can leave it by
+        // permanently failing. Hold the LSN if any did; the receive loop turns
+        // this into a fail-fast.
+        if (producer.deliveryErrorCount() > 0) {
+            continue;
+        }
+
         source.sendFeedback(io, lsn) catch |err| {
             std.log.err("Background LSN commit failed: {}", .{err});
             continue;
@@ -95,7 +102,7 @@ fn flushCommitWorker(
         std.log.warn("Final background flush failed: {}", .{err});
     };
 
-    if (lsn > 0) {
+    if (lsn > 0 and producer.deliveryErrorCount() == 0) {
         source.sendFeedback(io, lsn) catch |err| {
             std.log.warn("Final background LSN commit failed: {}", .{err});
         };
@@ -258,6 +265,14 @@ pub const Processor = struct {
             const batch_alloc = batch_arena.allocator();
 
             try self.processChangesToKafka(io, batch_alloc, constants.CDC.BATCH_SIZE);
+
+            // A permanent delivery failure (or fatal producer error) means data
+            // never reached Kafka. Fail fast so the slot re-sends from the last
+            // confirmed LSN after restart.
+            if (self.producer.deliveryErrorCount() > 0 or self.producer.fatalError()) {
+                std.log.warn("Kafka delivery failed; exiting for restart", .{});
+                return error.DeliveryFailed;
+            }
 
             // A stream quiet past the liveness window (no change and no keepalive)
             // is dead: a frozen or black-holed peer sends no FIN/RST, so reads just

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -176,6 +176,12 @@ pub const Processor = struct {
         var event_counts = std.ArrayList(EventCount).empty;
         defer event_counts.deinit(batch_allocator);
 
+        // With dr_msg_cb registered, a produced message counts against
+        // queue.buffering.max.messages until its delivery report is served by a
+        // poll. Serve them every KAFKA_POLL_INTERVAL sends so a large batch does
+        // not fill the queue before the single poll at the end.
+        var sent_since_poll: u32 = 0;
+
         for (batch.changes) |change_event| {
             var matched = try matchStreams(batch_allocator, self.streams, change_event);
             defer matched.deinit(batch_allocator);
@@ -197,6 +203,12 @@ pub const Processor = struct {
                 };
 
                 try tallyEvent(&event_counts, batch_allocator, stream.name, change_event.op);
+
+                sent_since_poll += 1;
+                if (sent_since_poll >= constants.CDC.KAFKA_POLL_INTERVAL) {
+                    producer.poll();
+                    sent_since_poll = 0;
+                }
 
                 self.events_processed += 1;
                 if (self.events_processed % 10000 == 0) {

--- a/tests/load/Makefile
+++ b/tests/load/Makefile
@@ -21,7 +21,7 @@ REPORT_INTERVAL ?= 5
 
 MINUTES ?= 60
 
-.PHONY: infra infra-up load start-debezium start-outboxx start-all reset create-slots slots status topics offsets results logs ps
+.PHONY: infra infra-up load start-debezium start-outboxx start-all reset create-slots slots status topics offsets check-gaps results logs ps
 
 # Bring infra up and ensure slots exist, leaving any running CDC readers alone.
 infra-up:
@@ -84,6 +84,10 @@ topics:
 offsets:
 	-$(COMPOSE) exec kafka /kafka/bin/kafka-get-offsets.sh --bootstrap-server kafka:9092 --topic debezium.public.benchmark_records
 	-$(COMPOSE) exec kafka /kafka/bin/kafka-get-offsets.sh --bootstrap-server kafka:9092 --topic outboxx.public.benchmark_records
+
+# Check the outboxx topic lost no message: every assigned id must be present.
+check-gaps:
+	@COMPOSE="$(COMPOSE)" bash scripts/check-gaps.sh
 
 results:
 	@MINUTES=$(MINUTES) bash scripts/results.sh

--- a/tests/load/scripts/check-gaps.sh
+++ b/tests/load/scripts/check-gaps.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Verify the outboxx topic lost no message: every id the source assigned must
+# appear at least once. Ids come from a BIGSERIAL (benchmark_records.id), so the
+# assigned space is 1..last_value; a missing id inside it is a dropped message.
+#
+# Source of truth is the sequence last_value, not max(id) in the table: deletes
+# remove rows but the id was still emitted, so the sequence is the only count
+# that survives deletes. Reads the topic from the beginning in a throwaway group,
+# so it is safe to run while outboxx keeps producing.
+#
+# The read is bounded by the topic's current end offsets, not by an idle timeout:
+# while outboxx keeps producing, a message always arrives before any idle window
+# elapses, so a timeout-based consumer would never stop. Snapshot the high
+# watermark and read exactly that many messages instead.
+#
+# Exit non-zero if a gap is found. Override with TOPIC=... IDLE_MS=... .
+set -euo pipefail
+
+COMPOSE="${COMPOSE:-docker compose}"
+TOPIC="${TOPIC:-outboxx.public.benchmark_records}"
+IDLE_MS="${IDLE_MS:-10000}" # fallback stop if fewer messages are readable than the snapshot
+
+# COMPOSE may start with env-var assignments (VAR=val ... docker compose -p ...).
+# After expansion the shell would treat the leading VAR=val as the command, so
+# run it through env, which consumes the assignments before the real command.
+compose() { env $COMPOSE "$@"; }
+
+# Highest id the source ever assigned. NULL (never called) -> 0.
+last_value="$(
+  compose exec -T postgres psql -U postgres -d bench -tAc \
+    "SELECT COALESCE(last_value, 0) FROM pg_sequences
+      WHERE schemaname = 'public' AND sequencename = 'benchmark_records_id_seq'"
+)"
+last_value="${last_value:-0}"
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+# Snapshot the current end offset (sum over partitions) as the message count to
+# read. Bounds the consumer so it stops even while the topic keeps growing.
+end_total="$(
+  compose exec -T kafka /kafka/bin/kafka-get-offsets.sh \
+    --bootstrap-server kafka:9092 --topic "$TOPIC" \
+    | awk -F: '{ sum += $3 } END { print sum + 0 }'
+)"
+
+if [ "$end_total" -eq 0 ]; then
+  echo "Topic $TOPIC is empty: no messages to check."
+  [ "$last_value" -gt 0 ] && exit 1 || exit 0
+fi
+
+echo "Consuming $end_total message(s) from $TOPIC (snapshot end offset)..."
+# --max-messages stops at the snapshot; --timeout-ms is only a fallback if fewer
+# are actually readable (e.g. retention trimmed the head). Tolerate its non-zero
+# exit and work off what it printed.
+compose exec -T kafka /kafka/bin/kafka-console-consumer.sh \
+  --bootstrap-server kafka:9092 --topic "$TOPIC" \
+  --from-beginning --max-messages "$end_total" --timeout-ms "$IDLE_MS" >"$tmp" 2>/dev/null || true
+
+# Sorted ids (duplicates kept), one pass for range, distinct/dup counts, gaps.
+jq -r '.data.id // empty' "$tmp" | sort -n | awk -v last="$last_value" '
+  NR == 1 { min = $1; max = $1; distinct = 1; prev = $1; next }
+  $1 != prev {
+    if ($1 > prev + 1) {
+      holes += $1 - prev - 1
+      if (shown < 10) { printf "  missing id range %d..%d\n", prev + 1, $1 - 1; shown++ }
+    }
+    distinct++; max = $1; prev = $1
+  }
+  END {
+    if (NR == 0) { print "Topic is empty: no messages to check."; exit (last > 0 ? 1 : 0) }
+
+    duplicates = NR - distinct
+    printf "messages: %d   distinct ids: %d   duplicates: %d\n", NR, distinct, duplicates
+    printf "range: %d..%d   sequence last_value: %d\n", min, max, last
+
+    fail = 0
+    if (holes > 0)   { printf "GAP: %d id(s) missing inside %d..%d\n", holes, min, max; fail = 1 }
+    if (max < last)  { printf "GAP: topic ends at %d but source reached %d (%d tail id(s) missing)\n", max, last, last - max; fail = 1 }
+    if (min > 1)     { printf "NOTE: first id is %d, not 1 (topic retention or a trimmed run?)\n", min }
+
+    if (fail == 0) printf "OK: no gaps, every assigned id present (%d duplicate re-deliveries).\n", duplicates
+    exit fail
+  }'


### PR DESCRIPTION
## Problem

`KafkaProducer.init` never registered a delivery report callback. Without `dr_msg_cb`, librdkafka discards per-message reports and `rd_kafka_flush()` only waits for the queue to drain. A message that permanently fails delivery (after `delivery.timeout.ms`) leaves the queue, `flush()` still returns `NO_ERROR`, and the flush/commit worker confirms its LSN. The slot advances past data that never reached Kafka: silent loss, breaking at-least-once.

## Solution

- Register `dr_msg_cb` and count permanently failed deliveries through the callback opaque (a heap-allocated atomic, stable across the struct move into the Processor).
- Flush/commit worker holds the LSN while the failure count is non-zero, so a failed message is never confirmed.
- Receive loop checks the count and `rd_kafka_fatal_error()` (idempotent-producer fatals surface only there) after each batch and exits non-zero, so the slot re-sends from the last confirmed position after restart.
- Unit test: mock cluster injects a non-retriable Produce error; assert the failure count increments.

Closes #72.