### PR TITLE
Validate release binaries with the e2e suite instead of a bash smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,10 +142,8 @@ jobs:
         include:
           - arch: amd64
             runner: ubuntu-24.04
-            zig_target: x86_64-linux-musl
           - arch: arm64
             runner: ubuntu-24.04-arm
-            zig_target: aarch64-linux-musl
 
     steps:
       - name: Checkout code
@@ -171,62 +169,24 @@ jobs:
       - name: Build static binary
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          ZIG_TARGET: ${{ matrix.zig_target }}
         run: |
-          deps="$(nix build .#static-deps --print-out-paths)"
-          nix develop --command bash -c "
-            export C_INCLUDE_PATH=\"$deps/include\"
-            zig build -Doptimize=ReleaseSafe -Dcpu=baseline -Dversion=\"$VERSION\" \
-              -Dtarget=\"$ZIG_TARGET\" -Dstatic-deps=true --search-prefix \"$deps\"
-          "
+          make build-static VERSION="$VERSION"
           # Native arch matches the target, so the binary must run right here.
           ./zig-out/bin/outboxx --version
           tar -czf "outboxx-${VERSION}-linux-${{ matrix.arch }}.tar.gz" -C zig-out/bin outboxx
 
-      # A released build must do more than print its version: run the full e2e
-      # suite (INSERT/UPDATE/DELETE through Postgres -> CDC -> Kafka) built
-      # against the exact static link set. Services mirror pr-checks.yml,
-      # minus the TLS listener the e2e tests do not use.
-      - name: Start Postgres and Kafka
-        run: |
-          docker run -d --name pg --network host \
-            -e POSTGRES_PASSWORD=password \
-            -e POSTGRES_DB=outboxx_test \
-            -e POSTGRES_INITDB_ARGS="-c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10 -c max_logical_replication_workers=4" \
-            postgres:17
-          docker run -d --name kafka --network host \
-            -e KAFKA_CFG_NODE_ID=1 \
-            -e KAFKA_CFG_PROCESS_ROLES=broker,controller \
-            -e KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@localhost:19093 \
-            -e KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:19093 \
-            -e KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 \
-            -e KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT \
-            -e KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER \
-            -e KAFKA_KRAFT_CLUSTER_ID=preflight-cluster-id \
-            -e ALLOW_PLAINTEXT_LISTENER=yes \
-            -e KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true \
-            bitnamilegacy/kafka:latest
-          # Host-side pg_isready: the temporary initdb server listens only on
-          # the unix socket, so the TCP port only answers once the real one is up.
-          until pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; do sleep 1; done
-          PGPASSWORD=password psql -h localhost -p 5432 -U postgres -d outboxx_test -f dev/postgres/postgres-init.sql
-          timeout 90s bash -c 'until nc -z localhost 9092; do sleep 2; done'
+      # A released build must do more than print its version: run the e2e
+      # suite (Postgres -> CDC -> Kafka) built against the exact static link
+      # set, on the same dev environment the tests use everywhere else.
+      - name: Start the dev environment
+        run: make env-up
 
       - name: Run e2e tests against the static build
-        env:
-          ZIG_TARGET: ${{ matrix.zig_target }}
-        run: |
-          deps="$(nix build .#static-deps --print-out-paths)"
-          nix develop --command bash -c "
-            export C_INCLUDE_PATH=\"$deps/include\"
-            zig build test-e2e -Dstatic-deps=true -Dtarget=\"$ZIG_TARGET\" --search-prefix \"$deps\"
-          "
+        run: make test-e2e-static
 
       - name: Dump service logs on failure
         if: failure()
-        run: |
-          echo "=== kafka ==="; docker logs kafka 2>&1 | tail -40
-          echo "=== postgres ==="; docker logs pg 2>&1 | tail -40
+        run: docker-compose logs --tail=40
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,67 +183,50 @@ jobs:
           ./zig-out/bin/outboxx --version
           tar -czf "outboxx-${VERSION}-linux-${{ matrix.arch }}.tar.gz" -C zig-out/bin outboxx
 
-      # A released binary must do more than print its version: boot real
-      # services and drive one change through the whole pipeline.
-      - name: Smoke-test the binary end to end
+      # A released build must do more than print its version: run the full e2e
+      # suite (INSERT/UPDATE/DELETE through Postgres -> CDC -> Kafka) built
+      # against the exact static link set. Services mirror pr-checks.yml,
+      # minus the TLS listener the e2e tests do not use.
+      - name: Start Postgres and Kafka
         run: |
