### PR TITLE
Bump actions/upload-artifact to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
         run: docker compose logs --tail=40
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binary-${{ matrix.arch }}
           path: outboxx-*.tar.gz


### PR DESCRIPTION
## Problem
`download-artifact` was bumped to v8 (#131), but the matching `upload-artifact 4->7` PR (#130) was closed, so the release job uploaded binaries with `upload-artifact@v4` and downloaded them with `download-artifact@v8`, sitting on mismatched majors.

## Solution
- Bump `actions/upload-artifact@v4` to `@v7` in `release.yml`; the `with` inputs are unchanged, so the step is compatible as-is.
- Create the `dependencies`, `github-actions`, and `docker` labels referenced by `dependabot.yml`. They did not exist, so Dependabot warned "labels could not be found" on every PR; now dependency PRs get labeled.

Closes #116.