### PR TITLE
Add pgstream to the CDC load stand

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -17,5 +17,5 @@ paths = [
   # Dev/CI scaffolding uses disposable credentials, never real secrets.
   '''^docker-compose\.yml$''',
   '''^dev/''',
-  '''^tests/load/docker-compose\.yml$''',
+  '''^tests/load/''',
 ]

--- a/tests/load/Makefile
+++ b/tests/load/Makefile
@@ -9,7 +9,8 @@ COMPOSE ?= DEBEZIUM_COMPRESSION_TYPE=$(DEBEZIUM_COMPRESSION_TYPE) DEBEZIUM_OFFSE
 INFRA_SERVICES := postgres kafka postgres-exporter kafka-exporter prometheus grafana cadvisor kafka-ui
 DEBEZIUM_SERVICES := debezium
 OUTBOXX_SERVICES := outboxx
-ALL_CDC_SERVICES := debezium outboxx
+PGSTREAM_SERVICES := pgstream
+ALL_CDC_SERVICES := debezium outboxx pgstream
 
 DURATION ?= 120
 BATCH_SIZE ?= 10000
@@ -21,7 +22,7 @@ REPORT_INTERVAL ?= 5
 
 MINUTES ?= 60
 
-.PHONY: infra infra-up load start-debezium start-outboxx start-all reset create-slots slots status topics offsets check-gaps results logs ps
+.PHONY: infra infra-up load start-debezium start-outboxx start-pgstream start-all reset create-slots slots status topics offsets check-gaps results logs ps
 
 # Bring infra up and ensure slots exist, leaving any running CDC readers alone.
 infra-up:
@@ -30,8 +31,8 @@ infra-up:
 
 # Clean pre-load baseline: infra up, CDC readers stopped, slots ready.
 infra: infra-up
-	-$(COMPOSE) stop debezium outboxx
-	-$(COMPOSE) rm -sf debezium outboxx connector-init
+	-$(COMPOSE) stop debezium outboxx pgstream
+	-$(COMPOSE) rm -sf debezium outboxx pgstream connector-init pgstream-init
 
 # Generating load does not touch running readers, so lag/throughput can be
 # watched live. Use `make infra` first for the readers-down backlog scenario.
@@ -48,20 +49,28 @@ load: infra-up
 start-debezium:
 	$(COMPOSE) up -d --remove-orphans $(INFRA_SERVICES)
 	$(MAKE) create-slots
-	-$(COMPOSE) rm -sf outboxx debezium connector-init
+	-$(COMPOSE) rm -sf outboxx pgstream debezium connector-init
 	$(COMPOSE) up -d --build $(DEBEZIUM_SERVICES)
 	$(COMPOSE) run --rm connector-init
 
 start-outboxx:
 	$(COMPOSE) up -d --remove-orphans $(INFRA_SERVICES)
 	$(MAKE) create-slots
-	-$(COMPOSE) rm -sf debezium connector-init outboxx
+	-$(COMPOSE) rm -sf debezium connector-init pgstream outboxx
 	$(COMPOSE) up -d --build $(OUTBOXX_SERVICES)
+
+# pgstream uses a prebuilt image, so no --build. create-slots already ran
+# pgstream-init, so the wal2json slot and pgstream schema exist by now.
+start-pgstream:
+	$(COMPOSE) up -d --remove-orphans $(INFRA_SERVICES)
+	$(MAKE) create-slots
+	-$(COMPOSE) rm -sf debezium connector-init outboxx pgstream
+	$(COMPOSE) up -d $(PGSTREAM_SERVICES)
 
 start-all:
 	$(COMPOSE) up -d --remove-orphans $(INFRA_SERVICES)
 	$(MAKE) create-slots
-	-$(COMPOSE) rm -sf debezium outboxx connector-init
+	-$(COMPOSE) rm -sf debezium outboxx pgstream connector-init
 	$(COMPOSE) up -d --build $(ALL_CDC_SERVICES)
 	$(COMPOSE) run --rm connector-init
 
@@ -71,6 +80,7 @@ reset:
 
 create-slots:
 	$(COMPOSE) exec -T postgres psql -U postgres -d bench -f /sql/create-slots.sql
+	-$(COMPOSE) run --rm pgstream-init
 
 slots:
 	$(COMPOSE) exec -T postgres psql -U postgres -d bench -f /sql/slot-lag.sql
