### PR TITLE
Carry the Zig toolchain in the release tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -17,12 +17,13 @@ Release PR:
 - [ ] build.zig.zon: `.version = "X.Y.Z"`
 - [ ] build.zig: the `-Dversion` fallback is `orelse "X.Y.Z"`
 - [ ] `make build && ./zig-out/bin/outboxx --version` prints X.Y.Z
-- [ ] Merge the PR. The merge is the release trigger: auto-tag mints `vX.Y.Z` and dispatches the release workflow
+- [ ] Add the `release` label: it runs the preflight dry run on the PR
+- [ ] Merge the PR. The merge is the release trigger: auto-tag mints `vX.Y.Z-zigA.B` and dispatches the release workflow
 
 Definition of Done (the merge only hands off to automation, verify the result):
 
-- [ ] Release `vX.Y.Z` is on the releases page with the notes from the
-      CHANGELOG section
+- [ ] Release `vX.Y.Z-zigA.B` is on the releases page with the notes from the
+      CHANGELOG section and the two binary tarballs attached
 - [ ] `docker run --rm ghcr.io/lukashes/outboxx:X.Y.Z --version` prints X.Y.Z
       (amd64 and arm64)
 - [ ] The X.Y.Z milestone is closed

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,8 +1,9 @@
 name: Auto-tag Release
 
 # Mint the release tag from the version in build.zig.zon: after a merge to
-# main, if v{version} does not exist yet and CHANGELOG.md has that version's
-# section, tag the merge commit and dispatch the release workflow on it.
+# main, if the version is not tagged yet and CHANGELOG.md has that version's
+# section, tag the merge commit and dispatch the release workflow on it. The
+# tag carries the Zig toolchain as build metadata: v{version}-zig{major.minor}.
 #
 # Idempotent by construction: an existing tag makes every later merge a no-op,
 # so reverts and repeated runs cannot re-release. The release workflow is
@@ -36,19 +37,24 @@ jobs:
         id: version
         run: |
           version="$(awk -F'"' '/\.version =/ {print $2; exit}' build.zig.zon)"
-          if [ -z "$version" ]; then
-            echo "failed to read .version from build.zig.zon" >&2
+          zig="$(awk -F'"' '/minimum_zig_version/ {print $2; exit}' build.zig.zon)"
+          if [ -z "$version" ] || [ -z "$zig" ]; then
+            echo "failed to read .version / .minimum_zig_version from build.zig.zon" >&2
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v${version}-zig${zig%.*}" >> "$GITHUB_OUTPUT"
 
       - name: Check tag and changelog
         id: check
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          if git ls-remote --exit-code origin "refs/tags/v${VERSION}" >/dev/null; then
-            echo "v${VERSION} already exists; nothing to release" >> "$GITHUB_STEP_SUMMARY"
+          # A version releases exactly once, whatever zig suffix it was tagged
+          # with: a toolchain bump alone must not re-release the same version.
+          if git ls-remote origin "refs/tags/v${VERSION}" "refs/tags/v${VERSION}-*" | grep -q .; then
+            echo "${VERSION} is already tagged; nothing to release" >> "$GITHUB_STEP_SUMMARY"
             echo "release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -66,15 +72,15 @@ jobs:
       - name: Push tag
         if: steps.check.outputs.release == 'true'
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "Release v${VERSION}"
-          if ! git push origin "v${VERSION}"; then
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          if ! git push origin "${TAG}"; then
             # Lost a race with a concurrent run; fine if the tag now exists.
-            git ls-remote --exit-code origin "refs/tags/v${VERSION}" >/dev/null
-            echo "v${VERSION} was pushed by a concurrent run" >> "$GITHUB_STEP_SUMMARY"
+            git ls-remote --exit-code origin "refs/tags/${TAG}" >/dev/null
+            echo "${TAG} was pushed by a concurrent run" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
@@ -82,7 +88,7 @@ jobs:
         if: steps.check.outputs.release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          gh workflow run release.yml --ref "v${VERSION}"
-          echo "released v${VERSION}: tagged and dispatched release.yml" >> "$GITHUB_STEP_SUMMARY"
+          gh workflow run release.yml --ref "${TAG}"
+          echo "released ${TAG}: tagged and dispatched release.yml" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -28,8 +28,10 @@ jobs:
             exit 1
           fi
           echo "version: $version"
