### PR TITLE
Build static musl release binaries and attach them to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,68 @@ jobs:
           ./zig-out/bin/outboxx --version
           tar -czf "outboxx-${VERSION}-linux-${{ matrix.arch }}.tar.gz" -C zig-out/bin outboxx
 
+      # A released binary must do more than print its version: boot real
+      # services and drive one change through the whole pipeline.
+      - name: Smoke-test the binary end to end
+        run: |
+          set -euo pipefail
+          docker run -d --name pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:17 -c wal_level=logical
+          docker run -d --name kafka -p 9092:9092 apache/kafka:3.9.0
+
+          until docker exec pg pg_isready -U postgres >/dev/null 2>&1; do sleep 1; done
+          docker exec pg psql -U postgres -c "CREATE TABLE users (id int PRIMARY KEY, name text)"
+          until docker exec kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1; do sleep 2; done
+
+          cat > smoke.toml <<'TOML'
+          [metadata]
+          version = "v0"
+          [source]
+          type = "postgres"
+          [source.postgres]
+          connection_env = "POSTGRES_URL"
+          slot_name = "smoke_slot"
+          publication_name = "smoke_publication"
+          [sink]
+          type = "kafka"
+          [sink.kafka]
+          brokers = ["localhost:9092"]
+          tls = false
+          [observability]
+          address = "127.0.0.1"
+          port = 9464
+          [[streams]]
+          name = "users-smoke"
+          [streams.source]
+          resource = "users"
+          operations = ["insert"]
+          [streams.flow]
+          format = "json"
+          [streams.sink]
+          destination = "smoke.users"
+          routing_key = "id"
+          TOML
+
+          POSTGRES_URL="postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" \
+            ./zig-out/bin/outboxx --config smoke.toml > smoke.log 2>&1 &
+          smoke_pid=$!
+
+          for _ in $(seq 1 30); do
+            grep -q "CDC processor started successfully" smoke.log && break
+            sleep 2
+          done
+          grep "CDC processor started successfully" smoke.log
+          curl -fsS -o /dev/null -w 'healthz: %{http_code}\n' http://127.0.0.1:9464/healthz
+
+          docker exec pg psql -U postgres -c "INSERT INTO users VALUES (1, 'smoke')"
+          docker exec kafka /opt/kafka/bin/kafka-console-consumer.sh \
+            --bootstrap-server localhost:9092 --topic smoke.users \
+            --from-beginning --max-messages 1 --timeout-ms 60000 > event.json
+          grep '"op":"INSERT"' event.json
+          cat event.json
+
+          kill "$smoke_pid"
+          docker rm -f pg kafka >/dev/null
+
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,17 +120,82 @@ jobs:
             echo "- Commit tag: \`${IMAGE_NAME}:sha-${GITHUB_SHA::12}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # Portable standalone binaries: static musl builds, so unlike the nix-built
+  # image binary they carry no /nix/store paths and run on any Linux.
+  binary:
+    name: Static binary (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            zig_target: x86_64-linux-musl
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            zig_target: aarch64-linux-musl
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Read version
+        id: version
+        run: |
+          version="$(awk -F'"' '/\.version =/ {print $2; exit}' build.zig.zon)"
+          if [ -z "$version" ]; then
+            echo "failed to read .version from build.zig.zon" >&2
+            exit 1
+          fi
+          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [ "${GITHUB_REF_NAME}" != "v${version}" ]; then
+            echo "tag ${GITHUB_REF_NAME} does not match build.zig.zon version v${version}" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v16
+
+      - name: Build static binary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          ZIG_TARGET: ${{ matrix.zig_target }}
+        run: |
+          deps="$(nix build .#static-deps --print-out-paths)"
+          nix develop --command bash -c "
+            export C_INCLUDE_PATH=\"$deps/include\"
+            zig build -Doptimize=ReleaseSafe -Dcpu=baseline -Dversion=\"$VERSION\" \
+              -Dtarget=\"$ZIG_TARGET\" -Dstatic-deps=true --search-prefix \"$deps\"
+          "
+          # Native arch matches the target, so the binary must run right here.
+          ./zig-out/bin/outboxx --version
+          tar -czf "outboxx-${VERSION}-linux-${{ matrix.arch }}.tar.gz" -C zig-out/bin outboxx
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.arch }}
+          path: outboxx-*.tar.gz
+          if-no-files-found: error
+
   github-release:
     name: GitHub release
     if: github.ref_type == 'tag'
     runs-on: ubuntu-24.04
-    needs: publish
+    needs: [publish, binary]
     permissions:
       contents: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: binary-*