-          set -euo pipefail
-          docker run -d --name pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:17 -c wal_level=logical
-          docker run -d --name kafka -p 9092:9092 apache/kafka:3.9.0
+          docker run -d --name pg --network host \
+            -e POSTGRES_PASSWORD=password \
+            -e POSTGRES_DB=outboxx_test \
+            -e POSTGRES_INITDB_ARGS="-c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10 -c max_logical_replication_workers=4" \
+            postgres:17
+          docker run -d --name kafka --network host \
+            -e KAFKA_CFG_NODE_ID=1 \
+            -e KAFKA_CFG_PROCESS_ROLES=broker,controller \
+            -e KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@localhost:19093 \
+            -e KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:19093 \
+            -e KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 \
+            -e KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT \
+            -e KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+            -e KAFKA_KRAFT_CLUSTER_ID=preflight-cluster-id \
+            -e ALLOW_PLAINTEXT_LISTENER=yes \
+            -e KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true \
+            bitnamilegacy/kafka:latest
+          # Host-side pg_isready: the temporary initdb server listens only on
+          # the unix socket, so the TCP port only answers once the real one is up.
+          until pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; do sleep 1; done
+          PGPASSWORD=password psql -h localhost -p 5432 -U postgres -d outboxx_test -f dev/postgres/postgres-init.sql
+          timeout 90s bash -c 'until nc -z localhost 9092; do sleep 2; done'
 
-          until docker exec pg pg_isready -U postgres >/dev/null 2>&1; do sleep 1; done
-          docker exec pg psql -U postgres -c "CREATE TABLE users (id int PRIMARY KEY, name text)"
-          until docker exec kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1; do sleep 2; done
+      - name: Run e2e tests against the static build
+        env:
+          ZIG_TARGET: ${{ matrix.zig_target }}
+        run: |
+          deps="$(nix build .#static-deps --print-out-paths)"
+          nix develop --command bash -c "
+            export C_INCLUDE_PATH=\"$deps/include\"
+            zig build test-e2e -Dstatic-deps=true -Dtarget=\"$ZIG_TARGET\" --search-prefix \"$deps\"
+          "
 
-          cat > smoke.toml <<'TOML'
-          [metadata]
-          version = "v0"
-          [source]
-          type = "postgres"
-          [source.postgres]
-          connection_env = "POSTGRES_URL"
-          slot_name = "smoke_slot"
-          publication_name = "smoke_publication"
-          [sink]
-          type = "kafka"
-          [sink.kafka]
-          brokers = ["localhost:9092"]
-          tls = false
-          [observability]
-          address = "127.0.0.1"
-          port = 9464
-          [[streams]]
-          name = "users-smoke"
-          [streams.source]
-          resource = "users"
-          operations = ["insert"]
-          [streams.flow]
-          format = "json"
-          [streams.sink]
-          destination = "smoke.users"
-          routing_key = "id"
-          TOML
-
-          POSTGRES_URL="postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable" \
-            ./zig-out/bin/outboxx --config smoke.toml > smoke.log 2>&1 &
-          smoke_pid=$!
-
-          for _ in $(seq 1 30); do
-            grep -q "CDC processor started successfully" smoke.log && break
-            sleep 2
-          done
-          grep "CDC processor started successfully" smoke.log
-          curl -fsS -o /dev/null -w 'healthz: %{http_code}\n' http://127.0.0.1:9464/healthz
-
-          docker exec pg psql -U postgres -c "INSERT INTO users VALUES (1, 'smoke')"
-          docker exec kafka /opt/kafka/bin/kafka-console-consumer.sh \
-            --bootstrap-server localhost:9092 --topic smoke.users \
-            --from-beginning --max-messages 1 --timeout-ms 60000 > event.json
-          grep '"op":"INSERT"' event.json
-          cat event.json
-
-          kill "$smoke_pid"
-          docker rm -f pg kafka >/dev/null
+      - name: Dump service logs on failure
+        if: failure()
+        run: |
+          echo "=== kafka ==="; docker logs kafka 2>&1 | tail -40
+          echo "=== postgres ==="; docker logs pg 2>&1 | tail -40
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build run test test-integration test-unit clean fmt lint dev install-deps check-deps env-up env-down env-restart env-logs env-status coverage bench bench-collect bench-report bench-compare bench-save bench-ci
+.PHONY: help build build-static run test test-integration test-unit test-e2e-static clean fmt lint dev install-deps check-deps env-up env-down env-restart env-logs env-status coverage bench bench-collect bench-report bench-compare bench-save bench-ci
 
 # Use direnv to auto-load Nix environment for local development
 # This allows commands to work without 'nix develop' wrapper
@@ -94,6 +94,26 @@ test-e2e:
 	@echo -n "Running E2E tests... "
 	$(call run_with_spinner,zig build test-e2e,E2E tests)
 