@@ -84,6 +94,7 @@ topics:
 offsets:
 	-$(COMPOSE) exec kafka /kafka/bin/kafka-get-offsets.sh --bootstrap-server kafka:9092 --topic debezium.public.benchmark_records
 	-$(COMPOSE) exec kafka /kafka/bin/kafka-get-offsets.sh --bootstrap-server kafka:9092 --topic outboxx.public.benchmark_records
+	-$(COMPOSE) exec kafka /kafka/bin/kafka-get-offsets.sh --bootstrap-server kafka:9092 --topic pgstream.public.benchmark_records
 
 # Check the outboxx topic lost no message: every assigned id must be present.
 check-gaps:
@@ -93,7 +104,7 @@ results:
 	@MINUTES=$(MINUTES) bash scripts/results.sh
 
 logs:
-	$(COMPOSE) logs -f postgres kafka debezium outboxx connector-init workload prometheus grafana
+	$(COMPOSE) logs -f postgres kafka debezium outboxx pgstream connector-init pgstream-init workload prometheus grafana
 
 ps:
 	$(COMPOSE) ps

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,4 +1,4 @@
-# Postgres -> Debezium/Outboxx -> Kafka benchmark
+# Postgres -> Debezium/Outboxx/pgstream -> Kafka benchmark
 
 Local stand for generating PostgreSQL WAL first, then starting CDC readers and watching catch-up in Grafana.
 
@@ -17,9 +17,10 @@ What each command does:
 
 - `make infra` starts PostgreSQL, Kafka, Kafka UI, Prometheus, Grafana, exporters, and cAdvisor. It stops Debezium/Outboxx if they exist and creates logical replication slots before any workload.
 - `make load` brings infra and slots up if needed, then generates PostgreSQL writes. It leaves any running readers in place, so lag and throughput can be watched live while the load runs. For the readers-down backlog scenario (WAL accumulating behind the slots), run `make infra` first.
-- `make start-debezium` starts only Debezium. Outboxx is stopped/removed first.
-- `make start-outboxx` starts only Outboxx. Debezium and connector-init are stopped/removed first.
-- `make start-all` starts Debezium and Outboxx together. Debezium is registered automatically.
+- `make start-debezium` starts only Debezium. Outboxx and pgstream are stopped/removed first.
+- `make start-outboxx` starts only Outboxx. Debezium, pgstream, and connector-init are stopped/removed first.
+- `make start-pgstream` starts only pgstream. Debezium, Outboxx, and connector-init are stopped/removed first.
+- `make start-all` starts Debezium, Outboxx, and pgstream together. Debezium is registered automatically.
 - `make reset` stops the stand and removes this stand's PostgreSQL, Kafka, Prometheus, and Grafana volumes.
 
 To benchmark the local checkout, copy the example override and rebuild:
@@ -46,9 +47,9 @@ make infra LOAD_POSTGRES_PORT=15433 LOAD_KAFKA_PORT=19094 LOAD_KAFKA_CONTROLLER_
 
 ## Results
 
-`make results` reads Prometheus and prints the headline numbers for both readers draining the same WAL backlog: total events, drain time, effective throughput (events / drain window, so a short burst is not undercounted the way a 1m rate would be), and peak memory/CPU.
+`make results` reads Prometheus and prints the headline numbers for each reader draining the same WAL backlog: total events, drain time, effective throughput (events / drain window, so a short burst is not undercounted the way a 1m rate would be), and peak memory/CPU. It prints one row per tool (debezium, outboxx, pgstream) and compares outboxx against both debezium and pgstream.
 
-Example (Apple M1, mixed insert/update/delete, neither reader resource-capped):
+Example from a debezium vs outboxx run (Apple M1, mixed insert/update/delete, neither reader resource-capped). A run with pgstream started adds a third row and an `outboxx vs pgstream` block:
 
 ```
 % make results MINUTES=200
@@ -64,6 +65,17 @@ outboxx vs debezium:
 ```
 
 Set the lookback with `MINUTES=` (default 60). The window must bracket a single run, so `make reset` between runs to start each topic at 0. `mem_peak`/`cpu_peak` come from cAdvisor (container working set and cores).