+          merge-multiple: true
 
       - name: Collect release notes
         run: |
@@ -143,13 +208,10 @@ jobs:
             exit 1
           fi
 
-      # No binary assets: the nix-built binary hardwires its ELF interpreter to
-      # a /nix/store path and only runs inside the image, which carries the
-      # whole closure. Portable standalone binaries need a static build first.
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" \
+          gh release create "${GITHUB_REF_NAME}" outboxx-*.tar.gz \
             --title "${GITHUB_REF_NAME}" \
             --notes-file notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,25 +64,6 @@ jobs:
             .
           docker run --rm "${IMAGE_NAME}:${VERSION}-${ARCH}" --version
 
-      # The release binary is the exact file shipped in the image, byte for byte,
-      # not a separate build that could drift from it.
-      - name: Extract binary from image
-        env:
-          ARCH: ${{ matrix.arch }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          id="$(docker create "${IMAGE_NAME}:${VERSION}-${ARCH}")"
-          docker cp "${id}:/app/outboxx" outboxx
-          docker rm "${id}" >/dev/null
-          tar -czf "outboxx-${VERSION}-linux-${ARCH}.tar.gz" outboxx
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: binary-${{ matrix.arch }}
-          path: outboxx-*.tar.gz
-          if-no-files-found: error
-
       - name: Push image
         env:
           ARCH: ${{ matrix.arch }}
@@ -151,12 +132,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Download binaries
-        uses: actions/download-artifact@v4
-        with:
-          pattern: binary-*
-          merge-multiple: true
-
       - name: Collect release notes
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -168,10 +143,13 @@ jobs:
             exit 1
           fi
 
+      # No binary assets: the nix-built binary hardwires its ELF interpreter to
+      # a /nix/store path and only runs inside the image, which carries the
+      # whole closure. Portable standalone binaries need a static build first.
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" outboxx-*.tar.gz \
+          gh release create "${GITHUB_REF_NAME}" \
             --title "${GITHUB_REF_NAME}" \
             --notes-file notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ All notable changes to Outboxx are documented here.
 ### Added
 
 - Release workflow for tags matching `v*.*.*`: verifies the tag against the
-  `build.zig.zon` version, then publishes the GHCR image and a GitHub release
-  with `linux/amd64` + `linux/arm64` binaries (extracted from the image, so
-  they are byte-identical to it) and notes taken from this file's section for
-  the released version.
+  `build.zig.zon` version, then publishes the `linux/amd64` + `linux/arm64`
+  GHCR image and a GitHub release with notes taken from this file's section
+  for the released version.
 - Auto-tagging: a merge to main whose `build.zig.zon` version has no `v*` tag
   yet (and has its section in this file) is tagged automatically and the
   release workflow is dispatched on the new tag, so a release is one merged

--- a/build.zig
+++ b/build.zig
@@ -163,11 +163,26 @@ pub fn build(b: *std.Build) void {
     // Link libc for PostgreSQL and Kafka C libraries
     exe.root_module.link_libc = true;
 
+    // Static (musl) release binaries: the archives' transitive dependencies are
+    // not discovered through .so metadata, so they must be linked explicitly.
+    // pkg-config is bypassed too: it resolves to the dynamic libs in the dev
+    // shell (and zig drops literal *.a paths from Libs), so static builds rely
+    // on --search-prefix instead. Unreferenced archive members cost nothing.
+    const static_deps = b.option(bool, "static-deps", "Link the C dependencies of libpq/librdkafka explicitly (static musl builds)") orelse false;
+    const link_opts: std.Build.Module.LinkSystemLibraryOptions = if (static_deps) .{ .use_pkg_config = .no } else .{};
+
     // Add PostgreSQL library (libpq)
-    exe.root_module.linkSystemLibrary("pq", .{});
+    exe.root_module.linkSystemLibrary("pq", link_opts);
 
     // Add Kafka library (librdkafka)
-    exe.root_module.linkSystemLibrary("rdkafka", .{});
+    exe.root_module.linkSystemLibrary("rdkafka", link_opts);
+
+    if (static_deps) {
+        // libpq needs pgcommon/pgport/ssl/crypto; librdkafka needs ssl/z/zstd.
+        for ([_][]const u8{ "pgcommon", "pgport", "ssl", "crypto", "z", "zstd" }) |name| {
+            exe.root_module.linkSystemLibrary(name, link_opts);
+        }
+    }
 
     b.installArtifact(exe);
 

--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-static": {
+      "locked": {
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-static": "nixpkgs-static"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,13 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Static (musl) C dependencies for the release binaries. Pinned separately
+    # so bumping it can never move the dev toolchain (zig) underneath us.
+    nixpkgs-static.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { nixpkgs, flake-utils, ... }:
+  outputs = { nixpkgs, nixpkgs-static, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -60,5 +63,40 @@
             echo "Outboxx development environment ready"
           '';
         };
-      });
+      }
+      # Static (musl) archives for the portable release binaries, merged into
+      # one prefix: zig build takes it via --search-prefix (lib/) and the
+      # translate-c step via C_INCLUDE_PATH (include/). Linux only: pkgsStatic
+      # targets static darwin on macOS, which is neither supported nor needed.
+      // nixpkgs.lib.optionalAttrs (pkgs.stdenv.isLinux) (
+        let
+          spkgs = nixpkgs-static.legacyPackages.${system};
+          st = spkgs.pkgsStatic;
+          # No curl (only used for OAuth OIDC token fetch) and no cyrus-sasl
+          # (only adds GSSAPI; its mechanisms are dlopen plugins, useless in a
+          # static binary). TLS and the builtin SCRAM/PLAIN stay in.
+          rdkafka-lean = (st.rdkafka.override { curl = null; cyrus_sasl = null; }).overrideAttrs (o: {
+            cmakeFlags = o.cmakeFlags ++ [ "-DWITH_CURL=OFF" "-DWITH_SASL=OFF" "-DWITH_OAUTHBEARER_OIDC=OFF" ];
+            # Upstream bug: config.h.in uses cmakedefine01 (macro always
+            # defined, as 0 or 1) but the sources guard with #ifdef, so an
+            # OFF build still tries to include curl.h.
+            postPatch = (o.postPatch or "") + ''
+              sed -i "s/#ifdef WITH_OAUTHBEARER_OIDC/#if WITH_OAUTHBEARER_OIDC/" src/*.c src/*.h
+            '';
+          });
+        in
+        {
+          packages.static-deps = spkgs.symlinkJoin {
+            name = "outboxx-static-deps";
+            paths = [
+              st.libpq.dev # the .a files live in the dev output on static builds
+              rdkafka-lean
+              rdkafka-lean.dev
+              st.openssl.out
+              (st.zlib.static or st.zlib)
+              st.zstd.out
+            ];
+          };
+        }
+      ));
 }


### PR DESCRIPTION
## Problem

The nix-built binary hardwires its ELF interpreter to a `/nix/store` path and only runs inside the Docker image, so 0.3.0 ships without binary assets (#118).

## Solution

- **flake**: a separately pinned `nixpkgs-static` input (cannot move the dev toolchain) provides `pkgsStatic` musl archives, merged into one prefix by the new `static-deps` package: libpq (+pgcommon/pgport), a lean librdkafka, openssl, zlib, zstd. The `.a` files of static libpq live in its `dev` output; the default output is intentionally empty.
- **lean rdkafka**: built without curl (only used for OAuth OIDC token fetch) and without cyrus-sasl (its mechanisms are dlopen plugins, useless in a static binary). TLS and the builtin SCRAM/PLAIN stay in, verified by symbol scan. Includes a workaround for an upstream cmake bug: `config.h.in` uses `cmakedefine01` (macro always defined, as 0 or 1) while sources guard with `#ifdef`, so a curl-less cmake build fails on a `curl.h` include. Worth reporting upstream.
- **build.zig**: `-Dstatic-deps` links the transitive archives explicitly and bypasses pkg-config (it resolves to the dev shell's dynamic libs and zig drops literal `*.a` paths from pc `Libs`).
- **release.yml**: a per-arch `binary` job (native amd64/arm64 runners, nix installer) builds `x86_64-linux-musl` / `aarch64-linux-musl`, smoke-runs `--version`, uploads tarballs; `github-release` attaches them. Includes the image-plus-notes change from #117, so this merges cleanly after the 0.3.0 release.

## Verified

- `nix build .#static-deps` + `zig build -Dstatic-deps` reproduced end to end from the pinned flake.
- The aarch64 binary is `statically linked` (18MB with debug info) and runs `--version` on Ubuntu 24.04, Alpine 3.20, and Debian bookworm.
- Full CDC cycle from a clean Ubuntu container against the load stand: replication connected, a probe row delivered to Kafka, `confirmed_flush_lsn` caught up to the WAL head (the delivery gate from #110 confirms the LSN only after a successful flush).

Notes: static rdkafka is 2.13.0 (the pinned unstable) vs 2.12.1 in the dynamic dev shell; 2.13.0 includes the same latency fixes. CHANGELOG entry will be added on rebase after #117 merges, to avoid conflicting with the 0.3.0 restructure.

Closes #118.