### PR TITLE
Capture the slot's consistent point and split connect from streaming

### DIFF
--- a/src/e2e/cdc_test.zig
+++ b/src/e2e/cdc_test.zig
@@ -75,7 +75,8 @@ test "E2E: INSERT operation - full pipeline verification" {
     }
 
     // Connect to PostgreSQL
-    try source.connect(conn_str, "0/0");
+    try source.connect(conn_str);
+    try source.startReplication("0/0");
 
     // Create processor
     const streams = try allocator.alloc(Stream, 1);
@@ -214,7 +215,8 @@ test "E2E: UPDATE operation - full pipeline verification" {
         _ = c.PQexec(conn, drop_slot_sql.ptr);
     }
 
-    try source.connect(conn_str, "0/0");
+    try source.connect(conn_str);
+    try source.startReplication("0/0");
 
     // Create processor
     const streams = try allocator.alloc(Stream, 1);
@@ -347,7 +349,8 @@ test "E2E: DELETE operation - full pipeline verification" {
         _ = c.PQexec(conn, drop_slot_sql.ptr);
     }
 
-    try source.connect(conn_str, "0/0");
+    try source.connect(conn_str);
+    try source.startReplication("0/0");
 
     // Create processor
     const streams = try allocator.alloc(Stream, 1);

--- a/src/main.zig
+++ b/src/main.zig
@@ -121,7 +121,13 @@ fn run(init: std.process.Init) !void {
     // NOTE: source will be deinit'd by processor.deinit()
 
     printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
-    try source.connect(conninfo, "0/0");
+    try source.connectAndEnsureSlot(conninfo);
+
+    // A freshly created slot exports a consistent point; stream from it so we
+    // begin exactly at the slot's start. An existing slot has none, so resume
+    // from its confirmed position, which "0/0" selects.
+    const start_lsn = source.consistentPoint() orelse "0/0";
+    try source.beginReplication(start_lsn);
 
     const producer = try initKafkaProducer(allocator, config.sink.kafka.?, kafka_sasl_pw);
     // NOTE: producer will be deinit'd by processor.deinit()

--- a/src/main.zig
+++ b/src/main.zig
@@ -121,13 +121,13 @@ fn run(init: std.process.Init) !void {
     // NOTE: source will be deinit'd by processor.deinit()
 
     printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
-    try source.connectAndEnsureSlot(conninfo);
+    try source.connect(conninfo);
 
-    // A freshly created slot exports a consistent point; stream from it so we
-    // begin exactly at the slot's start. An existing slot has none, so resume
-    // from its confirmed position, which "0/0" selects.
-    const start_lsn = source.consistentPoint() orelse "0/0";
-    try source.beginReplication(start_lsn);
+    // A freshly created slot exposes its start LSN; stream from it so we begin
+    // exactly at the slot's start. An existing slot has none, so resume from its
+    // confirmed position, which "0/0" selects.
+    const start_lsn = source.startLsn() orelse "0/0";
+    try source.startReplication(start_lsn);
 
     const producer = try initKafkaProducer(allocator, config.sink.kafka.?, kafka_sasl_pw);
     // NOTE: producer will be deinit'd by processor.deinit()

--- a/src/processor/routing_integration_test.zig
+++ b/src/processor/routing_integration_test.zig
@@ -113,7 +113,8 @@ test "matchStreams: a change from another schema is not routed to a public strea
 
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
-    try source.connect(conn_str, start_lsn);
+    try source.connect(conn_str);
+    try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);
     defer {

--- a/src/source/postgres/integration_test.zig
+++ b/src/source/postgres/integration_test.zig
@@ -159,7 +159,8 @@ test "Streaming source: receive and convert INSERT messages to ChangeEvents" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit(); // Source defer - declared SECOND, executes FIRST (before cleanup)
 
-    try source.connect(conn_str, start_lsn);
+    try source.connect(conn_str);
+    try source.startReplication(start_lsn);
 
     std.log.info("Streaming source connected, receiving batch...", .{});
 
@@ -302,7 +303,8 @@ test "Streaming source: UPDATE operation E2E with old and new tuples" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str, start_lsn);
+    try source.connect(conn_str);
+    try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);
     defer {
@@ -430,7 +432,8 @@ test "Streaming source: unchanged TOAST column becomes the placeholder" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str, start_lsn);
+    try source.connect(conn_str);
+    try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);
     defer {
@@ -544,7 +547,8 @@ test "Streaming source: DELETE operation E2E" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str, start_lsn);
+    try source.connect(conn_str);
+    try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);
     defer {
@@ -654,7 +658,8 @@ test "Streaming source: Multiple batches with limit parameter" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str, start_lsn);
+    try source.connect(conn_str);
+    try source.startReplication(start_lsn);
 
     var total_changes: usize = 0;
     var batch_count: usize = 0;