+
+## pgstream
+
+[pgstream](https://github.com/xataio/pgstream) is the golang CDC reader in the comparison (from Xata), next to outboxx (zig) and debezium (java). Two things set it apart from both and shape the stand:
+
+- It decodes the WAL with the `wal2json` output plugin, not `pgoutput`. Neither the stock `postgres` image nor `debezium/postgres` ships wal2json, so the shared Postgres is built from `postgres/Dockerfile` (`postgres:18` with `postgresql-18-wal2json` added), keeping the built-in pgoutput that debezium and outboxx use.
+- It exports metrics over OTLP only, with no Prometheus endpoint to scrape. Its throughput and resource use come from kafka-exporter (topic append rate) and cAdvisor (memory/CPU), the same outward signals `make results` reads for every tool. The self-reported Grafana panels (events/sec, lag) stay debezium/outboxx only.
+
+pgstream creates its replication slot and internal schema itself through `pgstream init`, not `create-slots.sql`. The `pgstream-init` service runs that step from `create-slots`, so the wal2json slot exists before load just like the pgoutput slots. The reader runs from the prebuilt `ghcr.io/xataio/pgstream` image pinned in `docker-compose.yml`, so there is nothing to build.
+
+Config lives in `pgstream/config.yaml`. The Kafka batch is enlarged over pgstream's upstream example so it drains the backlog in batches closer to debezium's. The injector and XIDs are turned off so events carry row data instead of pgstream's internal ids (schema_id, table/column pgstream ids). The event shape itself (`action`, `columns[]`, `identity` on updates/deletes) is hardcoded in pgstream's serialiser, so it stays more verbose than outboxx's `op`/`data`/`meta`, and `REPLICA IDENTITY FULL` (needed by debezium/outboxx deletes) keeps `identity` populated; config cannot change either.
 
 ## Load Parameters
 
@@ -166,14 +178,17 @@ Topics:
 ```text
 debezium.public.benchmark_records         # Debezium
 outboxx.public.benchmark_records          # Outboxx
+pgstream.public.benchmark_records         # pgstream
 ```
 
-Grafana dashboard: **CDC / Debezium benchmark overview**. Besides the Kafka/cAdvisor
-comparison panels, Prometheus scrapes Outboxx's own `/metrics` (job `outboxx`, port
-9464) and Debezium's JMX metrics, so two panels compare each tool's self-reported
-numbers side by side: events/sec (`outboxx_events_processed_total` vs
-`debezium_postgres_streaming_totalnumberofeventsseen`) and lag behind source in
-seconds (`outboxx_replication_lag_seconds` vs Debezium's
-`millisecondsbehindsource / 1000`). Both lag metrics are wall-clock time behind the
-last committed transaction, so they share one axis. The Kafka-offset append-rate
-panel stays as an independent throughput comparison.
+Grafana ships two pairwise dashboards, each pitting outboxx against one
+competitor: **CDC: Outboxx vs Debezium** and **CDC: Outboxx vs pgstream**. They
+share the same panels: PostgreSQL write rate, Kafka append rate (kafka-exporter,
+an independent throughput view), and container memory/CPU (cAdvisor). Where both
+tools expose Prometheus metrics, two more panels compare self-reported events/sec
+and lag behind source in seconds: outboxx (`outboxx_events_processed_total`,
+`outboxx_replication_lag_seconds`) against Debezium's JMX
+(`totalnumberofeventsseen`, `millisecondsbehindsource / 1000`). The lag metrics
+are wall-clock time behind the last committed transaction, so they share one axis.
+pgstream has no Prometheus endpoint (OTLP only), so on its board the self-reported
+panels stay outboxx-only.

--- a/tests/load/docker-compose.yml
+++ b/tests/load/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   postgres:
-    image: postgres:16
+    # Built from ./postgres/Dockerfile: postgres:18 plus wal2json, which pgstream
+    # needs. debezium/outboxx use the built-in pgoutput. Neither the official image
+    # nor debezium/postgres ships wal2json, so we install it ourselves.
+    build:
+      context: ./postgres
+    image: cdc-postgres-wal2json:local
     container_name: cdc-postgres
     command:
       - postgres
@@ -27,7 +32,9 @@ services:
     ports:
       - "${LOAD_POSTGRES_PORT:-15432}:5432"
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      # postgres:18+ stores data in a version subdirectory and wants the volume
+      # mounted at /var/lib/postgresql (not /var/lib/postgresql/data as in <=17).
+      - postgres-data:/var/lib/postgresql
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/001-init.sql:ro
       - ./postgres/create-slots.sql:/sql/create-slots.sql:ro
       - ./postgres/slot-lag.sql:/sql/slot-lag.sql:ro
