### PR TITLE
Release 0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,8 @@ jobs:
 
       - name: Dump service logs on failure
         if: failure()
-        run: docker-compose logs --tail=40
+        # The runner only ships the compose v2 plugin, not standalone docker-compose.
+        run: docker compose logs --tail=40
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,12 +264,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Download binaries
-        uses: actions/download-artifact@v4
-        with:
-          pattern: binary-*
-          merge-multiple: true
-
       - name: Collect release notes
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -281,10 +275,13 @@ jobs:
             exit 1
           fi
 
+      # No binary assets: the nix-built binary hardwires its ELF interpreter to
+      # a /nix/store path and only runs inside the image, which carries the
+      # whole closure. Portable standalone binaries need a static build first.
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" outboxx-*.tar.gz \
+          gh release create "${GITHUB_REF_NAME}" \
             --title "${GITHUB_REF_NAME}" \
             --notes-file notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and restart cycles).
   `build.zig.zon` version, then publishes the `linux/amd64` + `linux/arm64`
   GHCR image and a GitHub release with notes taken from this file's section
   for the released version.
+- Static (musl) release binaries for `linux/amd64` and `linux/arm64`,
+  attached to the GitHub release. Each build is smoke-tested in CI end to
+  end before publishing: the binary starts against real Postgres and Kafka
+  and one INSERT is read back from the topic.
 - Auto-tagging: a merge to main whose `build.zig.zon` version has no `v*` tag
   yet (and has its section in this file) is tagged automatically and the
   release workflow is dispatched on the new tag, so a release is one merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,17 @@ All notable changes to Outboxx are documented here.
 
 ## Unreleased
 
+## 0.3.0 - 2026-07-18
+
+First GA release: the at-least-once guarantee is now enforced end to end and
+verified on the load stand (11.5M messages, zero gaps across repeated crash
+and restart cycles).
+
 ### Added
 
+- Observability endpoints: Prometheus `/metrics` (events by stream and
+  operation, replication lag, produce errors) plus `/healthz` and `/readyz`.
+- Kafka sink TLS (on by default) and SASL authentication.
 - Release workflow for tags matching `v*.*.*`: verifies the tag against the
   `build.zig.zon` version, then publishes the `linux/amd64` + `linux/arm64`
   GHCR image and a GitHub release with notes taken from this file's section
@@ -17,3 +26,36 @@ All notable changes to Outboxx are documented here.
 - Manual GitHub Actions workflow that publishes a multi-stage GHCR image for
   `linux/amd64` and `linux/arm64` using the version from `build.zig.zon`.
 - `outboxx --version` and `outboxx --help` for release smoke checks.
+
+### Changed
+
+- `meta.timestamp` is the transaction's commit time (stable across replays,
+  was processing time); `meta.lsn` carries the record's WAL position in
+  pg_lsn text form as a dedup key for redeliveries (was always null).
+- Column values map to native JSON types by column OID (int, float, bool);
+  `numeric` and everything else stays a string to never lose precision.
+  Unchanged TOAST columns emit a placeholder instead of a fake null.
+- The Postgres connection is an env-supplied libpq conninfo named by
+  `connection_env`; the password never appears in the config file.
+- Release builds default to ReleaseFast with the libc allocator; the Docker
+  image runs on a scratch runtime.
+
+### Fixed
+
+- The replication slot LSN is confirmed only after Kafka delivery is
+  verified: the LSN is snapshotted before the flush, delivery reports gate
+  the confirmation, and a permanently failed delivery stops the process
+  instead of silently dropping data.
+- A silently stalled replication stream (a frozen peer looks idle, not
+  broken) trips a liveness deadline and ends the process for the supervisor
+  to restart; an idle stream no longer restarts in a loop, because every LSN
+  feedback requests a keepalive back.
+- Access to the shared libpq replication connection is serialized between
+  the receive loop and the flush worker.
+- Streams match tables only in the `public` schema, so a same-named table in
+  another schema cannot leak into a stream.
+- `REPLICA IDENTITY FULL` is validated at startup for delete-tracking
+  streams; slot and publication names are folded to lowercase.
+- JSON output escapes all mandatory characters via the stdlib encoder;
+  unhandled pgoutput message types are skipped instead of crash-looping;
+  unimplemented config adapters are rejected at startup.

--- a/build.zig
+++ b/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
         []const u8,
         "version",
         "Version string embedded into the outboxx binary",
-    ) orelse "0.2.0";
+    ) orelse "0.3.0";
 
     // Minimum log level compiled in. Default info keeps Release/prod output clean
     // (lower levels are filtered at comptime); the load stand builds with

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .outboxx,
-    .version = "0.2.0",
+    .version = "0.3.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zbench = .{

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,10 @@
             # unlike @cImport which also reads NIX_CFLAGS_COMPILE).
             export C_INCLUDE_PATH="${pkgs.postgresql.dev}/include:${rdkafka-latest.dev}/include:''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
 
-            echo "Outboxx development environment ready"
+            # stderr: make's $(shell ...) runs through .make-shell / nix develop
+            # and captures stdout, so a banner there corrupts variables like
+            # STATIC_TARGET ("Outboxx ... x86_64-linux-musl").
+            echo "Outboxx development environment ready" >&2
           '';
         };
       }


### PR DESCRIPTION
## What

- CHANGELOG: `Unreleased` moved under `## 0.3.0` and extended to cover everything since v0.2.0 (delivery-guarantee fixes, stall detection, message contract, observability, TLS/SASL, release pipeline).
- Version `0.2.0` -> `0.3.0` in `build.zig.zon` and the `build.zig` fallback.
- Release ships the image and notes only, no binary tarballs: the nix-built binary hardwires its ELF interpreter to a `/nix/store` path and only runs inside the image (verified on plain Ubuntu 24.04: exec fails). Portable binaries need a static build; the fix is included here so the release tag points at a commit that carries it.

## Merging this PR releases 0.3.0

auto-tag sees the untagged version with its CHANGELOG section, mints `v0.3.0`, and dispatches the release workflow: GHCR image (amd64+arm64) and a GitHub release with the notes from the 0.3.0 section.