### PR TITLE
Guard column-count reads in the decode and convert paths

### DIFF
--- a/src/source/postgres/converter.zig
+++ b/src/source/postgres/converter.zig
@@ -101,6 +101,10 @@ pub const Converter = struct {
 };
 
 fn tupleToRowData(allocator: std.mem.Allocator, tuple: anytype, rel_info: anytype) !RowData {
+    // A tuple with more columns than the relation would index past rel_info.columns:
+    // panic under ReleaseSafe, silent corruption under ReleaseFast.
+    if (tuple.columns.len != rel_info.columns.len) return error.ColumnCountMismatch;
+
     var builder = RowDataHelpers.createBuilder(allocator);
     errdefer {
         for (builder.items) |field| {
@@ -757,6 +761,36 @@ test "tupleToRowData: unchanged TOAST column becomes the placeholder" {
     try testing.expectEqualStrings("body", row_data[1].name);
     try testing.expect(row_data[1].value == .string);
     try testing.expectEqualStrings(constants.UNKNOWN_VALUE_PLACEHOLDER, row_data[1].value.string);
+}
+
+test "tupleToRowData: error when tuple arity differs from relation" {
+    const allocator = testing.allocator;
+
+    var registry = RelationRegistry.init(allocator);
+    defer registry.deinit();
+
+    var rel_msg = pg_output_decoder.RelationMessage{
+        .relation_id = 400,
+        .namespace = try allocator.dupe(u8, "public"),
+        .relation_name = try allocator.dupe(u8, "users"),
+        .replica_identity = 'd',
+        .columns = try allocator.alloc(pg_output_decoder.RelationMessageColumn, 2),
+    };
+    defer rel_msg.deinit(allocator);
+    rel_msg.columns[0] = .{ .flags = 1, .name = try allocator.dupe(u8, "id"), .data_type = 23, .type_modifier = -1 };
+    rel_msg.columns[1] = .{ .flags = 0, .name = try allocator.dupe(u8, "name"), .data_type = 25, .type_modifier = -1 };
+    try registry.register(rel_msg);
+
+    // One column against a two-column relation: indexing rel_info.columns[i]
+    // would run past the end without the arity check.
+    var tuple = pg_output_decoder.TupleMessage{
+        .columns = try allocator.alloc(pg_output_decoder.TupleData, 1),
+    };
+    defer tuple.deinit(allocator);
+    tuple.columns[0] = .{ .column_type = .text, .value = try allocator.dupe(u8, "42") };
+
+    const rel_info = try registry.get(400);
+    try testing.expectError(error.ColumnCountMismatch, tupleToRowData(allocator, tuple, rel_info));
 }
 
 test "convert INSERT: error when relation not found in registry" {

--- a/src/source/postgres/pg_output_decoder.zig
+++ b/src/source/postgres/pg_output_decoder.zig
@@ -363,6 +363,7 @@ pub const PgOutputDecoder = struct {
 
         var old_tuple: ?TupleMessage = null;
         if (tuple_type == 'O' or tuple_type == 'K') {
+            if (pos + 2 > data.len) return DecoderError.InvalidMessage;
             const column_count = readU16(data[pos .. pos + 2]);
             pos += 2;
 
@@ -377,6 +378,7 @@ pub const PgOutputDecoder = struct {
             return DecoderError.InvalidMessage;
         }
 
+        if (pos + 2 > data.len) return DecoderError.InvalidMessage;
         const new_column_count = readU16(data[pos .. pos + 2]);
         pos += 2;
 
@@ -695,6 +697,18 @@ test "PgOutputDecoder: decode UPDATE message with old tuple" {
     // Check new tuple
     try testing.expectEqual(@as(usize, 1), msg.update.new_tuple.columns.len);
     try testing.expectEqualStrings("new_name", msg.update.new_tuple.columns[0].value.?);
+}
+
+test "PgOutputDecoder: UPDATE truncated before a column count" {
+    const allocator = testing.allocator;
+    var pg_decoder = PgOutputDecoder.init(allocator);
+
+    // 'U' + relation_id(4) + tuple flag, then nothing: the column_count read must
+    // not slice past the end. 'O' hits the old-tuple guard, 'N' the new-tuple one.
+    for ([_]u8{ 'O', 'N' }) |flag| {
+        const data = [_]u8{ 'U', 0, 0, 0, 1, flag };
+        try testing.expectError(DecoderError.InvalidMessage, pg_decoder.decode(allocator, &data));
+    }
 }
 
 test "PgOutputDecoder: decode DELETE message" {


### PR DESCRIPTION
## Problem

Two spots on the decode to convert path index by a length they never check:

- `decodeUpdate` slices `data[pos .. pos + 2]` for both column counts with no bounds check, so a truncated UPDATE reads out of bounds (panic under ReleaseSafe, UB under ReleaseFast).
- `tupleToRowData` indexes `rel_info.columns[i]` per tuple column without checking arity, so a decoder bug or protocol violation reads past the relation (panic under ReleaseSafe, silent corruption to Kafka under ReleaseFast).

## Change

- `decodeUpdate`: add a `pos + 2 > data.len` guard before each `readU16`, matching the guards `decodeTuple` already has.
- `tupleToRowData`: reject `tuple.columns.len != rel_info.columns.len` with a `ColumnCountMismatch` decode error.
- Unit tests for both: a truncated UPDATE and an arity mismatch.

Fixes #82
Fixes #98