@@ -161,6 +168,32 @@ services:
       - ./outboxx/config.toml:/app/config.toml:ro
     command: ["--config", "/app/config.toml"]
     restart: unless-stopped
+
+  pgstream:
+    profiles: ["compare"]
+    image: ghcr.io/xataio/pgstream:1.2.1
+    container_name: cdc-pgstream
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    volumes:
+      - ./pgstream/config.yaml:/pgstream.yaml:ro
+    command: ["run", "-c", "/pgstream.yaml", "--log-level", "info"]
+    restart: unless-stopped
+
+  # One-shot slot + pgstream-schema setup (wal2json slot, schema_log, triggers).
+  # Analogous to connector-init for debezium; run via `docker compose run --rm`.
+  pgstream-init:
+    image: ghcr.io/xataio/pgstream:1.2.1
+    container_name: cdc-pgstream-init
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./pgstream/config.yaml:/pgstream.yaml:ro
+    command: ["init", "-c", "/pgstream.yaml"]
 
   smoke-consumer:
     image: quay.io/debezium/kafka:3.5.2.Final

--- a/tests/load/grafana/dashboards/outboxx-vs-debezium.json
+++ b/tests/load/grafana/dashboards/outboxx-vs-debezium.json
@@ -1,0 +1,698 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "rate(pg_stat_database_tup_inserted{datname=\"bench\"}[1m])",
+          "legendFormat": "insert",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "rate(pg_stat_database_tup_updated{datname=\"bench\"}[1m])",
+          "legendFormat": "update",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "rate(pg_stat_database_tup_deleted{datname=\"bench\"}[1m])",
+          "legendFormat": "delete",
+          "refId": "C"
+        }
+      ],
+      "title": "PostgreSQL write rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "eps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "outboxx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "debezium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(kafka_topic_partition_current_offset{topic=\"outboxx.public.benchmark_records\"}[1m]))",
+          "legendFormat": "outboxx",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(kafka_topic_partition_current_offset{topic=\"debezium.public.benchmark_records\"}[1m]))",
+          "legendFormat": "debezium",
+          "refId": "B"
+        }
+      ],
+      "title": "Kafka append rate: outboxx vs Debezium",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "outboxx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "debezium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "container_memory_working_set_bytes{container_label_com_docker_compose_service=~\"outboxx|debezium\"}",
+          "legendFormat": "{{container_label_com_docker_compose_service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Container memory: outboxx vs Debezium",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "cores"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "outboxx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "debezium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum by (container_label_com_docker_compose_service) (rate(container_cpu_usage_seconds_total{container_label_com_docker_compose_service=~\"outboxx|debezium\"}[1m]))",
+          "legendFormat": "{{container_label_com_docker_compose_service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Container CPU: outboxx vs Debezium",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "eps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "outboxx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "debezium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "rate(outboxx_events_processed_total[1m])",
+          "legendFormat": "outboxx",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(debezium_postgres_streaming_totalnumberofeventsseen[1m]))",
+          "legendFormat": "debezium",
+          "refId": "B"
+        }
+      ],
+      "title": "CDC events/sec (self-reported): outboxx vs Debezium",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "outboxx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "debezium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "outboxx_replication_lag_seconds",
+          "legendFormat": "outboxx",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "max(debezium_postgres_streaming_millisecondsbehindsource) / 1000",
+          "legendFormat": "debezium",
+          "refId": "B"
+        }
+      ],
+      "title": "CDC lag behind source (seconds): outboxx vs Debezium",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "cdc",
+    "outboxx",
+    "debezium",
+    "kafka"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "CDC: Outboxx vs Debezium",
+  "uid": "outboxx-vs-debezium",
+  "version": 1
+}

--- a/tests/load/grafana/dashboards/outboxx-vs-pgstream.json
+++ b/tests/load/grafana/dashboards/outboxx-vs-pgstream.json
@@ -9,18 +9,15 @@
         },
         "enable": true,
         "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "datasource": {
@@ -33,27 +30,12 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
             "axisPlacement": "auto",