-          if git ls-remote --exit-code origin "refs/tags/v${version}" >/dev/null; then
-            echo "v${version} is already tagged: merging would not release; bump the version" >&2
+          # Same rule as auto-tag: any v{version} or v{version}-zig* tag
+          # means this version has already been released.
+          if git ls-remote origin "refs/tags/v${version}" "refs/tags/v${version}-*" | grep -q .; then
+            echo "${version} is already tagged: merging would not release; bump the version" >&2
             exit 1
           fi
           if ! awk -v ver="$version" '/^## / { on = ($2 == ver); next } on' CHANGELOG.md | grep -q .; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,9 @@ jobs:
           fi
           # A tag must release exactly the version the source claims, or the
           # image/binary labels and the tag would disagree.
-          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [ "${GITHUB_REF_NAME}" != "v${version}" ]; then
-            echo "tag ${GITHUB_REF_NAME} does not match build.zig.zon version v${version}" >&2
+          zig="$(awk -F'"' '/minimum_zig_version/ {print $2; exit}' build.zig.zon)"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [ "${GITHUB_REF_NAME}" != "v${version}-zig${zig%.*}" ]; then
+            echo "tag ${GITHUB_REF_NAME} does not match v${version}-zig${zig%.*} from build.zig.zon" >&2
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -157,8 +158,9 @@ jobs:
             echo "failed to read .version from build.zig.zon" >&2
             exit 1
           fi
-          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [ "${GITHUB_REF_NAME}" != "v${version}" ]; then
-            echo "tag ${GITHUB_REF_NAME} does not match build.zig.zon version v${version}" >&2
+          zig="$(awk -F'"' '/minimum_zig_version/ {print $2; exit}' build.zig.zon)"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ] && [ "${GITHUB_REF_NAME}" != "v${version}-zig${zig%.*}" ]; then
+            echo "tag ${GITHUB_REF_NAME} does not match v${version}-zig${zig%.*} from build.zig.zon" >&2
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -208,9 +210,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: binary-*
+          merge-multiple: true
+
       - name: Collect release notes
         run: |
+          # The tag is v{version}-zig{major.minor}; CHANGELOG sections use the
+          # bare version.
           version="${GITHUB_REF_NAME#v}"
+          version="${version%%-zig*}"
           # The section for this version in CHANGELOG.md: from its "## X.Y.Z"
           # heading (exclusive) to the next "## " heading.
           awk -v ver="$version" '/^## / { on = ($2 == ver); next } on' CHANGELOG.md > notes.md
@@ -219,13 +230,13 @@ jobs:
             exit 1
           fi
 
-      # No binary assets: the nix-built binary hardwires its ELF interpreter to
-      # a /nix/store path and only runs inside the image, which carries the
-      # whole closure. Portable standalone binaries need a static build first.
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "${GITHUB_REF_NAME}" \
+          version="${GITHUB_REF_NAME#v}"
+          version="${version%%-zig*}"
+          zig="$(awk -F'"' '/minimum_zig_version/ {print $2; exit}' build.zig.zon)"
+          gh release create "${GITHUB_REF_NAME}" outboxx-*.tar.gz \
+            --title "Outboxx v${version} (Zig ${zig})" \
             --notes-file notes.md


### PR DESCRIPTION
Releases have always been tagged `vX.Y.Z-zigA.B` (`v0.2.0-zig0.16`): the toolchain is part of the version, like a build number. The new automation minted plain `v0.3.0`, so the first auto-tagged release broke the convention (that tag is deleted, the run was cancelled).

- auto-tag mints `v{version}-zig{major.minor}` from `.minimum_zig_version` and skips when any `v{version}*` tag exists, so a toolchain bump alone cannot re-release the same version
- release.yml tag guards compare against the same derived name; the GitHub release is titled "Outboxx vX.Y.Z (Zig A.B.C)"
- the preflight check and the release issue template follow the format

Also restores the github-release job that #117 overwrote with its pre-static-binaries variant: without this, the release would ship with no binary tarballs attached.

Merging this releases 0.3.0: the version is untagged and its CHANGELOG section is already on main, so auto-tag fires on the merge.