### PR TITLE
Dry-run the release on PRs labeled release

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -1,0 +1,45 @@
+name: Release Preflight
+
+# Dry-run of the release for PRs labeled `release`: the full pipeline builds
+# (image and static binaries, with the e2e smoke) but publishes nothing, so a
+# broken release surfaces at review time, not after the tag exists. The check
+# job mirrors auto-tag's conditions, catching the cases where the merge would
+# silently not release at all.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  check:
+    name: Version is releasable
+    if: contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Check version and changelog
+        run: |
+          version="$(awk -F'"' '/\.version =/ {print $2; exit}' build.zig.zon)"
+          if [ -z "$version" ]; then
+            echo "failed to read .version from build.zig.zon" >&2
+            exit 1
+          fi
+          echo "version: $version"
+          if git ls-remote --exit-code origin "refs/tags/v${version}" >/dev/null; then
+            echo "v${version} is already tagged: merging would not release; bump the version" >&2
+            exit 1
+          fi
+          if ! awk -v ver="$version" '/^## / { on = ($2 == ver); next } on' CHANGELOG.md | grep -q .; then
+            echo "CHANGELOG.md has no \"## ${version}\" section: auto-tag would skip after the merge" >&2
+            exit 1
+          fi
+
+  dry-run:
+    name: Release dry run
+    if: contains(github.event.pull_request.labels.*.name, 'release')
+    uses: ./.github/workflows/release.yml
+    with:
+      dry-run: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   workflow_dispatch:
   push:
     tags: ["v*.*.*"]
+  # Reused by release-preflight.yml on PRs labeled `release`: everything is
+  # built and smoke-tested, nothing is pushed or published.
+  workflow_call:
+    inputs:
+      dry-run:
+        description: Build and smoke-test everything, publish nothing
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -46,6 +54,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Login to GHCR
+        if: inputs.dry-run != true
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Build image
@@ -65,6 +74,7 @@ jobs:
           docker run --rm "${IMAGE_NAME}:${VERSION}-${ARCH}" --version
 
       - name: Push image
+        if: inputs.dry-run != true
         env:
           ARCH: ${{ matrix.arch }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -75,6 +85,7 @@ jobs:
 
   publish:
     name: Publish multi-arch tags
+    if: inputs.dry-run != true
     runs-on: ubuntu-24.04
     needs: docker-image
 


### PR DESCRIPTION
## Problem

A broken release pipeline surfaces only after the tag exists, when a re-run needs manual tag surgery. And a release PR that forgot the CHANGELOG section (or kept an already-tagged version) merges fine and then silently does not release.

## Solution

- `release.yml` is reusable via `workflow_call` with a `dry-run` input: every publishing step is skipped (GHCR login/push, the multi-arch publish job; the GitHub release job is tag-gated already), while the image build, the static binary build, and the e2e smoke all run for real.
- `release-preflight.yml` triggers on PRs labeled `release` (including the moment the label is added) and:
  - checks auto-tag's minting conditions up front: the version is not tagged yet and `CHANGELOG.md` has the `## X.Y.Z` section, so "merge that would not release" fails at review time;
  - calls the release workflow in dry-run mode, from the PR's branch, so a release PR that also touches the pipeline tests its own version of it.

Follow-up: add "label the PR `release`" to the release issue template checklist.