-            "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
             "showPoints": "never",
             "spanNulls": false,
             "stacking": {
@@ -84,7 +66,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 4,
+      "id": 1,
       "options": {
         "legend": {
           "calcs": [
@@ -142,9 +124,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisPlacement": "auto",
             "drawStyle": "line",
             "fillOpacity": 10,
@@ -192,14 +171,14 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "debezium"
+              "options": "pgstream"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
                   "mode": "fixed",
-                  "fixedColor": "orange"
+                  "fixedColor": "purple"
                 }
               }
             ]
@@ -212,7 +191,7 @@
         "x": 12,
         "y": 0
       },
-      "id": 7,
+      "id": 2,
       "options": {
         "legend": {
           "calcs": [
@@ -233,8 +212,8 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "sum(rate(kafka_topic_partition_current_offset{topic=\"debezium.public.benchmark_records\"}[1m]))",
-          "legendFormat": "debezium",
+          "expr": "sum(rate(kafka_topic_partition_current_offset{topic=\"outboxx.public.benchmark_records\"}[1m]))",
+          "legendFormat": "outboxx",
           "refId": "A"
         },
         {
@@ -242,12 +221,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "sum(rate(kafka_topic_partition_current_offset{topic=\"outboxx.public.benchmark_records\"}[1m]))",
-          "legendFormat": "outboxx",
+          "expr": "sum(rate(kafka_topic_partition_current_offset{topic=\"pgstream.public.benchmark_records\"}[1m]))",
+          "legendFormat": "pgstream",
           "refId": "B"
         }
       ],
-      "title": "Debezium vs Outboxx Kafka append rate",
+      "title": "Kafka append rate: outboxx vs pgstream",
       "type": "timeseries"
     },
     {
@@ -261,9 +240,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisPlacement": "auto",
             "drawStyle": "line",
             "fillOpacity": 10,
@@ -311,14 +287,14 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "debezium"
+              "options": "pgstream"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
                   "mode": "fixed",
-                  "fixedColor": "orange"
+                  "fixedColor": "purple"
                 }
               }
             ]
@@ -331,7 +307,7 @@
         "x": 0,
         "y": 8
       },
-      "id": 8,
+      "id": 3,
       "options": {
         "legend": {
           "calcs": [
@@ -352,12 +328,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "container_memory_working_set_bytes{container_label_com_docker_compose_service=~\"debezium|outboxx\"}",
+          "expr": "container_memory_working_set_bytes{container_label_com_docker_compose_service=~\"outboxx|pgstream\"}",
           "legendFormat": "{{container_label_com_docker_compose_service}}",
           "refId": "A"
         }
       ],
-      "title": "Container memory: Debezium vs Outboxx",
+      "title": "Container memory: outboxx vs pgstream",
       "type": "timeseries"
     },
     {
@@ -371,9 +347,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisPlacement": "auto",
             "drawStyle": "line",
             "fillOpacity": 10,
@@ -421,14 +394,14 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "debezium"
+              "options": "pgstream"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
                   "mode": "fixed",
-                  "fixedColor": "orange"
+                  "fixedColor": "purple"
                 }
               }
             ]
@@ -441,7 +414,7 @@
         "x": 12,
         "y": 8
       },
-      "id": 9,
+      "id": 4,
       "options": {
         "legend": {
           "calcs": [
@@ -462,12 +435,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "sum by (container_label_com_docker_compose_service) (rate(container_cpu_usage_seconds_total{container_label_com_docker_compose_service=~\"debezium|outboxx\"}[1m]))",
+          "expr": "sum by (container_label_com_docker_compose_service) (rate(container_cpu_usage_seconds_total{container_label_com_docker_compose_service=~\"outboxx|pgstream\"}[1m]))",
           "legendFormat": "{{container_label_com_docker_compose_service}}",
           "refId": "A"
         }
       ],
-      "title": "Container CPU: Debezium vs Outboxx",
+      "title": "Container CPU: outboxx vs pgstream",
       "type": "timeseries"
     },
     {
@@ -481,9 +454,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisPlacement": "auto",
             "drawStyle": "line",
             "fillOpacity": 10,
@@ -512,7 +482,38 @@
           },
           "unit": "eps"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "outboxx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pgstream"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "purple"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -520,7 +521,7 @@
         "x": 0,
         "y": 16
       },
-      "id": 10,
+      "id": 5,
       "options": {
         "legend": {
           "calcs": [
@@ -542,20 +543,11 @@
             "uid": "Prometheus"
           },
           "expr": "rate(outboxx_events_processed_total[1m])",
-          "legendFormat": "outboxx (self-reported)",
+          "legendFormat": "outboxx",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "expr": "sum(rate(debezium_postgres_streaming_totalnumberofeventsseen[1m]))",
-          "legendFormat": "debezium (self-reported)",
-          "refId": "B"
         }
       ],