+# Static (musl) release build and its validation. Linux only: the binaries
+# target the host arch and run in place. VERSION defaults to build.zig.zon.
+VERSION ?= $(shell awk -F'"' '/\.version =/ {print $$2; exit}' build.zig.zon)
+STATIC_TARGET = $(shell uname -m)-linux-musl
+
+# Build the release binary against the static musl deps from the flake.
+build-static:
+	@deps=$$(nix build .#static-deps --print-out-paths); \
+	echo "zig build (static, $(STATIC_TARGET), $(VERSION))"; \
+	C_INCLUDE_PATH="$$deps/include" zig build -Doptimize=ReleaseSafe -Dcpu=baseline \
+		-Dversion="$(VERSION)" -Dtarget=$(STATIC_TARGET) -Dstatic-deps=true --search-prefix "$$deps"
+
+# Run the e2e suite built against the same static link set the release ships.
+# Needs the dev environment (make env-up).
+test-e2e-static:
+	@deps=$$(nix build .#static-deps --print-out-paths); \
+	echo "Running E2E tests against the static build ($(STATIC_TARGET))..."; \
+	C_INCLUDE_PATH="$$deps/include" zig build test-e2e -Dstatic-deps=true \
+		-Dtarget=$(STATIC_TARGET) --search-prefix "$$deps"
+
 # Run all tests with database setup
 test: env-up test-unit test-integration test-e2e
 
@@ -148,8 +168,9 @@ env-up:
 	./dev/kafka-tls/gen-certs.sh
 	@echo "Starting PostgreSQL development environment..."
 	docker-compose up -d
-	@echo "Waiting for PostgreSQL to be ready..."
-	@sleep 5
+	@echo "Waiting for PostgreSQL and Kafka to be ready..."
+	@timeout 60 bash -c 'until pg_isready -h localhost -p 5432 -U postgres >/dev/null 2>&1; do sleep 1; done'
+	@timeout 90 bash -c 'until (echo > /dev/tcp/localhost/9092) 2>/dev/null; do sleep 1; done'
 	@echo "Development environment is ready!"
 	@echo "PostgreSQL: localhost:5432"
 	@echo "Database: outboxx_test"

--- a/build.zig
+++ b/build.zig
@@ -170,6 +170,8 @@ pub fn build(b: *std.Build) void {
     // on --search-prefix instead. Unreferenced archive members cost nothing.
     const static_deps = b.option(bool, "static-deps", "Link the C dependencies of libpq/librdkafka explicitly (static musl builds)") orelse false;
     const link_opts: std.Build.Module.LinkSystemLibraryOptions = if (static_deps) .{ .use_pkg_config = .no } else .{};
+    // libpq needs pgcommon/pgport/ssl/crypto; librdkafka needs ssl/z/zstd.
+    const static_dep_names = [_][]const u8{ "pgcommon", "pgport", "ssl", "crypto", "z", "zstd" };
 
     // Add PostgreSQL library (libpq)
     exe.root_module.linkSystemLibrary("pq", link_opts);
@@ -178,8 +180,7 @@ pub fn build(b: *std.Build) void {
     exe.root_module.linkSystemLibrary("rdkafka", link_opts);
 
     if (static_deps) {
-        // libpq needs pgcommon/pgport/ssl/crypto; librdkafka needs ssl/z/zstd.
-        for ([_][]const u8{ "pgcommon", "pgport", "ssl", "crypto", "z", "zstd" }) |name| {
+        for (static_dep_names) |name| {
             exe.root_module.linkSystemLibrary(name, link_opts);
         }
     }
@@ -386,9 +387,16 @@ pub fn build(b: *std.Build) void {
     e2e_streaming_test.root_module.addImport("config", config_module);
     e2e_streaming_test.root_module.addImport("postgres_source", postgres_source_module);
     e2e_streaming_test.root_module.addImport("kafka_producer", kafka_producer_module);
+    // Links like the exe so `zig build test-e2e -Dstatic-deps -Dtarget=*-musl`
+    // exercises the full suite against the exact static release link set.
     e2e_streaming_test.root_module.link_libc = true;
-    e2e_streaming_test.root_module.linkSystemLibrary("pq", .{});
-    e2e_streaming_test.root_module.linkSystemLibrary("rdkafka", .{});
+    e2e_streaming_test.root_module.linkSystemLibrary("pq", link_opts);
+    e2e_streaming_test.root_module.linkSystemLibrary("rdkafka", link_opts);
+    if (static_deps) {
+        for (static_dep_names) |name| {
+            e2e_streaming_test.root_module.linkSystemLibrary(name, link_opts);
+        }
+    }
 
     const run_e2e_streaming_test = b.addRunArtifact(e2e_streaming_test);
 


### PR DESCRIPTION
## Problem

The binary job's hand-rolled smoke hung on the runners with zero diagnostics, failing the 0.3.0 preflight while the binaries built fine. And all of its service setup lived as inline bash in the workflow, unrunnable outside CI.

## Solution

Validation is the real e2e suite, and everything runs through make, reusable locally:

- `make build-static`: the static musl release build (arch from `uname`, VERSION defaults to `build.zig.zon`).
- `make test-e2e-static`: the e2e suite (INSERT/UPDATE/DELETE through Postgres -> CDC -> Kafka) linked against the exact static archives the release ships. `e2e_streaming_test` shares the `-Dstatic-deps` machinery with the exe.
- The binary job is now three make calls: `build-static`, `env-up`, `test-e2e-static`, on the same dev environment every other test uses. Service logs are dumped on failure.
- `make env-up` waits for real readiness (pg_isready + a TCP probe on 9092) instead of `sleep 5`, which also fixes the long-standing first-run flake of integration tests right after env-up.

Local reproduction of the release validation on any Linux box: `make env-up && make test-e2e-static`.

Verified: `make build-static` runs end to end in the nix container (arch autodetected, static binary produced); the static e2e binary compiles, links, and reaches the expected connection error without services.

After merge: re-add the `release` label on #117 to re-trigger the preflight.