### PR TITLE
Run the release end to end on version tags

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,88 @@
+name: Auto-tag Release
+
+# Mint the release tag from the version in build.zig.zon: after a merge to
+# main, if v{version} does not exist yet and CHANGELOG.md has that version's
+# section, tag the merge commit and dispatch the release workflow on it.
+#
+# Idempotent by construction: an existing tag makes every later merge a no-op,
+# so reverts and repeated runs cannot re-release. The release workflow is
+# dispatched explicitly because events created with GITHUB_TOKEN do not
+# trigger other workflows (GitHub's recursion guard), so the tag push alone
+# would not start it.
+
+on:
+  push:
+    branches: [main]
+
+# Serialize runs so two quick merges cannot race the exists-check.
+concurrency:
+  group: auto-tag-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  tag:
+    name: Tag when the version is new
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Read version
+        id: version
+        run: |
+          version="$(awk -F'"' '/\.version =/ {print $2; exit}' build.zig.zon)"
+          if [ -z "$version" ]; then
+            echo "failed to read .version from build.zig.zon" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Check tag and changelog
+        id: check
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if git ls-remote --exit-code origin "refs/tags/v${VERSION}" >/dev/null; then
+            echo "v${VERSION} already exists; nothing to release" >> "$GITHUB_STEP_SUMMARY"
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Require the version's CHANGELOG section before minting the tag:
+          # a missing section would otherwise fail the release only after the
+          # image is published, leaving a half-done release behind an
+          # already-existing tag.
+          if ! awk -v ver="$VERSION" '/^## / { on = ($2 == ver); next } on' CHANGELOG.md | grep -q .; then
+            echo "v${VERSION} is untagged but CHANGELOG.md has no \"## ${VERSION}\" section; not releasing" >> "$GITHUB_STEP_SUMMARY"
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "release=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push tag
+        if: steps.check.outputs.release == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          if ! git push origin "v${VERSION}"; then
+            # Lost a race with a concurrent run; fine if the tag now exists.
+            git ls-remote --exit-code origin "refs/tags/v${VERSION}" >/dev/null
+            echo "v${VERSION} was pushed by a concurrent run" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+      - name: Dispatch release workflow
+        if: steps.check.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh workflow run release.yml --ref "v${VERSION}"
+          echo "released v${VERSION}: tagged and dispatched release.yml" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
-name: Publish Docker Image
+name: Release
 
 on:
   workflow_dispatch:
+  push:
+    tags: ["v*.*.*"]
 
 permissions:
   contents: read
@@ -35,6 +37,12 @@ jobs:
             echo "failed to read .version from build.zig.zon" >&2
             exit 1
           fi
+          # A tag must release exactly the version the source claims, or the
+          # image/binary labels and the tag would disagree.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [ "${GITHUB_REF_NAME}" != "v${version}" ]; then
+            echo "tag ${GITHUB_REF_NAME} does not match build.zig.zon version v${version}" >&2
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
@@ -55,6 +63,25 @@ jobs:
             --tag "${IMAGE_NAME}:sha-${GITHUB_SHA::12}-${ARCH}" \
             .
           docker run --rm "${IMAGE_NAME}:${VERSION}-${ARCH}" --version
+
+      # The release binary is the exact file shipped in the image, byte for byte,
+      # not a separate build that could drift from it.
+      - name: Extract binary from image
+        env:
+          ARCH: ${{ matrix.arch }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          id="$(docker create "${IMAGE_NAME}:${VERSION}-${ARCH}")"
+          docker cp "${id}:/app/outboxx" outboxx
+          docker rm "${id}" >/dev/null
+          tar -czf "outboxx-${VERSION}-linux-${ARCH}.tar.gz" outboxx
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.arch }}
+          path: outboxx-*.tar.gz
+          if-no-files-found: error
 
       - name: Push image
         env:
@@ -111,3 +138,40 @@ jobs:
             echo "- Build tag: \`${IMAGE_NAME}:${VERSION}-${{ github.run_number }}\`"
             echo "- Commit tag: \`${IMAGE_NAME}:sha-${GITHUB_SHA::12}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  github-release:
+    name: GitHub release
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-24.04
+    needs: publish
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: binary-*
+          merge-multiple: true
+
+      - name: Collect release notes
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          # The section for this version in CHANGELOG.md: from its "## X.Y.Z"
+          # heading (exclusive) to the next "## " heading.
+          awk -v ver="$version" '/^## / { on = ($2 == ver); next } on' CHANGELOG.md > notes.md
+          if ! [ -s notes.md ]; then
+            echo "CHANGELOG.md has no \"## ${version}\" section; move Unreleased under it before tagging" >&2
+            exit 1
+          fi
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" outboxx-*.tar.gz \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to Outboxx are documented here.
 
 ### Added
 
-- Release workflow for tags matching `v*.*.*`.
+- Release workflow for tags matching `v*.*.*`: verifies the tag against the
+  `build.zig.zon` version, then publishes the GHCR image and a GitHub release
+  with `linux/amd64` + `linux/arm64` binaries (extracted from the image, so
+  they are byte-identical to it) and notes taken from this file's section for
+  the released version.
 - Manual GitHub Actions workflow that publishes a multi-stage GHCR image for
   `linux/amd64` and `linux/arm64` using the version from `build.zig.zon`.
 - `outboxx --version` and `outboxx --help` for release smoke checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to Outboxx are documented here.
   with `linux/amd64` + `linux/arm64` binaries (extracted from the image, so
   they are byte-identical to it) and notes taken from this file's section for
   the released version.
+- Auto-tagging: a merge to main whose `build.zig.zon` version has no `v*` tag
+  yet (and has its section in this file) is tagged automatically and the
+  release workflow is dispatched on the new tag, so a release is one merged
+  PR: move Unreleased under the version heading and bump the version.
 - Manual GitHub Actions workflow that publishes a multi-stage GHCR image for
   `linux/amd64` and `linux/arm64` using the version from `build.zig.zon`.
 - `outboxx --version` and `outboxx --help` for release smoke checks.


### PR DESCRIPTION
## Problem

The release workflow only ran by hand (`workflow_dispatch`) and only published the Docker image. No prebuilt binaries, no GitHub release, so #52 stayed open.

## Solution

Release fires from a merged PR, no manual tagging:

- `auto-tag.yml`: after a merge to main, if `v{build.zig.zon version}` does not exist and CHANGELOG.md has that version's section, the merge commit is tagged and the release workflow is dispatched on the tag. An existing tag makes later merges a no-op, so reverts and repeats cannot re-release. The dispatch is explicit because a tag pushed with `GITHUB_TOKEN` does not trigger other workflows.
- The CHANGELOG check runs before minting the tag: failing it later would leave a half-published release behind an already-existing tag.
- `release.yml` also triggers on manual `v*.*.*` tag pushes; a guard fails the run if the tag disagrees with the `build.zig.zon` version.
- The per-arch image jobs extract `/app/outboxx` from the built image and upload it as `outboxx-{version}-linux-{arch}.tar.gz`. The binary is the exact file the image ships, not a parallel build.
- A tag-only `github-release` job (needs `contents: write`) creates the GitHub release with both tarballs and notes taken from the CHANGELOG section for the released version.

Release flow: one PR that moves `Unreleased` under `## X.Y.Z` in CHANGELOG.md and sets the version in `build.zig.zon`. Merge it, everything else is automatic.

Activation is safe: main currently has version `0.2.0` with no `## 0.2.0` section in CHANGELOG.md and only suffixed historical tags (`v0.2.0-zig0.16`), so the first runs skip until a real release PR lands.

No macOS binaries: the dynamic libpq/librdkafka linkage does not travel; Docker covers non-Linux use for now.

Closes #52.