-      "title": "CDC events/sec: Outboxx vs Debezium (self-reported)",
+      "title": "CDC events/sec (self-reported): outboxx only (pgstream exports OTLP, not Prometheus)",
       "type": "timeseries"
     },
     {
@@ -569,9 +561,6 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisPlacement": "auto",
             "drawStyle": "line",
             "fillOpacity": 10,
@@ -600,7 +589,38 @@
           },
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "outboxx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pgstream"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "purple"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -608,7 +628,7 @@
         "x": 12,
         "y": 16
       },
-      "id": 11,
+      "id": 6,
       "options": {
         "legend": {
           "calcs": [
@@ -632,18 +652,9 @@
           "expr": "outboxx_replication_lag_seconds",
           "legendFormat": "outboxx",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "expr": "max(debezium_postgres_streaming_millisecondsbehindsource) / 1000",
-          "legendFormat": "debezium",
-          "refId": "B"
         }
       ],
-      "title": "CDC lag behind source: Outboxx vs Debezium (seconds)",
+      "title": "CDC lag behind source (seconds): outboxx only (pgstream exports OTLP, not Prometheus)",
       "type": "timeseries"
     }
   ],
@@ -651,8 +662,8 @@
   "schemaVersion": 39,
   "tags": [
     "cdc",
-    "debezium",
-    "postgres",
+    "outboxx",
+    "pgstream",
     "kafka"
   ],
   "templating": {
@@ -662,10 +673,8 @@
     "from": "now-30m",
     "to": "now"
   },
-  "timepicker": {},
   "timezone": "browser",
-  "title": "CDC / Debezium benchmark overview",
-  "uid": "cdc-debezium-benchmark",
-  "version": 1,
-  "weekStart": ""
+  "title": "CDC: Outboxx vs pgstream",
+  "uid": "outboxx-vs-pgstream",
+  "version": 1
 }

--- a/tests/load/outboxx/Dockerfile
+++ b/tests/load/outboxx/Dockerfile
@@ -12,7 +12,7 @@ RUN nix develop --command echo "deps cached"
 # -Dlog_level=debug keeps ReleaseFast perf but compiles in std.log.debug so the
 # load stand can trace teardown / fail-fast behavior.
 COPY . .
-RUN nix develop --command zig build -Doptimize=ReleaseFast -Dlog_level=debug
+RUN nix develop --command zig build -Doptimize=ReleaseFast -Dlog_level=info
 
 WORKDIR /app
 EXPOSE 9464

--- a/tests/load/pgstream/config.yaml
+++ b/tests/load/pgstream/config.yaml
@@ -1,0 +1,42 @@
+# pgstream (github.com/xataio/pgstream) reader for the benchmark: Postgres CDC
+# -> Kafka, the golang counterpart to outboxx (zig) and debezium (java).
+#
+# Unlike debezium/outboxx, pgstream decodes the WAL with wal2json (not pgoutput),
+# so the shared Postgres image must ship that plugin and the slot is created by
+# `pgstream init`, not by create-slots.sql. pgstream also needs its own schema
+# (schema_log, triggers) which `init` installs; `run` only connects.
+source:
+  postgres:
+    url: "postgres://postgres:postgres@postgres:5432/bench?sslmode=disable"
+    mode: replication # replication only, no initial snapshot (matches debezium no_data)
+    replication:
+      replication_slot: "pgstream_benchmark_slot"
+      plugin:
+        include_xids: false # keep transaction ids out of the payload
+        add_tables: "public.benchmark_records" # decode only the benchmark table
+
+target:
+  kafka:
+    servers: ["kafka:9092"]
+    topic:
+      name: "pgstream.public.benchmark_records"
+      partitions: 1
+      replication_factor: 1
+      auto_create: true
+    # size is raised over the upstream example (100) so the reader drains the WAL
+    # backlog in larger batches. max_bytes stays at 1MiB to sit under Kafka's
+    # default message.max.bytes (~1MiB per record batch); it is the effective
+    # flush trigger here, since 10000 small rows exceed 1MiB first.
+    batch:
+      timeout: 1000 # flush at least once per second
+      size: 10000 # messages per batch
+      max_bytes: 1048576 # 1MiB, under the broker's default record-batch limit
+
+# Strip everything optional so the message carries row data, not pgstream
+# internals: the injector (schema_id, table/column pgstream ids) is off and no
+# transformer/filter runs. The event shape itself (action, columns[], identity
+# for updates/deletes, an empty metadata object) is hardcoded in pgstream's
+# serialiser and cannot be turned into outboxx's op/data/meta by config.
+modifiers:
+  injector:
+    enabled: false # drop pgstream metadata; emit only the row data