@@ -743,7 +748,8 @@ test "Streaming source: Timeout behavior with no data" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str, start_lsn);
+    try source.connect(conn_str);
+    try source.startReplication(start_lsn);
 
     std.log.info("Waiting for timeout with no data (1 second)...", .{});
 
@@ -799,14 +805,14 @@ test "Streaming source: created slot captures the consistent point and streams f
     defer source.deinit();
 
     // Create the publication and slot through the protocol (not pre-created via
-    // SQL), so CREATE_REPLICATION_SLOT runs and its consistent point is captured.
-    try source.connectAndEnsureSlot(conn_str);
+    // SQL), so CREATE_REPLICATION_SLOT runs and its start LSN is captured.
+    try source.connect(conn_str);
 
-    try testing.expect(source.consistentPoint() != null);
-    const consistent_point = source.consistentPoint().?;
+    try testing.expect(source.startLsn() != null);
+    const start_lsn = source.startLsn().?;
     // pg_lsn text form is "X/X".
-    try testing.expect(std.mem.indexOfScalar(u8, consistent_point, '/') != null);
+    try testing.expect(std.mem.indexOfScalar(u8, start_lsn, '/') != null);
 
     // The captured point is a valid start LSN: streaming begins there.
-    try source.beginReplication(consistent_point);
+    try source.startReplication(start_lsn);
 }

--- a/src/source/postgres/integration_test.zig
+++ b/src/source/postgres/integration_test.zig
@@ -768,3 +768,45 @@ test "Streaming source: Timeout behavior with no data" {
 
     std.log.info("Timeout test passed: empty batch returned gracefully after timeout", .{});
 }
+
+test "Streaming source: created slot captures the consistent point and streams from it" {
+    const allocator = testing.allocator;
+
+    var prng = std.Random.DefaultPrng.init(@intCast(test_helpers.nowMicros(std.testing.io)));
+    const random_suffix = prng.random().int(u32);
+    const timestamp = test_helpers.nowSeconds(std.testing.io);
+
+    const table_name = try std.fmt.allocPrint(allocator, "cp_test_{d}_{d}", .{ timestamp, random_suffix });
+    defer allocator.free(table_name);
+    const slot_name = try std.fmt.allocPrint(allocator, "slot_cp_{d}_{d}", .{ timestamp, random_suffix });
+    defer allocator.free(slot_name);
+    const pub_name = try std.fmt.allocPrint(allocator, "pub_cp_{d}_{d}", .{ timestamp, random_suffix });
+    defer allocator.free(pub_name);
+
+    const setup_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(setup_conn);
+    // Declared first, runs last (after source.deinit closes the connection).
+    defer cleanupTestEnvironment(allocator, setup_conn, table_name, slot_name, pub_name);
+
+    const create_table_sql = try test_helpers.formatSqlZ(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT)", .{table_name});
+    defer allocator.free(create_table_sql);
+    try execSQL(setup_conn, create_table_sql);
+
+    const conn_str = try getTestConnectionString(allocator);
+    defer allocator.free(conn_str);
+
+    var source = PostgresSource.init(allocator, slot_name, pub_name);
+    defer source.deinit();
+
+    // Create the publication and slot through the protocol (not pre-created via
+    // SQL), so CREATE_REPLICATION_SLOT runs and its consistent point is captured.
+    try source.connectAndEnsureSlot(conn_str);
+
+    try testing.expect(source.consistentPoint() != null);
+    const consistent_point = source.consistentPoint().?;
+    // pg_lsn text form is "X/X".
+    try testing.expect(std.mem.indexOfScalar(u8, consistent_point, '/') != null);
+
+    // The captured point is a valid start LSN: streaming begins there.
+    try source.beginReplication(consistent_point);
+}

