### PR TITLE
Apply backpressure on a full Kafka producer queue

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -29,13 +29,12 @@ pub const CDC = struct {
     pub const KAFKA_POLL_INTERVAL: u32 = 100; // Poll every N messages (reduces syscall overhead)
 
     // Backpressure on a full producer queue. The synchronous pipeline blocks the
-    // WAL read here, so Postgres slows too: serve delivery reports and retry until
-    // the queue drains, bounded by MAX_WAIT_MS so a wedged broker still fails fast.
-    // Sits between delivery.timeout.ms (30s: the queue can't stay full longer) and
-    // OBSERVABILITY.LIVENESS_MAX_STALE_SEC (90s), so runtime spikes ride out while a
-    // real stall still exits before liveness trips.
-    pub const KAFKA_BACKPRESSURE_MAX_WAIT_MS: i64 = 40_000;
-    pub const KAFKA_BACKPRESSURE_POLL_MS: i32 = 100; // Blocking poll between retries; serves delivery reports
+    // WAL read here, so Postgres slows too: block on poll (it wakes up as soon as
+    // a delivery report lands, not just on timeout) and retry produce. No deadline
+    // of our own is needed: a message can't sit in the queue past
+    // delivery.timeout.ms (30s) before its delivery report fires, so a wedged
+    // broker surfaces as deliveryErrorCount > 0 well within that window.
+    pub const KAFKA_BACKPRESSURE_POLL_MS: i32 = 5000;
 };
 
 /// Observability tuning constants.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -28,13 +28,15 @@ pub const CDC = struct {
     pub const KAFKA_BATCH_SIZE = "262144"; // 256KB batches for better network utilization
     pub const KAFKA_POLL_INTERVAL: u32 = 100; // Poll every N messages (reduces syscall overhead)
 
-    // Backpressure on a full producer queue. The synchronous pipeline blocks the
-    // WAL read here, so Postgres slows too: block on poll (it wakes up as soon as
-    // a delivery report lands, not just on timeout) and retry produce. No deadline
-    // of our own is needed: a message can't sit in the queue past
-    // delivery.timeout.ms (30s) before its delivery report fires, so a wedged
-    // broker surfaces as deliveryErrorCount > 0 well within that window.
-    pub const KAFKA_BACKPRESSURE_POLL_MS: i32 = 5000;
+    // Poll slice while draining the producer queue: flush loops on it until the
+    // queue empties, and backpressure reuses flush on a full queue. Blocking poll
+    // wakes as soon as a delivery report lands, not just on timeout. No overall
+    // deadline of our own: a message can't sit in the queue past delivery.timeout.ms
+    // (30s) before its delivery report fires, so a wedged broker surfaces as a
+    // failed delivery well within that window (and the 90s liveness limit). The
+    // slice only bounds how often the drain loop rechecks the queue, delivery
+    // errors, and the stop signal.
+    pub const KAFKA_FLUSH_POLL_MS: i32 = 5000;
 };
 
 /// Observability tuning constants.

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -27,6 +27,15 @@ pub const CDC = struct {
     pub const KAFKA_LINGER_MS = "50"; // Optimal for throughput (balance batching vs latency)
     pub const KAFKA_BATCH_SIZE = "262144"; // 256KB batches for better network utilization
     pub const KAFKA_POLL_INTERVAL: u32 = 100; // Poll every N messages (reduces syscall overhead)
+
+    // Backpressure on a full producer queue. The synchronous pipeline blocks the
+    // WAL read here, so Postgres slows too: serve delivery reports and retry until
+    // the queue drains, bounded by MAX_WAIT_MS so a wedged broker still fails fast.
+    // Sits between delivery.timeout.ms (30s: the queue can't stay full longer) and
+    // OBSERVABILITY.LIVENESS_MAX_STALE_SEC (90s), so runtime spikes ride out while a
+    // real stall still exits before liveness trips.
+    pub const KAFKA_BACKPRESSURE_MAX_WAIT_MS: i64 = 40_000;
+    pub const KAFKA_BACKPRESSURE_POLL_MS: i32 = 100; // Blocking poll between retries; serves delivery reports
 };
 
 /// Observability tuning constants.