--- a/tests/load/postgres/Dockerfile
+++ b/tests/load/postgres/Dockerfile
@@ -1,0 +1,9 @@
+# Postgres with wal2json, which pgstream needs (debezium and outboxx use the
+# built-in pgoutput). Neither the official postgres image nor debezium/postgres
+# ships wal2json, so install it from the pgdg apt repo the base image already has.
+# Recipe follows pgstream's own build/docker/postgres-18 image, minus the
+# anonymizer extension the benchmark does not use.
+FROM postgres:18
+RUN apt-get update \
+	&& apt-get install -y postgresql-18-wal2json \
+	&& rm -rf /var/lib/apt/lists/*

--- a/tests/load/postgres/slot-lag.sql
+++ b/tests/load/postgres/slot-lag.sql
@@ -7,5 +7,5 @@ SELECT
     pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal,
     pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)) AS unflushed_wal
 FROM pg_replication_slots
-WHERE slot_name IN ('dbz_benchmark_slot', 'outboxx_benchmark_slot')
+WHERE slot_name IN ('dbz_benchmark_slot', 'outboxx_benchmark_slot', 'pgstream_benchmark_slot')
 ORDER BY slot_name;

--- a/tests/load/scripts/results.sh
+++ b/tests/load/scripts/results.sh
@@ -57,7 +57,7 @@ echo "Window: last ${MINUTES}m"
 printf "%-9s %13s %10s %15s %11s %9s\n" tool events "drain(s)" "evt/s(eff)" "mem_peak" "cpu_peak"
 
 # Plain per-tool vars (macOS ships bash 3.2 without associative arrays).
-for tool in debezium outboxx; do
+for tool in debezium outboxx pgstream; do
   read -r ev s thr < <(drain "${tool}.public.benchmark_records")
   mem="$(instant "max_over_time(container_memory_working_set_bytes{container_label_com_docker_compose_service=\"$tool\"}[$win])")"
   cpu="$(instant "max_over_time(sum(rate(container_cpu_usage_seconds_total{container_label_com_docker_compose_service=\"$tool\"}[1m]))[$win:15s])")"
@@ -72,3 +72,9 @@ echo "outboxx vs debezium:"
 echo "  throughput:  $(ratio "$THR_outboxx" "$THR_debezium") (outboxx / debezium)"
 echo "  memory:      $(ratio "$MEM_debezium" "$MEM_outboxx") less (debezium / outboxx)"
 echo "  cpu peak:    $(ratio "$CPU_debezium" "$CPU_outboxx") less (debezium / outboxx)"
+
+echo
+echo "outboxx vs pgstream:"
+echo "  throughput:  $(ratio "$THR_outboxx" "$THR_pgstream") (outboxx / pgstream)"
+echo "  memory:      $(ratio "$MEM_pgstream" "$MEM_outboxx") less (pgstream / outboxx)"
+echo "  cpu peak:    $(ratio "$CPU_pgstream" "$CPU_outboxx") less (pgstream / outboxx)"


### PR DESCRIPTION
Adds pgstream (Xata, Go) as a third CDC reader in the load stand, so outboxx can be measured against a lightweight Go tool alongside debezium.

- pgstream decodes the WAL with wal2json instead of pgoutput, so the shared Postgres is now built with the plugin (`postgres/Dockerfile`, `postgres:18` + `postgresql-18-wal2json`). debezium and outboxx keep using the built-in pgoutput.
- pgstream exports metrics over OTLP only, so its throughput and resource use are read from kafka-exporter and cAdvisor like the other outward numbers; the self-reported Grafana panels stay debezium/outboxx.
- The single overview dashboard is split into per-competitor pairwise boards (Outboxx vs Debezium, Outboxx vs pgstream) so each comparison reads on its own.
- Also flips the outboxx load image to `log_level=info`.