### PR TITLE
Fix E2E flake: single-partition dev/CI Kafka topics

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,7 +78,7 @@ jobs:
             -e KAFKA_KRAFT_CLUSTER_ID=test-cluster-id \
             -e ALLOW_PLAINTEXT_LISTENER=yes \
             -e KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true \
-            -e KAFKA_CFG_NUM_PARTITIONS=3 \
+            -e KAFKA_CFG_NUM_PARTITIONS=1 \
             -e KAFKA_CFG_DEFAULT_REPLICATION_FACTOR=1 \
             -e KAFKA_TLS_TYPE=PEM \
             -e KAFKA_TLS_CLIENT_AUTH=none \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,8 @@ services:
       KAFKA_TLS_CLIENT_AUTH: none
       # Auto-create topics for CDC
       KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_CFG_NUM_PARTITIONS: 3
+      # One partition so keyed messages stay in consumed order for E2E asserts.
+      KAFKA_CFG_NUM_PARTITIONS: 1
       KAFKA_CFG_DEFAULT_REPLICATION_FACTOR: 1
     networks:
       - outboxx-network


### PR DESCRIPTION
## Problem

Dev and CI Kafka run with `KAFKA_CFG_NUM_PARTITIONS=3`, so auto-created test
topics get 3 partitions. Messages keyed by `id` scatter across partitions, the
consumer reads partitions in no fixed order, and the E2E INSERT test asserts
`data.name`/`data.value` by consumed position (Alice, Bob, Carol). It flakes when
partitions come back out of insert order (seen on the v0.3.0-zig0.16 release run).

## Solution

- Set `KAFKA_CFG_NUM_PARTITIONS=1` in `docker-compose.yml` (local `make test-e2e`
  and the release workflow's `env-up`) and in the `pr-checks` Kafka container.
- Single-partition topics make the consumed order deterministic, so the positional
  assertion holds.

Verified locally: after the change the auto-created `topic.stream.insert.*` and
`topic.stream.update.*` report `PartitionCount: 1`, and `make test-e2e` passes.

If dev topics ever need more partitions, the durable fix is to make the INSERT
test match by key instead of by consumed position.

Fixes #126.
