### PR TITLE
Request a keepalive with each LSN feedback to keep idle-stream liveness fed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,8 +129,11 @@ TOML, secrets kept out of the file (see `docs/examples/config.toml`).
   `len=0` (looks idle, `CONNECTION_OK`) forever; `docker pause` reproduces it,
   60s of silence with no error. Polling faster does not help: there is no signal
   to read. The source catches this with a liveness deadline: no message (a
-  change or a server keepalive) for `LIVENESS_MAX_STALE_SEC` (90s, must exceed
-  the server keepalive interval ~`wal_sender_timeout/2`) yields `StreamStalled`
-  and fail-fast. The `/healthz` heartbeat is refreshed only by real wire
-  activity, for the same reason (an empty batch on a dead stream must not look
-  alive).
+  change or a server keepalive) for `LIVENESS_MAX_STALE_SEC` (90s) yields
+  `StreamStalled` and fail-fast. An idle stream is kept alive by our own probe:
+  each LSN feedback requests an immediate keepalive back (`reply_requested`),
+  because regular feedback suppresses the walsender's own probes (it only sends
+  one after ~`wal_sender_timeout/2` of client silence) and a quiet cluster
+  would otherwise trip the deadline in a restart loop (#111). The `/healthz`
+  heartbeat is refreshed only by real wire activity, for the same reason (an
+  empty batch on a dead stream must not look alive).

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -35,7 +35,9 @@ pub const OBSERVABILITY = struct {
     // keepalive) before the stream is considered dead. One signal, two readers:
     // the /healthz probe and the receive loop's fail-fast on a silently stalled
     // stream (a frozen or dead peer sends no FIN/RST, so it looks idle, not
-    // broken). Must exceed the server keepalive interval (~wal_sender_timeout/2,
-    // default 30s) with margin, or a healthy idle stream would trip it.
+    // broken). On an idle stream the wire is fed by the keepalive the server
+    // returns to each feedback's reply request (every KAFKA_FLUSH_INTERVAL_SEC),
+    // with the server's own probe (~wal_sender_timeout/2, default 30s) as the
+    // fallback before the first confirmed LSN. Must exceed both with margin.
     pub const LIVENESS_MAX_STALE_SEC: i64 = 90;
 };

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -284,7 +284,13 @@ pub const PostgresSource = struct {
             .wal_flush_position = lsn,
             .wal_apply_position = lsn,
             .client_time = std.Io.Timestamp.now(io, .real).toSeconds(),
-            .reply_requested = false,
+            // Request an immediate keepalive back. Our regular feedback keeps the
+            // walsender quiet (it only probes after wal_sender_timeout/2 of client
+            // silence), so an idle stream would carry no inbound traffic and trip
+            // the liveness deadline (#111). The requested reply feeds liveness on
+            // every feedback cycle; a frozen peer cannot answer, so stall
+            // detection still fires.
+            .reply_requested = true,
         };
 
         self.protocol.sendStatusUpdate(io, status) catch |err| {


### PR DESCRIPTION
## Problem

The flush/commit worker re-sends feedback every 10s, which keeps the walsender quiet: it only probes after `wal_sender_timeout/2` of client silence. On a cluster with no write traffic the stream carries zero inbound bytes, the liveness deadline (90s) trips, and the process restarts in a permanent ~100s loop. Observed live on the load stand: 31 `StreamStalled` restarts.

## Solution

- Set `reply_requested` on the standby status update. The server answers each feedback with an immediate keepalive, so a healthy idle stream sees inbound traffic every flush interval (10s) and liveness stays fresh, independent of `wal_sender_timeout`. A frozen peer cannot answer, so stall detection still fires.
- Updated the `LIVENESS_MAX_STALE_SEC` comment and the AGENTS.md gotcha to describe the probe.

Verified on the load stand (previously restarting every ~100s):
- 5.5 min idle with the fix: 0 stalls, 0 restarts, `/healthz` 200.
- `docker pause` on Postgres: `StreamStalled` fired in 85s, clean recovery after unpause.

Closes #111.