### PR TITLE
Grant the dry-run call the permissions release.yml declares

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -41,5 +41,14 @@ jobs:
     name: Release dry run
     if: contains(github.event.pull_request.labels.*.name, 'release')
     uses: ./.github/workflows/release.yml
+    # The called workflow statically declares the write permissions its
+    # publishing steps need, and GitHub validates them at startup even though
+    # dry-run skips every one of those steps. Grant them so the call passes
+    # validation; nothing in a dry run uses the token for writes. Fork PRs
+    # cannot be granted write and would fail at startup, which is fine: only
+    # maintainer release PRs carry the `release` label.
+    permissions:
+      contents: write
+      packages: write
     with:
       dry-run: true


### PR DESCRIPTION
## Problem

Release Preflight failed at startup on #117: the called `release.yml` statically declares `packages: write` (top level) and `contents: write` (the `github-release` job), and GitHub validates these against the caller before running anything. On a `pull_request` event the default token is read-only, so the call was rejected even though dry-run skips every publishing step.

## Solution

The `dry-run` caller job grants `contents: write` and `packages: write` explicitly. A dry run never uses the token for writes (GHCR login/push and publish are gated off, the release job is tag-gated). Fork PRs cannot receive write tokens and would still fail at startup; acceptable, since only maintainer release PRs carry the `release` label.