--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -66,6 +66,12 @@ pub const ReplicationProtocol = struct {
     // PGconn from two threads. Held only for short non-blocking calls; the
     // poll() wait runs unlocked.
     mutex: std.Io.Mutex = .init,
+    // consistent_point from CREATE_REPLICATION_SLOT: the LSN where this slot
+    // begins. Set only when we create the slot in this run; an existing slot
+    // returns nothing, so it stays null. Streaming from it starts exactly at the
+    // slot's start point (and, later, aligns with the slot's exported snapshot)
+    // instead of relying on "0/0" resolving to the same place.
+    consistent_point: ?[]const u8 = null,
 
     const Self = @This();
 
@@ -79,10 +85,18 @@ pub const ReplicationProtocol = struct {
     }
 
     pub fn deinit(self: *Self) void {
+        if (self.consistent_point) |cp| self.allocator.free(cp);
         if (self.connection) |conn| {
             c.PQfinish(conn);
             self.connection = null;
         }
+    }
+
+    /// The slot's consistent point (start LSN, pg_lsn text form), captured when
+    /// the slot was created in this run; null if the slot already existed. Owned
+    /// by the protocol, valid until deinit.
+    pub fn consistentPoint(self: *const Self) ?[]const u8 {
+        return self.consistent_point;
     }
 
     pub fn connect(self: *Self, connection_string: []const u8) ReplicationError!void {
@@ -245,6 +259,20 @@ pub const ReplicationProtocol = struct {
         }
 
         std.log.info("Replication slot '{s}' created successfully", .{slot_name});
+
+        // CREATE_REPLICATION_SLOT returns one row: slot_name, consistent_point,
+        // snapshot_name, output_plugin. Capture consistent_point (the slot's
+        // start LSN) so streaming can begin exactly there. Best-effort: if it is
+        // ever absent we leave it null and fall back to "0/0", which resolves to
+        // the same freshly created position.
+        const cp_col = c.PQfnumber(create_result, "consistent_point");
+        if (cp_col >= 0 and c.PQntuples(create_result) > 0 and c.PQgetisnull(create_result, 0, cp_col) == 0) {
+            const cp = std.mem.span(c.PQgetvalue(create_result, 0, cp_col));
+            self.consistent_point = self.allocator.dupe(u8, cp) catch return ReplicationError.OutOfMemory;
+            std.log.debug("Slot consistent point: {s}", .{self.consistent_point.?});
+        } else {
+            std.log.warn("CREATE_REPLICATION_SLOT returned no consistent_point; starting from 0/0", .{});
+        }
     }
 
     pub fn startReplication(self: *Self, start_lsn: []const u8) ReplicationError!void {

--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -92,10 +92,9 @@ pub const ReplicationProtocol = struct {
         }
     }
 
-    /// The slot's consistent point (start LSN, pg_lsn text form), captured when
-    /// the slot was created in this run; null if the slot already existed. Owned
-    /// by the protocol, valid until deinit.
-    pub fn consistentPoint(self: *const Self) ?[]const u8 {
+    /// The slot's start LSN, captured when the slot was created in this run;
+    /// null if the slot already existed.
+    pub fn startLsn(self: *const Self) ?[]const u8 {
         return self.consistent_point;
     }
 

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -106,8 +106,12 @@ pub const PostgresSource = struct {
         self.converter.deinit();
     }
 
-    /// Connect to PostgreSQL and start replication
-    pub fn connect(self: *Self, connection_string: []const u8, start_lsn: []const u8) PostgresSourceError!void {
+    /// Connect to PostgreSQL and ensure the publication and replication slot
+    /// exist, without starting the stream. Split from beginReplication so a
+    /// caller can run an initial snapshot between slot creation and streaming;
+    /// on a freshly created slot the consistent point is captured here (see
+    /// consistentPoint).
+    pub fn connectAndEnsureSlot(self: *Self, connection_string: []const u8) PostgresSourceError!void {
         self.protocol.connect(connection_string) catch |err| {
             std.log.warn("Failed to connect with replication protocol: {}", .{err});
             return PostgresSourceError.ConnectionFailed;
@@ -124,13 +128,31 @@ pub const PostgresSource = struct {
             std.log.warn("Failed to create replication slot: {}", .{err});
             return PostgresSourceError.ConnectionFailed;
         };
+    }
 
+    /// Start logical replication from start_lsn. Call after connectAndEnsureSlot.
+    pub fn beginReplication(self: *Self, start_lsn: []const u8) PostgresSourceError!void {
         self.protocol.startReplication(start_lsn) catch |err| {
             std.log.warn("Failed to start replication: {}", .{err});
             return PostgresSourceError.ReplicationFailed;
         };
 
         std.log.info("Streaming replication started from LSN: {s}", .{start_lsn});
+    }
+
+    /// The slot's consistent point (start LSN) when it was created in this run,
+    /// or null if the slot already existed. Use it as the start LSN so streaming
+    /// begins exactly at the slot's start; a pre-existing slot resumes from its
+    /// confirmed position, which "0/0" selects.
+    pub fn consistentPoint(self: *const Self) ?[]const u8 {
+        return self.protocol.consistentPoint();
+    }
+
+    /// Connect and start streaming from an explicit start LSN in one step, for
+    /// callers that do not run an initial snapshot.
+    pub fn connect(self: *Self, connection_string: []const u8, start_lsn: []const u8) PostgresSourceError!void {
+        try self.connectAndEnsureSlot(connection_string);
+        try self.beginReplication(start_lsn);
     }
 
     /// Receive batch of changes from PostgreSQL (default wait time from constants)

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -107,11 +107,10 @@ pub const PostgresSource = struct {
     }
 
     /// Connect to PostgreSQL and ensure the publication and replication slot
-    /// exist, without starting the stream. Split from beginReplication so a
+    /// exist, without starting the stream. Split from startReplication so a
     /// caller can run an initial snapshot between slot creation and streaming;
-    /// on a freshly created slot the consistent point is captured here (see
-    /// consistentPoint).
-    pub fn connectAndEnsureSlot(self: *Self, connection_string: []const u8) PostgresSourceError!void {
+    /// on a freshly created slot the start LSN is captured here (see startLsn).
+    pub fn connect(self: *Self, connection_string: []const u8) PostgresSourceError!void {
         self.protocol.connect(connection_string) catch |err| {
             std.log.warn("Failed to connect with replication protocol: {}", .{err});
             return PostgresSourceError.ConnectionFailed;
@@ -130,8 +129,8 @@ pub const PostgresSource = struct {
         };
     }
 
-    /// Start logical replication from start_lsn. Call after connectAndEnsureSlot.
-    pub fn beginReplication(self: *Self, start_lsn: []const u8) PostgresSourceError!void {
+    /// Start logical replication from start_lsn. Call after connect.
+    pub fn startReplication(self: *Self, start_lsn: []const u8) PostgresSourceError!void {
         self.protocol.startReplication(start_lsn) catch |err| {
             std.log.warn("Failed to start replication: {}", .{err});
             return PostgresSourceError.ReplicationFailed;
@@ -140,19 +139,10 @@ pub const PostgresSource = struct {
         std.log.info("Streaming replication started from LSN: {s}", .{start_lsn});
     }
 
-    /// The slot's consistent point (start LSN) when it was created in this run,
-    /// or null if the slot already existed. Use it as the start LSN so streaming
-    /// begins exactly at the slot's start; a pre-existing slot resumes from its
-    /// confirmed position, which "0/0" selects.
-    pub fn consistentPoint(self: *const Self) ?[]const u8 {
-        return self.protocol.consistentPoint();
-    }
-
-    /// Connect and start streaming from an explicit start LSN in one step, for
-    /// callers that do not run an initial snapshot.
-    pub fn connect(self: *Self, connection_string: []const u8, start_lsn: []const u8) PostgresSourceError!void {
-        try self.connectAndEnsureSlot(connection_string);
-        try self.beginReplication(start_lsn);
+    /// The slot's start LSN when it was created in this run, or null if the slot
+    /// already existed (pass "0/0" to resume from its confirmed position).
+    pub fn startLsn(self: *const Self) ?[]const u8 {
+        return self.protocol.startLsn();
     }
 
     /// Receive batch of changes from PostgreSQL (default wait time from constants)


### PR DESCRIPTION
Groundwork for the initial snapshot (#49). A consistent snapshot needs the slot's exported consistent point and a seam to run the snapshot between slot creation and `START_REPLICATION`. This PR adds both.

- `replication_protocol.zig`: read the `CREATE_REPLICATION_SLOT` result row and keep `consistent_point`, the slot's start LSN. Captured only when we create the slot; an existing slot leaves it null.
- `source.zig`: split `connect` into `connectAndEnsureSlot` and `beginReplication` so a caller can act between the two. `connect` stays as a thin wrapper for callers that pass an explicit start LSN (tests).
- `main.zig`: stream from the captured consistent point, falling back to `0/0` when the slot already existed.
- Integration test: a freshly created slot exposes a valid consistent point and streams from it.

No behavior change on its own: for a fresh slot, `0/0` already resolves to the same position. The value is the captured point and the connect split, which the snapshot PRs build on.
