### PR TITLE
Validate the routing key and resolve its default in config

### DIFF
--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -102,7 +102,7 @@ pub const StreamFlow = struct {
 
 pub const StreamSink = struct {
     destination: []const u8, // topic/url/path/table
-    routing_key: ?[]const u8 = null, // partition_key/routing
+    routing_key: []const u8 = "id", // partition key column; defaults to the primary key
 };
 
 pub const Stream = struct {
@@ -315,9 +315,7 @@ pub const Config = struct {
 
         // Sink validation
         try validateKafkaTopicName(stream.sink.destination, "stream.sink.destination");
-        if (stream.sink.routing_key) |routing_key| {
-            try validateStringLength(routing_key, ValidationLimits.MAX_IDENTIFIER_LEN, "stream.sink.routing_key");
-        }
+        try validateStringLength(stream.sink.routing_key, ValidationLimits.MAX_IDENTIFIER_LEN, "stream.sink.routing_key");
     }
 
     fn validateStreams(allocator: std.mem.Allocator, streams: []const Stream) !void {

--- a/src/config/config_test.zig
+++ b/src/config/config_test.zig
@@ -28,7 +28,7 @@ fn createTestDefault() Config {
                 .name = "test_stream",
                 .source = .{ .resource = "users", .operations = &.{"insert"} },
                 .flow = .{ .format = "json" },
-                .sink = .{ .destination = "test_topic", .routing_key = null },
+                .sink = .{ .destination = "test_topic", .routing_key = "id" },
             },
         },
     };
@@ -87,7 +87,7 @@ test "Stream.hasDeleteOperation reflects the configured operations" {
         .name = "s",
         .source = .{ .resource = "users", .operations = &.{} },
         .flow = .{ .format = "json" },
-        .sink = .{ .destination = "t", .routing_key = null },
+        .sink = .{ .destination = "t", .routing_key = "id" },
     };
 
     var insert_update = base;
@@ -261,7 +261,46 @@ test "parse stream with inline comments and optional routing_key" {
     try testing.expectEqualStrings("update", stream.source.operations[1]);
     try testing.expectEqualStrings("json", stream.flow.format);
     try testing.expectEqualStrings("outboxx.users", stream.sink.destination);
-    try testing.expectEqualStrings("id", stream.sink.routing_key.?);
+    try testing.expectEqualStrings("id", stream.sink.routing_key);
+}
+
+test "routing_key defaults to id when omitted" {
+    const toml_content =
+        \\[metadata]
+        \\version = "v0"
+        \\
+        \\[source]
+        \\type = "postgres"
+        \\
+        \\[source.postgres]
+        \\connection_env = "PG_URL"
+        \\slot_name = "slot"
+        \\publication_name = "pub"
+        \\
+        \\[sink]
+        \\type = "kafka"
+        \\
+        \\[sink.kafka]
+        \\brokers = ["kafka1:9092"]
+        \\
+        \\[[streams]]
+        \\name = "users-stream"
+        \\
+        \\[streams.source]
+        \\resource = "users"
+        \\operations = ["insert"]
+        \\
+        \\[streams.flow]
+        \\format = "json"
+        \\
+        \\[streams.sink]
+        \\destination = "outboxx.users"
+    ;
+
+    var parsed = try Config.loadFromTomlString(testing.allocator, toml_content);
+    defer parsed.deinit();
+
+    try testing.expectEqualStrings("id", parsed.value.streams[0].sink.routing_key);
 }
 
 test "parse multiple streams" {
@@ -326,7 +365,7 @@ test "parse multiple streams" {
     try testing.expect(stream1.source.operations.len == 2);
     try testing.expectEqualStrings("json", stream1.flow.format);
     try testing.expectEqualStrings("outboxx.users", stream1.sink.destination);
-    try testing.expectEqualStrings("id", stream1.sink.routing_key.?);
+    try testing.expectEqualStrings("id", stream1.sink.routing_key);
 
     const stream2 = cfg.streams[1];
     try testing.expectEqualStrings("orders-stream", stream2.name);
@@ -334,7 +373,7 @@ test "parse multiple streams" {
     try testing.expect(stream2.source.operations.len == 3);
     try testing.expectEqualStrings("delete", stream2.source.operations[2]);
     try testing.expectEqualStrings("outboxx.orders", stream2.sink.destination);
-    try testing.expectEqualStrings("order_id", stream2.sink.routing_key.?);
+    try testing.expectEqualStrings("order_id", stream2.sink.routing_key);
 }
 
 test "parse invalid boolean type fails" {
@@ -385,7 +424,7 @@ test "Config validation - unsupported format should fail" {
         .name = "test_stream",
         .source = .{ .resource = "users", .operations = &.{"insert"} },
         .flow = .{ .format = "avro" },
-        .sink = .{ .destination = "test_topic", .routing_key = null },
+        .sink = .{ .destination = "test_topic", .routing_key = "id" },
     }};
 
     try testing.expectError(error.InvalidEnumValue, cfg.validate(testing.allocator));

--- a/src/domain/change_event.zig
+++ b/src/domain/change_event.zig
@@ -406,3 +406,51 @@ test "getPartitionKeyValue extracts field values" {
         try testing.expectEqualStrings("42", key.?);
     }
 }
+
+test "partitionKeyInt formats i64 boundaries and returns null for other types" {
+    const testing = std.testing;
+
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer {
+        const deinit_status = gpa.deinit();
+        if (deinit_status == .leak) {
+            std.debug.panic("Memory leak in test!", .{});
+        }
+    }
+    const allocator = gpa.allocator();
+
+    const metadata = Metadata{
+        .source = try allocator.dupe(u8, "postgres"),
+        .resource = try allocator.dupe(u8, "users"),
+        .schema = try allocator.dupe(u8, "public"),
+        .timestamp = 1234567890,
+        .lsn = null,
+    };
+
+    var event = ChangeEvent.init(ChangeOperation.INSERT, metadata);
+    defer event.deinit(allocator);
+
+    var builder = RowDataHelpers.createBuilder(allocator);
+    try RowDataHelpers.put(&builder, allocator, "min_id", FieldValueHelpers.integer(std.math.minInt(i64)));
+    try RowDataHelpers.put(&builder, allocator, "max_id", FieldValueHelpers.integer(std.math.maxInt(i64)));
+    try RowDataHelpers.put(&builder, allocator, "email", try FieldValueHelpers.text(allocator, "a@b.co"));
+    try RowDataHelpers.put(&builder, allocator, "ratio", FieldValueHelpers.float(2.5));
+    try RowDataHelpers.put(&builder, allocator, "active", FieldValueHelpers.boolean(true));
+    const row = try RowDataHelpers.finalize(&builder, allocator);
+    event.setInsertData(row);
+
+    // The result borrows buf (no allocation, no free): librdkafka copies the key.
+    var buf: [20]u8 = undefined;
+
+    // i64 min is the 20-byte worst case and has to fit buf exactly.
+    try testing.expectEqualStrings("-9223372036854775808", event.partitionKeyInt(&buf, "min_id").?);
+    try testing.expectEqualStrings("9223372036854775807", event.partitionKeyInt(&buf, "max_id").?);
+
+    // Non-integer columns return null so the caller takes the allocating slow path.
+    try testing.expect(event.partitionKeyInt(&buf, "email") == null);
+    try testing.expect(event.partitionKeyInt(&buf, "ratio") == null);
+    try testing.expect(event.partitionKeyInt(&buf, "active") == null);
+
+    // A missing column is null too.
+    try testing.expect(event.partitionKeyInt(&buf, "nonexistent") == null);
+}

--- a/src/domain/change_event.zig
+++ b/src/domain/change_event.zig
@@ -165,6 +165,24 @@ pub const ChangeEvent = struct {
         }
     }
 
+    /// Fast path for the common integer partition key: format the field into `buf`
+    /// and return the slice, without allocating. Returns null when the field is
+    /// absent or not an integer, so the caller falls back to getPartitionKeyValue.
+    /// The result borrows `buf`, which must hold at least 20 bytes (i64 min).
+    pub fn partitionKeyInt(self: *const Self, buf: []u8, field_name: []const u8) ?[]const u8 {
+        const row = switch (self.data) {
+            .insert => |data| data,
+            .delete => |data| data,
+            .update => |update_data| update_data.new,
+        };
+
+        const field_value = RowDataHelpers.getField(row, field_name) orelse return null;
+        return switch (field_value) {
+            .integer => |i| std.fmt.bufPrint(buf, "{d}", .{i}) catch unreachable,
+            else => null,
+        };
+    }
+
     /// Get partition key value from the event data
     /// For INSERT and DELETE: uses the primary data row
     /// For UPDATE: uses the new data row

--- a/src/main.zig
+++ b/src/main.zig
@@ -291,6 +291,14 @@ fn validatePostgres(allocator: std.mem.Allocator, cfg: Config, conninfo: []const
             return err;
         };
 
+        // The partition key defaults to "id" when routing_key is unset, matching
+        // getPartitionKey; a missing column would silently collapse partitioning.
+        const routing_key = stream.sink.routing_key orelse "id";
+        validator.checkColumnExists("public", stream.source.resource, routing_key) catch |err| {
+            printStatus("ERROR: Routing key validation failed for '{s}' (column '{s}'): {}\n", .{ stream.source.resource, routing_key, err });
+            return err;
+        };
+
         // Only a stream that tracks DELETE needs REPLICA IDENTITY FULL, so the
         // deleted row carries all columns. Schema is fixed to "public" for now.
         if (stream.hasDeleteOperation()) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -291,9 +291,8 @@ fn validatePostgres(allocator: std.mem.Allocator, cfg: Config, conninfo: []const
             return err;
         };
 
-        // The partition key defaults to "id" when routing_key is unset, matching
-        // getPartitionKey; a missing column would silently collapse partitioning.
-        const routing_key = stream.sink.routing_key orelse "id";
+        // A missing routing key column would silently collapse partitioning.
+        const routing_key = stream.sink.routing_key;
         validator.checkColumnExists("public", stream.source.resource, routing_key) catch |err| {
             printStatus("ERROR: Routing key validation failed for '{s}' (column '{s}'): {}\n", .{ stream.source.resource, routing_key, err });
             return err;

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -234,13 +234,12 @@ pub const Processor = struct {
 
         const key_field = stream.sink.routing_key orelse "id";
 
-        if (change_event.getPartitionKeyValue(allocator, key_field)) |key_opt| {
-            if (key_opt) |key| {
-                return key;
-            }
-        } else |_| {}
-
-        return try allocator.dupe(u8, change_event.meta.resource);
+        // Startup validation guarantees the key column exists (and REPLICA IDENTITY
+        // FULL for delete-tracking streams), so a missing value here is not a
+        // misconfiguration to route around but an unexpected row shape. Fail fast
+        // rather than collapse the change onto a table-name partition.
+        return try change_event.getPartitionKeyValue(allocator, key_field) orelse
+            error.PartitionKeyUnavailable;
     }
 
     /// Run the batch loop until stop_signal is set, with a background flush/commit worker.

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -122,6 +122,9 @@ pub const Processor = struct {
 
     events_processed: usize,
     pending_lsn: std.atomic.Value(u64),
+    // Reused per message to format integer partition keys: an i64 is at most 20
+    // bytes, and librdkafka copies the key on produce, so no per-message alloc.
+    partition_key_buf: [20]u8,
 
     const Self = @This();
 
@@ -135,6 +138,7 @@ pub const Processor = struct {
             .obs = obs,
             .events_processed = 0,
             .pending_lsn = std.atomic.Value(u64).init(0),
+            .partition_key_buf = undefined,
         };
     }
 
@@ -230,9 +234,14 @@ pub const Processor = struct {
         change_event: ChangeEvent,
         stream: Stream,
     ) ![]const u8 {
-        _ = self;
+        const key_field = stream.sink.routing_key;
 
-        const key_field = stream.sink.routing_key orelse "id";
+        // Integer keys are the common case: format into a reusable buffer instead of
+        // allocating per message. librdkafka copies the key on produce, so the
+        // borrow only needs to outlive the sendMessage call, not the batch.
+        if (change_event.partitionKeyInt(&self.partition_key_buf, key_field)) |key| {
+            return key;
+        }
 
         // Startup validation guarantees the key column exists (and REPLICA IDENTITY
         // FULL for delete-tracking streams), so a missing value here is not a

--- a/src/source/postgres/validator.zig
+++ b/src/source/postgres/validator.zig
@@ -8,6 +8,7 @@ pub const ValidationError = error{
     InvalidWalLevel,
     SlotNotFound,
     TableNotFound,
+    ColumnNotFound,
     InvalidReplicaIdentity,
     QueryFailed,
     OutOfMemory,
@@ -124,6 +125,28 @@ pub const PostgresValidator = struct {
         }
 
         print("PostgreSQL validation: Table '{s}.{s}' exists ✓\n", .{ schema, table_name });
+    }
+
+    /// Check that a column exists on a table. Used for the stream's routing key:
+    /// a typo (or the default `id` on a table without one) would otherwise route
+    /// every change to the same partition, unnoticed.
+    pub fn checkColumnExists(self: *Self, schema: []const u8, table_name: []const u8, column_name: []const u8) ValidationError!void {
+        const query = std.fmt.allocPrintSentinel(self.allocator, "SELECT EXISTS (SELECT FROM information_schema.columns WHERE table_schema = '{s}' AND table_name = '{s}' AND column_name = '{s}');", .{ schema, table_name, column_name }, 0) catch return ValidationError.OutOfMemory;
+        defer self.allocator.free(query);
+
+        const result = try self.executeQuery(query.ptr);
+        defer c.PQclear(result);
+
+        const exists = c.PQgetvalue(result, 0, 0);
+        const exists_str = std.mem.span(exists);
+
+        if (!std.mem.eql(u8, exists_str, "t")) {
+            std.log.warn("PostgreSQL validation: Column '{s}' does not exist on table '{s}.{s}'", .{ column_name, schema, table_name });
+            std.log.warn("Fix: set stream.sink.routing_key to an existing column", .{});
+            return ValidationError.ColumnNotFound;
+        }
+
+        print("PostgreSQL validation: Column '{s}.{s}.{s}' exists ✓\n", .{ schema, table_name, column_name });
     }
 
     /// Require REPLICA IDENTITY FULL on a table whose stream tracks DELETE, so the

--- a/src/source/postgres/validator_test.zig
+++ b/src/source/postgres/validator_test.zig
@@ -81,6 +81,30 @@ test "PostgresValidator: invalid schema should error" {
     try testing.expectError(error.TableNotFound, result);
 }
 
+test "PostgresValidator: routing key column exists" {
+    const allocator = testing.allocator;
+    var validator = PostgresValidator.init(allocator);
+    defer validator.deinit();
+
+    const conn_str = "host=localhost port=5432 dbname=outboxx_test user=postgres password=password";
+
+    try validator.connect(conn_str);
+    try validator.checkColumnExists("public", "users", "id");
+}
+
+test "PostgresValidator: missing routing key column should error" {
+    const allocator = testing.allocator;
+    var validator = PostgresValidator.init(allocator);
+    defer validator.deinit();
+
+    const conn_str = "host=localhost port=5432 dbname=outboxx_test user=postgres password=password";
+
+    try validator.connect(conn_str);
+
+    const result = validator.checkColumnExists("public", "users", "nonexistent_column_xyz");
+    try testing.expectError(error.ColumnNotFound, result);
+}
+
 test "PostgresValidator: replica identity FULL passes" {
     const allocator = testing.allocator;
     var validator = PostgresValidator.init(allocator);
@@ -139,6 +163,9 @@ test "PostgresValidator: methods fail when not connected" {
 
     const table_result = validator.checkTableExists("public", "users");
     try testing.expectError(error.ConnectionFailed, table_result);
+
+    const column_result = validator.checkColumnExists("public", "users", "id");
+    try testing.expectError(error.ConnectionFailed, column_result);
 
     const identity_result = validator.checkReplicaIdentity("public", "users");
     try testing.expectError(error.ConnectionFailed, identity_result);

--- a/tests/benchmarks/components/partition_key_bench.zig
+++ b/tests/benchmarks/components/partition_key_bench.zig
@@ -60,10 +60,10 @@ const BenchPartitionKeyInteger = struct {
     event: ChangeEvent,
 
     pub fn run(self: *BenchPartitionKeyInteger, allocator: std.mem.Allocator) void {
-        const key = self.event.getPartitionKeyValue(allocator, "id") catch unreachable;
-        if (key) |k| {
-            allocator.free(k);
-        }
+        _ = allocator;
+        var buf: [20]u8 = undefined;
+        const key = self.event.partitionKeyInt(&buf, "id");
+        std.mem.doNotOptimizeAway(key);
     }
 };
 


### PR DESCRIPTION
## Problem

`getPartitionKey` fell back to the table name when the configured `routing_key` column was missing from a change, swallowing any error. A typo in `routing_key`, or the default `id` on a table without an `id` column, was never reported: every message got the same key and landed on one partition, killing ordering-by-key. The `id` default was also applied ad hoc at each call site rather than in the config.

## Solution

- Add `checkColumnExists` to the validator and call it in `validatePostgres` for each stream's routing key. A missing column fails startup with a clear message, before any data flows.
- Make the runtime path in `getPartitionKey` fail fast (`error.PartitionKeyUnavailable`) instead of falling back to the table name. After startup validation this path is unreachable in normal operation, so hitting it is a real anomaly, not a case to route around.
- Move the `id` default into the config layer: `StreamSink.routing_key` is now a non-optional field defaulting to `"id"`, so `main` and the processor read a concrete column name with no per-call `orelse`.
- Format integer partition keys into a reused per-processor buffer instead of allocating per message. librdkafka copies the key on produce, so the borrow only needs to outlive the send; the component benchmark drops from 3 allocations to 0.

Closes #84