--- a/src/kafka/producer.zig
+++ b/src/kafka/producer.zig
@@ -6,6 +6,7 @@ const KafkaError = error{
     ProducerCreationFailed,
     TopicCreationFailed,
     MessageSendFailed,
+    QueueFull,
     FlushFailed,
     ConfigurationFailed,
     ConnectionTestFailed,
@@ -298,6 +299,9 @@ pub const KafkaProducer = struct {
 
         if (result == -1) {
             const errno = c.rd_kafka_last_error();
+            // A full local queue is backpressure, not a failure: the processor
+            // drains delivery reports and retries. Keep it a distinct error.
+            if (errno == c.RD_KAFKA_RESP_ERR__QUEUE_FULL) return KafkaError.QueueFull;
             std.log.warn("Failed to produce message: {s}", .{c.rd_kafka_err2str(errno)});
             return KafkaError.MessageSendFailed;
         }
@@ -306,6 +310,13 @@ pub const KafkaProducer = struct {
     pub fn poll(self: *Self) void {
         const producer = self.producer orelse return;
         _ = c.rd_kafka_poll(producer, 0);
+    }
+
+    // Blocking drain used only for backpressure: wait up to timeout_ms while
+    // serving delivery reports, so the queue can free up before we retry.
+    pub fn drainFor(self: *Self, timeout_ms: i32) void {
+        const producer = self.producer orelse return;
+        _ = c.rd_kafka_poll(producer, timeout_ms);
     }
 
     pub fn flush(self: *Self, timeout_ms: i32) !void {
@@ -400,4 +411,44 @@ test "delivery callback counts a permanently failed message" {
     producer.flush(5000) catch {};
 
     try testing.expect(producer.deliveryErrorCount() > 0);
+}
+
+test "sendMessage reports a full queue as error.QueueFull" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var errstr: [512]u8 = undefined;
+    const mock_rk = c.rd_kafka_new(c.RD_KAFKA_PRODUCER, c.rd_kafka_conf_new(), &errstr, errstr.len);
+    try testing.expect(mock_rk != null);
+    defer c.rd_kafka_destroy(mock_rk);
+
+    const mcluster = c.rd_kafka_mock_cluster_new(mock_rk, 1);
+    try testing.expect(mcluster != null);
+    defer c.rd_kafka_mock_cluster_destroy(mcluster);
+
+    const bootstraps = std.mem.span(c.rd_kafka_mock_cluster_bootstraps(mcluster));
+    try testing.expect(c.rd_kafka_mock_topic_create(mcluster, "t", 1, 1) == c.RD_KAFKA_RESP_ERR_NO_ERROR);
+
+    // Broker down: nothing drains, so the local queue fills and rd_kafka_produce
+    // returns QUEUE_FULL. sendMessage must surface that as the distinct
+    // error.QueueFull (backpressure), not MessageSendFailed.
+    c.rd_kafka_mock_broker_set_down(mcluster, 1);
+
+    var producer = try KafkaProducer.init(allocator, bootstraps, null);
+    defer producer.deinit();
+    // The queue holds up to queue.buffering.max.messages undeliverable messages;
+    // purge before deinit so the final flush doesn't block on the downed broker.
+    defer _ = c.rd_kafka_purge(producer.producer.?, c.RD_KAFKA_PURGE_F_QUEUE | c.RD_KAFKA_PURGE_F_INFLIGHT);
+
+    // Fill past the default 100k queue; QueueFull must arrive before this bound.
+    var got_queue_full = false;
+    var i: usize = 0;
+    while (i < 200_000) : (i += 1) {
+        producer.sendMessage("t", null, "{}") catch |err| {
+            try testing.expectEqual(error.QueueFull, err);
+            got_queue_full = true;
+            break;
+        };
+    }
+    try testing.expect(got_queue_full);
 }

--- a/src/kafka/producer.zig
+++ b/src/kafka/producer.zig
@@ -36,6 +36,10 @@ pub const KafkaProducer = struct {
     // Heap-allocated so its address stays stable when the struct is moved into
     // the Processor: it is handed to librdkafka as the delivery-callback opaque.
     delivery_errors: *std.atomic.Value(u64),
+    // Sends since the last poll. A produced message holds a queue slot until its
+    // delivery report is served, so sendMessage self-drains every
+    // KAFKA_POLL_INTERVAL sends and callers never poll by hand.
+    sent_since_poll: u32 = 0,
 
     const Self = @This();
 
@@ -273,6 +277,10 @@ pub const KafkaProducer = struct {
         }
 
         std.log.debug("Batch sent: {d} messages to topic {s}", .{ sent, topic_name });
+
+        // Drain the batch's delivery reports so the queue does not grow unbounded
+        // across calls.
+        self.poll(0);
     }
 
     pub fn sendMessage(self: *Self, topic_name: []const u8, key: ?[]const u8, message: []const u8) !void {
@@ -299,27 +307,74 @@ pub const KafkaProducer = struct {
 
         if (result == -1) {
             const errno = c.rd_kafka_last_error();
-            // A full local queue is backpressure, not a failure: the processor
-            // drains delivery reports and retries. Keep it a distinct error.
+            // A full local queue is backpressure, not a failure: send() drains it
+            // and retries. Keep it a distinct error so send() can tell it apart.
             if (errno == c.RD_KAFKA_RESP_ERR__QUEUE_FULL) return KafkaError.QueueFull;
             std.log.warn("Failed to produce message: {s}", .{c.rd_kafka_err2str(errno)});
             return KafkaError.MessageSendFailed;
         }
+
+        // Serve delivery reports periodically so a long run of sends does not fill
+        // the queue between flushes and so failures surface without waiting for one.
+        self.sent_since_poll += 1;
+        if (self.sent_since_poll >= constants.CDC.KAFKA_POLL_INTERVAL) {
+            self.poll(0);
+            self.sent_since_poll = 0;
+        }
     }
 
-    pub fn poll(self: *Self, timeout_ms: i32) void {
+    // Raw event pump: serves delivery reports and frees queue slots. Private
+    // plumbing behind send/flush, which own how long to block.
+    fn poll(self: *Self, timeout_ms: i32) void {
         const producer = self.producer orelse return;
         _ = c.rd_kafka_poll(producer, timeout_ms);
     }
 
-    pub fn flush(self: *Self, timeout_ms: i32) !void {
+    /// Produce one message, treating a full local queue as backpressure rather
+    /// than an error. The pipeline is synchronous, so blocking here stalls the WAL
+    /// read and slows Postgres to match. On a full queue, flush drains it (which
+    /// also fails fast if any message permanently failed) and we retry. Returns
+    /// error.Shutdown if stop_signal fires while waiting, so the caller can stop
+    /// without staging an un-delivered LSN.
+    pub fn send(
+        self: *Self,
+        stop_signal: *std.atomic.Value(bool),
+        topic_name: []const u8,
+        key: ?[]const u8,
+        payload: []const u8,
+    ) !void {
+        while (true) {
+            self.sendMessage(topic_name, key, payload) catch |err| switch (err) {
+                error.QueueFull => {
+                    try self.flush(stop_signal);
+                    continue;
+                },
+                else => return err,
+            };
+            return;
+        }
+    }
+
+    /// Block until every produced message has been delivered, draining delivery
+    /// reports as they arrive. A clean return means the local queue is empty and
+    /// no message failed, so the caller may safely confirm the LSN. Returns
+    /// error.DeliveryFailed if any message permanently failed (a drained queue is
+    /// not a delivered queue) or error.Shutdown if stop_signal fires mid-drain.
+    /// No overall deadline of our own: delivery.timeout.ms bounds how long a
+    /// message can sit in the queue, so the loop always terminates within it.
+    pub fn flush(self: *Self, stop_signal: ?*std.atomic.Value(bool)) !void {
         const producer = self.producer orelse return KafkaError.FlushFailed;
 
-        const err = c.rd_kafka_flush(producer, timeout_ms);
-        if (err != c.RD_KAFKA_RESP_ERR_NO_ERROR) {
-            std.log.warn("Kafka flush failed: {s}", .{c.rd_kafka_err2str(err)});
-            return KafkaError.FlushFailed;
+        while (c.rd_kafka_outq_len(producer) > 0) {
+            if (self.deliveryErrorCount() > 0) return error.DeliveryFailed;
+            if (stop_signal) |s| {
+                if (s.load(.monotonic)) return error.Shutdown;
+            }
+            self.poll(constants.CDC.KAFKA_FLUSH_POLL_MS);
         }
+        // The last poll may have emptied the queue via a failed delivery; catch it
+        // so a clean return always means every message was actually delivered.
+        if (self.deliveryErrorCount() > 0) return error.DeliveryFailed;
     }
 
     /// Count of messages that permanently failed delivery over the producer's
@@ -401,7 +456,7 @@ test "delivery callback counts a permanently failed message" {
 
     try producer.sendMessage("t", "k", "{}");
     // flush serves the delivery callback on this thread, counting the failure.
-    producer.flush(5000) catch {};
+    producer.flush(null) catch {};
 
     try testing.expect(producer.deliveryErrorCount() > 0);
 }

--- a/src/kafka/producer.zig
+++ b/src/kafka/producer.zig
@@ -307,14 +307,7 @@ pub const KafkaProducer = struct {
         }
     }
 
-    pub fn poll(self: *Self) void {
-        const producer = self.producer orelse return;
-        _ = c.rd_kafka_poll(producer, 0);
-    }
-
-    // Blocking drain used only for backpressure: wait up to timeout_ms while
-    // serving delivery reports, so the queue can free up before we retry.
-    pub fn drainFor(self: *Self, timeout_ms: i32) void {
+    pub fn poll(self: *Self, timeout_ms: i32) void {
         const producer = self.producer orelse return;
         _ = c.rd_kafka_poll(producer, timeout_ms);
     }

--- a/src/kafka/producer.zig
+++ b/src/kafka/producer.zig
@@ -37,8 +37,8 @@ pub const KafkaProducer = struct {
     // the Processor: it is handed to librdkafka as the delivery-callback opaque.
     delivery_errors: *std.atomic.Value(u64),
     // Sends since the last poll. A produced message holds a queue slot until its
-    // delivery report is served, so sendMessage self-drains every
-    // KAFKA_POLL_INTERVAL sends and callers never poll by hand.
+    // delivery report is served, so send() self-drains every KAFKA_POLL_INTERVAL
+    // messages and callers never poll by hand.
     sent_since_poll: u32 = 0,
 
     const Self = @This();
@@ -313,14 +313,6 @@ pub const KafkaProducer = struct {
             std.log.warn("Failed to produce message: {s}", .{c.rd_kafka_err2str(errno)});
             return KafkaError.MessageSendFailed;
         }
-
-        // Serve delivery reports periodically so a long run of sends does not fill
-        // the queue between flushes and so failures surface without waiting for one.
-        self.sent_since_poll += 1;
-        if (self.sent_since_poll >= constants.CDC.KAFKA_POLL_INTERVAL) {
-            self.poll(0);
-            self.sent_since_poll = 0;
-        }
     }
 
     // Raw event pump: serves delivery reports and frees queue slots. Private
@@ -351,6 +343,14 @@ pub const KafkaProducer = struct {
                 },
                 else => return err,
             };
+
+            // Serve delivery reports periodically so a long run of sends does not fill
+            // the queue between flushes and so failures surface without waiting for one.
+            self.sent_since_poll += 1;
+            if (self.sent_since_poll >= constants.CDC.KAFKA_POLL_INTERVAL) {
+                self.poll(0);
+                self.sent_since_poll = 0;
+            }
             return;
         }
     }

--- a/src/kafka/producer.zig
+++ b/src/kafka/producer.zig
@@ -432,7 +432,7 @@ test "sendMessage reports a full queue as error.QueueFull" {
     // Broker down: nothing drains, so the local queue fills and rd_kafka_produce
     // returns QUEUE_FULL. sendMessage must surface that as the distinct
     // error.QueueFull (backpressure), not MessageSendFailed.
-    c.rd_kafka_mock_broker_set_down(mcluster, 1);
+    _ = c.rd_kafka_mock_broker_set_down(mcluster, 1);
 
     var producer = try KafkaProducer.init(allocator, bootstraps, null);
     defer producer.deinit();

--- a/src/kafka/producer_test.zig
+++ b/src/kafka/producer_test.zig
@@ -111,7 +111,7 @@ test "KafkaProducer can send message to topic" {
     try producer.sendMessage(test_topic, test_key, test_message);
 
     // Flush to ensure message is sent
-    try producer.flush(5000);
+    try producer.flush(null);
 
     // Verify the message was actually written to Kafka
     const message_written = verifyMessageWritten(allocator, "localhost:9092", test_topic, test_message, null) catch false;
@@ -148,7 +148,7 @@ test "KafkaProducer can send messages to multiple topics" {
     }
 
     // Flush all messages
-    try producer.flush(5000);
+    try producer.flush(null);
 
     // Verify at least one message was written
     const first_topic = topics[0];
@@ -214,7 +214,7 @@ test "KafkaProducer memory management" {
 
         try producer.sendMessage(topic, "memory_test", message);
 
-        try producer.flush(1000);
+        try producer.flush(null);
     }
 
     std.debug.print("Memory management test completed successfully\n", .{});
@@ -254,7 +254,7 @@ test "KafkaProducer connects over TLS and verifies the broker with a CA" {
     const topic = "test.kafka.tls";
     const message = "{\"operation\":\"INSERT\",\"table\":\"tls_table\",\"data\":\"tls_data\"}";
     try producer.sendMessage(topic, "tls_key", message);
-    try producer.flush(5000);
+    try producer.flush(null);
 
     const written = verifyMessageWritten(allocator, brokers, topic, message, ca) catch false;
     if (written) {

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -200,13 +200,13 @@ pub const Processor = struct {
                 const topic_name = stream.sink.destination;
                 const partition_key = try self.getPartitionKey(batch_allocator, change_event, stream);
 
-                try self.produceWithBackpressure(io, stop_signal, topic_name, partition_key, json_bytes);
+                try self.produceWithBackpressure(stop_signal, topic_name, partition_key, json_bytes);
 
                 try tallyEvent(&event_counts, batch_allocator, stream.name, change_event.op);
 
                 sent_since_poll += 1;
                 if (sent_since_poll >= constants.CDC.KAFKA_POLL_INTERVAL) {
-                    producer.poll();
+                    producer.poll(0);
                     sent_since_poll = 0;
                 }
 
@@ -219,7 +219,7 @@ pub const Processor = struct {
 
         for (event_counts.items) |e| self.obs.addEvents(e.count, e.stream, e.operation);
 
-        producer.poll();
+        producer.poll(0);
 
         self.pending_lsn.store(batch.last_lsn, .release);
     }
@@ -249,20 +249,19 @@ pub const Processor = struct {
 
     // Produce one message, treating a full producer queue as backpressure rather
     // than a failure. The pipeline is synchronous, so blocking here stalls the WAL
-    // read and slows Postgres. Serve delivery reports (which free the queue as acks
-    // land) and retry until it drains, bounded by KAFKA_BACKPRESSURE_MAX_WAIT_MS so a
-    // wedged broker still fails fast. Returns error.Shutdown when stop_signal fires
-    // mid-wait, so the caller can stop gracefully without staging the batch LSN.
+    // read and slows Postgres. Block on poll (it wakes on the first delivery report)
+    // to drain the queue, then retry. No deadline of our own: delivery.timeout.ms
+    // bounds how long a message can sit in the queue, and a wedged broker surfaces
+    // as deliveryErrorCount > 0 within it. Returns error.Shutdown when stop_signal
+    // fires mid-wait, so the caller can stop gracefully without staging the LSN.
     fn produceWithBackpressure(
         self: *Self,
-        io: std.Io,
         stop_signal: *std.atomic.Value(bool),
         topic_name: []const u8,
         key: ?[]const u8,
         payload: []const u8,
     ) !void {
         const producer = &self.producer;
-        var deadline: ?std.Io.Timestamp = null;
         while (true) {
             producer.sendMessage(topic_name, key, payload) catch |err| switch (err) {
                 error.QueueFull => {
@@ -270,19 +269,7 @@ pub const Processor = struct {
                     // A permanent delivery failure means the broker is rejecting, not
                     // just slow: stop waiting and fail fast now.
                     if (producer.deliveryErrorCount() > 0) return error.DeliveryFailed;
-
-                    const d = deadline orelse blk: {
-                        const nd = std.Io.Timestamp.now(io, .awake)
-                            .addDuration(.fromMilliseconds(constants.CDC.KAFKA_BACKPRESSURE_MAX_WAIT_MS));
-                        deadline = nd;
-                        break :blk nd;
-                    };
-                    if (std.Io.Timestamp.now(io, .awake).nanoseconds >= d.nanoseconds) {
-                        self.obs.recordProduceError();
-                        std.log.warn("Kafka queue full past backpressure window, failing fast", .{});
-                        return error.MessageSendFailed;
-                    }
-                    producer.drainFor(constants.CDC.KAFKA_BACKPRESSURE_POLL_MS);
+                    producer.poll(constants.CDC.KAFKA_BACKPRESSURE_POLL_MS);
                     continue;
                 },
                 else => {

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -78,17 +78,12 @@ fn flushCommitWorker(
             continue;
         }
 
-        producer.flush(constants.CDC.KAFKA_FLUSH_TIMEOUT_MS) catch |err| {
+        // flush returns cleanly only once every message is delivered; an error
+        // (a permanent delivery failure) means this LSN is not safe to confirm.
+        producer.flush(null) catch |err| {
             std.log.err("Background flush failed: {}", .{err});
             continue;
         };
-
-        // A drained queue is not a delivered queue: a message can leave it by
-        // permanently failing. Hold the LSN if any did; the receive loop turns
-        // this into a fail-fast.
-        if (producer.deliveryErrorCount() > 0) {
-            continue;
-        }
 
         source.sendFeedback(io, lsn) catch |err| {
             std.log.err("Background LSN commit failed: {}", .{err});
@@ -98,14 +93,17 @@ fn flushCommitWorker(
 
     const lsn = pending_lsn.load(.acquire);
 
-    producer.flush(constants.CDC.KAFKA_FLUSH_TIMEOUT_MS) catch |err| {
-        std.log.warn("Final background flush failed: {}", .{err});
-    };
-
-    if (lsn > 0 and producer.deliveryErrorCount() == 0) {
-        source.sendFeedback(io, lsn) catch |err| {
-            std.log.warn("Final background LSN commit failed: {}", .{err});
-        };
+    // Confirm the final LSN only if the flush fully drained. A failed flush leaves
+    // messages un-delivered, and advancing the slot past them would break
+    // at-least-once on the next restart.
+    if (producer.flush(null)) |_| {
+        if (lsn > 0) {
+            source.sendFeedback(io, lsn) catch |err| {
+                std.log.warn("Final background LSN commit failed: {}", .{err});
+            };
+        }
+    } else |err| {
+        std.log.warn("Final flush failed; not confirming LSN {}: {}", .{ lsn, err });
     }
 
     std.log.debug("Flush/commit worker stopped", .{});
@@ -163,8 +161,6 @@ pub const Processor = struct {
         // loop turning: an empty batch on a dead stream must not refresh it.
         if (batch.changes.len > 0 or batch.received_keepalive) self.obs.heartbeat(io);
 
-        const producer = &self.producer;
-
         if (batch.changes.len == 0) {
             self.pending_lsn.store(batch.last_lsn, .release);
             self.obs.setLag(0); // drained everything available -> caught up
@@ -180,12 +176,6 @@ pub const Processor = struct {
         var event_counts = std.ArrayList(EventCount).empty;
         defer event_counts.deinit(batch_allocator);
 
-        // With dr_msg_cb registered, a produced message counts against
-        // queue.buffering.max.messages until its delivery report is served by a
-        // poll. Serve them every KAFKA_POLL_INTERVAL sends so a large batch does
-        // not fill the queue before the single poll at the end.
-        var sent_since_poll: u32 = 0;
-
         for (batch.changes) |change_event| {
             var matched = try matchStreams(batch_allocator, self.streams, change_event);
             defer matched.deinit(batch_allocator);
@@ -200,15 +190,19 @@ pub const Processor = struct {
                 const topic_name = stream.sink.destination;
                 const partition_key = try self.getPartitionKey(batch_allocator, change_event, stream);
 
-                try self.produceWithBackpressure(stop_signal, topic_name, partition_key, json_bytes);
+                // A full queue is backpressure, not failure: send blocks (stalling
+                // the WAL read, so Postgres slows too) and retries. Shutdown and a
+                // permanent delivery failure propagate as-is; anything else is a
+                // produce error worth recording before it fails the pipeline.
+                self.producer.send(stop_signal, topic_name, partition_key, json_bytes) catch |err| switch (err) {
+                    error.Shutdown, error.DeliveryFailed => return err,
+                    else => {
+                        self.obs.recordProduceError();
+                        return err;
+                    },
+                };
 
                 try tallyEvent(&event_counts, batch_allocator, stream.name, change_event.op);
-
-                sent_since_poll += 1;
-                if (sent_since_poll >= constants.CDC.KAFKA_POLL_INTERVAL) {
-                    producer.poll(0);
-                    sent_since_poll = 0;
-                }
 
                 self.events_processed += 1;
                 if (self.events_processed % 10000 == 0) {
@@ -218,8 +212,6 @@ pub const Processor = struct {
         }
 
         for (event_counts.items) |e| self.obs.addEvents(e.count, e.stream, e.operation);
-
-        producer.poll(0);
 
         self.pending_lsn.store(batch.last_lsn, .release);
     }
@@ -245,40 +237,6 @@ pub const Processor = struct {
         // rather than collapse the change onto a table-name partition.
         return try change_event.getPartitionKeyValue(allocator, key_field) orelse
             error.PartitionKeyUnavailable;
-    }
-
-    // Produce one message, treating a full producer queue as backpressure rather
-    // than a failure. The pipeline is synchronous, so blocking here stalls the WAL
-    // read and slows Postgres. Block on poll (it wakes on the first delivery report)
-    // to drain the queue, then retry. No deadline of our own: delivery.timeout.ms
-    // bounds how long a message can sit in the queue, and a wedged broker surfaces
-    // as deliveryErrorCount > 0 within it. Returns error.Shutdown when stop_signal
-    // fires mid-wait, so the caller can stop gracefully without staging the LSN.
-    fn produceWithBackpressure(
-        self: *Self,
-        stop_signal: *std.atomic.Value(bool),
-        topic_name: []const u8,
-        key: ?[]const u8,
-        payload: []const u8,
-    ) !void {
-        const producer = &self.producer;
-        while (true) {
-            producer.sendMessage(topic_name, key, payload) catch |err| switch (err) {
-                error.QueueFull => {
-                    if (stop_signal.load(.monotonic)) return error.Shutdown;
-                    // A permanent delivery failure means the broker is rejecting, not
-                    // just slow: stop waiting and fail fast now.
-                    if (producer.deliveryErrorCount() > 0) return error.DeliveryFailed;
-                    producer.poll(constants.CDC.KAFKA_BACKPRESSURE_POLL_MS);
-                    continue;
-                },
-                else => {
-                    self.obs.recordProduceError();
-                    return err;
-                },
-            };
-            return;
-        }
     }
 
     /// Run the batch loop until stop_signal is set, with a background flush/commit worker.

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -151,7 +151,7 @@ pub const Processor = struct {
     }
 
     /// Receive one batch, route each change to its streams, and stage the batch LSN for commit.
-    pub fn processChangesToKafka(self: *Self, io: std.Io, batch_allocator: std.mem.Allocator, limit: u32) !void {
+    pub fn processChangesToKafka(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool), batch_allocator: std.mem.Allocator, limit: u32) !void {
         var batch = try self.source.receiveBatch(io, batch_allocator, limit);
         defer batch.deinit();
 
@@ -200,11 +200,7 @@ pub const Processor = struct {
                 const topic_name = stream.sink.destination;
                 const partition_key = try self.getPartitionKey(batch_allocator, change_event, stream);
 
-                producer.sendMessage(topic_name, partition_key, json_bytes) catch |err| {
-                    self.obs.recordProduceError();
-                    std.log.debug("processChangesToKafka: sendMessage failed, propagating {} (fail-fast)", .{err});
-                    return err;
-                };
+                try self.produceWithBackpressure(io, stop_signal, topic_name, partition_key, json_bytes);
 
                 try tallyEvent(&event_counts, batch_allocator, stream.name, change_event.op);
 
@@ -251,6 +247,53 @@ pub const Processor = struct {
             error.PartitionKeyUnavailable;
     }
 
+    // Produce one message, treating a full producer queue as backpressure rather
+    // than a failure. The pipeline is synchronous, so blocking here stalls the WAL
+    // read and slows Postgres. Serve delivery reports (which free the queue as acks
+    // land) and retry until it drains, bounded by KAFKA_BACKPRESSURE_MAX_WAIT_MS so a
+    // wedged broker still fails fast. Returns error.Shutdown when stop_signal fires
+    // mid-wait, so the caller can stop gracefully without staging the batch LSN.
+    fn produceWithBackpressure(
+        self: *Self,
+        io: std.Io,
+        stop_signal: *std.atomic.Value(bool),
+        topic_name: []const u8,
+        key: ?[]const u8,
+        payload: []const u8,
+    ) !void {
+        const producer = &self.producer;
+        var deadline: ?std.Io.Timestamp = null;
+        while (true) {
+            producer.sendMessage(topic_name, key, payload) catch |err| switch (err) {
+                error.QueueFull => {
+                    if (stop_signal.load(.monotonic)) return error.Shutdown;
+                    // A permanent delivery failure means the broker is rejecting, not
+                    // just slow: stop waiting and fail fast now.
+                    if (producer.deliveryErrorCount() > 0) return error.DeliveryFailed;
+
+                    const d = deadline orelse blk: {
+                        const nd = std.Io.Timestamp.now(io, .awake)
+                            .addDuration(.fromMilliseconds(constants.CDC.KAFKA_BACKPRESSURE_MAX_WAIT_MS));
+                        deadline = nd;
+                        break :blk nd;
+                    };
+                    if (std.Io.Timestamp.now(io, .awake).nanoseconds >= d.nanoseconds) {
+                        self.obs.recordProduceError();
+                        std.log.warn("Kafka queue full past backpressure window, failing fast", .{});
+                        return error.MessageSendFailed;
+                    }
+                    producer.drainFor(constants.CDC.KAFKA_BACKPRESSURE_POLL_MS);
+                    continue;
+                },
+                else => {
+                    self.obs.recordProduceError();
+                    return err;
+                },
+            };
+            return;
+        }
+    }
+
     /// Run the batch loop until stop_signal is set, with a background flush/commit worker.
     pub fn startStreaming(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
         // The source is connected and validated before we get here, so readiness's
@@ -284,7 +327,11 @@ pub const Processor = struct {
 
             const batch_alloc = batch_arena.allocator();
 
-            try self.processChangesToKafka(io, batch_alloc, constants.CDC.BATCH_SIZE);
+            self.processChangesToKafka(io, stop_signal, batch_alloc, constants.CDC.BATCH_SIZE) catch |err| switch (err) {
+                // Backpressure saw stop_signal mid-batch: leave the loop for the graceful final flush.
+                error.Shutdown => break,
+                else => return err,
+            };
 
             // A permanent delivery failure (or fatal producer error) means data
             // never reached Kafka. Fail fast so the slot re-sends from the last

--- a/tests/benchmarks/components/kafka_bench.zig
+++ b/tests/benchmarks/components/kafka_bench.zig
@@ -77,7 +77,6 @@ const BenchKafkaSend = struct {
         for (0..batch_size) |_| {
             self.producer.sendMessage("bench_topic", "key_123", payload) catch unreachable;
         }
-        self.producer.poll(0);
     }
 };
 
@@ -88,7 +87,6 @@ const BenchKafkaProduce = struct {
     pub fn run(self: *BenchKafkaProduce, allocator: std.mem.Allocator) void {
         _ = allocator;
         self.producer.produce("bench_topic", self.messages) catch unreachable;
-        self.producer.poll(0);
     }
 };
 
@@ -109,7 +107,7 @@ test "benchmark KafkaProducer sendMessage" {
     defer bench.deinit();
 
     _ = try producer.sendMessage("bench_topic", "warmup", "warmup");
-    try producer.flush(1000);
+    try producer.flush(null);
 
     alloc_count = 0;
 
@@ -159,7 +157,7 @@ test "benchmark KafkaProducer produce" {
     }
 
     _ = try producer.produce("bench_topic", batch);
-    try producer.flush(1000);
+    try producer.flush(null);
 
     alloc_count = 0;
 

--- a/tests/benchmarks/components/kafka_bench.zig
+++ b/tests/benchmarks/components/kafka_bench.zig
@@ -69,13 +69,17 @@ const MockCluster = struct {
 };
 
 // KafkaProducer setup is heavy (rd_kafka initialization, mock cluster), prepared outside benchmark
+// Benchmarks send(), the production entrypoint: raw sendMessage no longer drains
+// on its own, so a poll-less loop would fill the queue. send() self-polls, and on
+// this healthy mock broker the queue never fills, so backpressure never triggers.
 const BenchKafkaSend = struct {
     producer: *KafkaProducer,
+    stop_signal: *std.atomic.Value(bool),
 
     pub fn run(self: *BenchKafkaSend, allocator: std.mem.Allocator) void {
         _ = allocator;
         for (0..batch_size) |_| {
-            self.producer.sendMessage("bench_topic", "key_123", payload) catch unreachable;
+            self.producer.send(self.stop_signal, "bench_topic", "key_123", payload) catch unreachable;
         }
     }
 };
@@ -90,7 +94,7 @@ const BenchKafkaProduce = struct {
     }
 };
 
-test "benchmark KafkaProducer sendMessage" {
+test "benchmark KafkaProducer send" {
     var mock = try MockCluster.init();
     defer mock.deinit();
 
@@ -111,9 +115,10 @@ test "benchmark KafkaProducer sendMessage" {
 
     alloc_count = 0;
 
-    const bench_send = BenchKafkaSend{ .producer = &producer };
+    var stop_signal = std.atomic.Value(bool).init(false);
+    const bench_send = BenchKafkaSend{ .producer = &producer, .stop_signal = &stop_signal };
 
-    try bench.addParam("KafkaProducer.sendMessage", &bench_send, .{
+    try bench.addParam("KafkaProducer.send", &bench_send, .{
         .iterations = message_iterations,
         .track_allocations = true,
     });

--- a/tests/benchmarks/components/kafka_bench.zig
+++ b/tests/benchmarks/components/kafka_bench.zig
@@ -77,7 +77,7 @@ const BenchKafkaSend = struct {
         for (0..batch_size) |_| {
             self.producer.sendMessage("bench_topic", "key_123", payload) catch unreachable;
         }
-        self.producer.poll();
+        self.producer.poll(0);
     }
 };
 
@@ -88,7 +88,7 @@ const BenchKafkaProduce = struct {
     pub fn run(self: *BenchKafkaProduce, allocator: std.mem.Allocator) void {
         _ = allocator;
         self.producer.produce("bench_topic", self.messages) catch unreachable;
-        self.producer.poll();
+        self.producer.poll(0);
     }
 };
 

--- a/tests/e2e/cdc_test.zig
+++ b/tests/e2e/cdc_test.zig
@@ -111,8 +111,9 @@ test "E2E: INSERT operation - full pipeline verification" {
     // Use arena allocator for batch processing (matches production usage)
     var batch_arena = std.heap.ArenaAllocator.init(allocator);
     defer batch_arena.deinit();
+    var stop_signal = std.atomic.Value(bool).init(false);
 
-    try processor.processChangesToKafka(std.testing.io, batch_arena.allocator(), 100);
+    try processor.processChangesToKafka(std.testing.io, &stop_signal, batch_arena.allocator(), 100);
 
     // Verify: Read ALL messages from Kafka
     std.debug.print("Step 3: Consume and verify messages from Kafka topic '{s}'\n", .{topic_name});
@@ -240,7 +241,8 @@ test "E2E: UPDATE operation - full pipeline verification" {
     {
         var batch_arena = std.heap.ArenaAllocator.init(allocator);
         defer batch_arena.deinit();
-        try processor.processChangesToKafka(std.testing.io, batch_arena.allocator(), 100);
+        var stop_signal = std.atomic.Value(bool).init(false);
+        try processor.processChangesToKafka(std.testing.io, &stop_signal, batch_arena.allocator(), 100);
     }
 
     // Step 2: Update the record twice
@@ -258,7 +260,8 @@ test "E2E: UPDATE operation - full pipeline verification" {
     {
         var batch_arena = std.heap.ArenaAllocator.init(allocator);
         defer batch_arena.deinit();
-        try processor.processChangesToKafka(std.testing.io, batch_arena.allocator(), 100);
+        var stop_signal = std.atomic.Value(bool).init(false);
+        try processor.processChangesToKafka(std.testing.io, &stop_signal, batch_arena.allocator(), 100);
     }
 
     // Verify: Read messages from Kafka (1 INSERT + 2 UPDATEs = 3 total)
@@ -374,7 +377,8 @@ test "E2E: DELETE operation - full pipeline verification" {
     {
         var batch_arena = std.heap.ArenaAllocator.init(allocator);
         defer batch_arena.deinit();
-        try processor.processChangesToKafka(std.testing.io, batch_arena.allocator(), 100);
+        var stop_signal = std.atomic.Value(bool).init(false);
+        try processor.processChangesToKafka(std.testing.io, &stop_signal, batch_arena.allocator(), 100);
     }
 
     // Step 2: Delete the records
@@ -392,7 +396,8 @@ test "E2E: DELETE operation - full pipeline verification" {
     {
         var batch_arena = std.heap.ArenaAllocator.init(allocator);
         defer batch_arena.deinit();
-        try processor.processChangesToKafka(std.testing.io, batch_arena.allocator(), 100);
+        var stop_signal = std.atomic.Value(bool).init(false);
+        try processor.processChangesToKafka(std.testing.io, &stop_signal, batch_arena.allocator(), 100);
     }
 
     // Verify: Read messages from Kafka (2 INSERTs + 2 DELETEs = 4 total)


### PR DESCRIPTION
## Problem

On a cold start against a large WAL backlog, librdkafka's producer queue (default 100k) fills in under a second while the broker connection is still warming up (idempotence PID handshake). `rd_kafka_produce` returns `QUEUE_FULL`, which was mapped to a fatal error, so the process crashed and the supervisor restarted it in a loop, piling up duplicate redeliveries. It is not start-only: `QUEUE_FULL` is the general "sink slower than source" signal and can also fire at runtime (leader elections, throttling).

## Solution

Treat a full queue as backpressure rather than a failure:

- `sendMessage` now returns a distinct `error.QueueFull`.
- The processor drains delivery reports and retries until the queue frees up, bounded by a 40s deadline. The pipeline is synchronous, so blocking here stalls the WAL read and propagates backpressure all the way to Postgres, no extra queue needed.
- The deadline sits between `delivery.timeout.ms` (30s) and the liveness window (90s): transient spikes ride out, a genuinely wedged broker still fails fast.
- `stop_signal` during a wait returns `error.Shutdown`, so shutdown stays graceful without confirming an unsent LSN.

Adds a unit test that fills a mock producer's queue and asserts `sendMessage` surfaces `error.QueueFull`.

Closes #112
