### PR TITLE
Add the READ operation and a snapshot reader for existing rows

### DIFF
--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -20,7 +20,9 @@ pub const ValidationLimits = struct {
 pub const SupportedValues = struct {
     pub const SOURCE_TYPES = [_][]const u8{"postgres"};
     pub const SINK_TYPES = [_][]const u8{"kafka"};
-    pub const OPERATIONS = [_][]const u8{ "insert", "update", "delete" };
+    // "read" opts a stream into the initial snapshot: existing rows are emitted as
+    // READ events before streaming. A stream without it is stream-only.
+    pub const OPERATIONS = [_][]const u8{ "insert", "update", "delete", "read" };
     pub const FORMATS = [_][]const u8{"json"};
     // Only username/password mechanisms; GSSAPI/OAUTHBEARER need auth plumbing we don't expose yet.
     pub const KAFKA_SASL_MECHANISMS = [_][]const u8{ "PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512" };
@@ -959,6 +961,18 @@ test "Config validation - unsupported format should fail" {
     }};
 
     try testing.expectError(error.InvalidEnumValue, cfg.validate(testing.allocator));
+}
+
+test "Config validation - read operation is accepted" {
+    var cfg = createTestDefault();
+    cfg.streams = &.{.{
+        .name = "test_stream",
+        .source = .{ .resource = "users", .operations = &.{ "read", "insert" } },
+        .flow = .{ .format = "json" },
+        .sink = .{ .destination = "test_topic", .routing_key = "id" },
+    }};
+
+    try cfg.validate(testing.allocator);
 }
 
 test "Config validation - invalid source type shows proper error format" {

--- a/src/domain/change_event.zig
+++ b/src/domain/change_event.zig
@@ -1,10 +1,13 @@
 const std = @import("std");
 
-/// Kind of change operation.
+/// Kind of change operation. READ is a row observed by the initial snapshot, not a
+/// WAL change; it carries the current row state so a consumer can bootstrap before
+/// the stream begins.
 pub const ChangeOperation = enum {
     INSERT,
     UPDATE,
     DELETE,
+    READ,
     UNKNOWN,
 };
 

--- a/src/integration_test_root.zig
+++ b/src/integration_test_root.zig
@@ -6,5 +6,6 @@ comptime {
     _ = @import("source/postgres/replication_protocol_test.zig");
     _ = @import("source/postgres/validator_test.zig");
     _ = @import("source/postgres/integration_test.zig");
+    _ = @import("source/postgres/snapshot_test.zig");
     _ = @import("processor/routing_integration_test.zig");
 }

--- a/src/processor/routing_integration_test.zig
+++ b/src/processor/routing_integration_test.zig
@@ -8,6 +8,10 @@ const PostgresSource = @import("../source/postgres/source.zig").PostgresSource;
 const matchStreams = @import("processor.zig").matchStreams;
 const Stream = @import("../config/config.zig").Stream;
 
+const domain = @import("../domain/change_event.zig");
+const ChangeEvent = domain.ChangeEvent;
+const ChangeOperation = domain.ChangeOperation;
+
 const c = @import("c"); // C bindings (build-system translate-c)
 
 // Source is imported through the postgres_source module (not a relative path) so
@@ -158,4 +162,50 @@ test "matchStreams: each change is routed to the stream matching its schema" {
 
     try testing.expectEqual(@as(usize, 1), public_matched);
     try testing.expectEqual(@as(usize, 1), other_matched);
+}
+
+// Pure routing check (no services): a READ event goes through the same
+// case-insensitive operation match as any change, so opting into the snapshot is
+// just listing "read" in a stream's operations.
+test "matchStreams: a READ event routes only to streams that opt into read" {
+    const allocator = testing.allocator;
+
+    var event = ChangeEvent.init(ChangeOperation.READ, .{
+        .source = "postgres",
+        .resource = "public.users",
+        .timestamp = 0,
+        .lsn = null,
+    });
+    // matchStreams reads only op and meta.resource; give it an empty row so the
+    // event is well-formed without allocating field values.
+    const empty_row = try allocator.alloc(domain.FieldData, 0);
+    defer allocator.free(empty_row);
+    event.setInsertData(empty_row);
+
+    const streams = [_]Stream{
+        .{
+            .name = "reader",
+            .source = .{ .resource = "public.users", .operations = &.{ "read", "insert" } },
+            .flow = .{ .format = "json" },
+            .sink = .{ .destination = "t_read", .routing_key = "id" },
+        },
+        .{
+            .name = "stream_only",
+            .source = .{ .resource = "public.users", .operations = &.{ "insert", "update" } },
+            .flow = .{ .format = "json" },
+            .sink = .{ .destination = "t_stream", .routing_key = "id" },
+        },
+        .{
+            .name = "other_table",
+            .source = .{ .resource = "public.orders", .operations = &.{"read"} },
+            .flow = .{ .format = "json" },
+            .sink = .{ .destination = "t_other", .routing_key = "id" },
+        },
+    };
+
+    var matched = try matchStreams(allocator, &streams, event);
+    defer matched.deinit(allocator);
+
+    try testing.expectEqual(@as(usize, 1), matched.items.len);
+    try testing.expectEqualStrings("reader", matched.items[0].name);
 }

--- a/src/serialization/json.zig
+++ b/src/serialization/json.zig
@@ -221,6 +221,45 @@ test "JsonSerializer serialize UPDATE event" {
     try testing.expect(std.mem.find(u8, json_output, "pending") == null);
 }
 
+test "JsonSerializer serialize READ event" {
+    const testing = std.testing;
+
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer {
+        const deinit_status = gpa.deinit();
+        if (deinit_status == .leak) {
+            std.debug.panic("Memory leak in test!", .{});
+        }
+    }
+    const allocator = gpa.allocator();
+
+    const metadata = Metadata{
+        .source = try allocator.dupe(u8, "postgres"),
+        .resource = try allocator.dupe(u8, "public.users"),
+        .timestamp = 1234567890,
+        .lsn = try allocator.dupe(u8, "0/15D6E10"),
+    };
+
+    // A snapshot row reuses the insert payload, so only the op differs from a
+    // streamed INSERT.
+    var event = ChangeEvent.init(ChangeOperation.READ, metadata);
+    defer event.deinit(allocator);
+
+    var builder = RowDataHelpers.createBuilder(allocator);
+    try RowDataHelpers.put(&builder, allocator, "id", FieldValueHelpers.integer(1));
+    const row = try RowDataHelpers.finalize(&builder, allocator);
+    event.setInsertData(row);
+
+    const serializer = JsonSerializer.init();
+    const json_output = try serializer.serialize(event, allocator);
+    defer allocator.free(json_output);
+
+    try testing.expect(std.mem.find(u8, json_output, "\"op\":\"READ\"") != null);
+    try testing.expect(std.mem.find(u8, json_output, "\"resource\":\"public.users\"") != null);
+    try testing.expect(std.mem.find(u8, json_output, "\"lsn\":\"0/15D6E10\"") != null);
+    try testing.expect(std.mem.find(u8, json_output, "\"id\":1") != null);
+}
+
 test "JsonSerializer rejects non-finite float" {
     const testing = std.testing;
 

--- a/src/source/postgres/converter.zig
+++ b/src/source/postgres/converter.zig
@@ -163,7 +163,10 @@ const Oid = enum(u32) {
 //
 // Only the `.string` branch allocates (it dupes into caller-owned memory); the
 // numeric and boolean branches return by value.
-fn mapValue(allocator: std.mem.Allocator, oid: u32, text: []const u8) !FieldValue {
+//
+// Public so the snapshot reader can type its (oid, text) columns the same way, so a
+// READ row and a streamed change of the same column serialize identically.
+pub fn mapValue(allocator: std.mem.Allocator, oid: u32, text: []const u8) !FieldValue {
     switch (@as(Oid, @enumFromInt(oid))) {
         .int2, .int4, .int8 => {
             const n = std.fmt.parseInt(i64, text, 10) catch return FieldValueHelpers.text(allocator, text);

--- a/src/source/postgres/snapshot.zig
+++ b/src/source/postgres/snapshot.zig
@@ -17,21 +17,18 @@ pub const SnapshotError = error{
     OutOfMemory,
 };
 
-// One cursor is open at a time, so a fixed name is enough.
+// One cursor is open at a time (close before opening the next table), so a fixed
+// name is enough.
 const cursor_name = "outboxx_snapshot_cursor";
 
-/// Reads a table's existing rows as of an exported snapshot and emits them as READ
-/// events, so a consumer can bootstrap current state before the stream begins (#49).
-///
-/// Runs on a regular (non-replication) connection. The caller opens a cursor per
-/// resource and pulls batches with `fetch` until it returns null; the events live in
-/// the batch allocator, so a large table is bounded by fetching in chunks and freeing
-/// each batch.
+/// A snapshot session: a regular (non-replication) connection inside a REPEATABLE READ
+/// transaction bound to the slot's exported snapshot. It reads the database exactly as
+/// of the slot's start, so existing rows can be emitted as READ events before streaming
+/// begins (#49). Open one `TableSnapshot` per resource to pull its rows.
 pub const SnapshotReader = struct {
     allocator: std.mem.Allocator,
-    // Snapshot exported by CREATE_REPLICATION_SLOT. Reading under it sees the database
-    // exactly at the slot's start; the session that exported it must stay open until
-    // `connect` binds this transaction to it.
+    // Snapshot exported by CREATE_REPLICATION_SLOT. The session that exported it must
+    // stay open until `connect` binds this transaction to it.
     snapshot_name: []const u8,
     // The slot's consistent point (pg_lsn text form), stamped as meta.lsn on every READ
     // row so a snapshot row and the first stream change share the same dedup boundary.
@@ -39,9 +36,6 @@ pub const SnapshotReader = struct {
     // Wall-clock start of the snapshot, stamped as meta.timestamp on every READ row.
     timestamp: i64,
     connection: ?*c.PGconn = null,
-    // Resource of the open cursor; borrowed for the openCursor..closeCursor span and
-    // duped into each event's metadata.
-    resource: ?[]const u8 = null,
 
     const Self = @This();
 
@@ -56,12 +50,11 @@ pub const SnapshotReader = struct {
 
     pub fn deinit(self: *Self) void {
         if (self.connection) |conn| {
-            // Read-only snapshot transaction: nothing to persist, so end it best-effort.
-            _ = c.PQexec(conn, "COMMIT");
+            // The read-only snapshot transaction has nothing to persist; closing the
+            // connection rolls it back server-side, so there is no command to run here.
             c.PQfinish(conn);
             self.connection = null;
         }
-        self.resource = null;
     }
 
     /// Connect and enter the snapshot transaction. Must run while the session that
@@ -93,8 +86,9 @@ pub const SnapshotReader = struct {
         try self.execCommand(set_snapshot.ptr);
     }
 
-    /// Open a cursor over one resource. `resource` is borrowed until closeCursor.
-    pub fn openCursor(self: *Self, resource: []const u8) SnapshotError!void {
+    /// Open a cursor over one resource. The returned TableSnapshot borrows this reader
+    /// and `resource`; close it before opening the next.
+    pub fn open(self: *Self, resource: []const u8) SnapshotError!TableSnapshot {
         // resource is the operator-controlled, config-validated schema.table (the same
         // trust as validator.zig's to_regclass interpolation). DECLARE needs a real
         // identifier, not a string literal, so it goes straight into the FROM clause.
@@ -102,23 +96,40 @@ pub const SnapshotReader = struct {
         defer self.allocator.free(sql);
 
         try self.execCommand(sql.ptr);
-        self.resource = resource;
+        return .{ .reader = self, .resource = resource };
     }
 
-    pub fn closeCursor(self: *Self) SnapshotError!void {
-        try self.execCommand("CLOSE " ++ cursor_name);
-        self.resource = null;
-    }
-
-    /// Fetch up to `limit` more rows from the open cursor as READ events allocated in
-    /// `batch_allocator`; returns null once the cursor is exhausted. The caller owns the
-    /// batch and frees `batch_allocator` before the next fetch.
-    pub fn fetch(self: *Self, batch_allocator: std.mem.Allocator, limit: usize) SnapshotError!?[]ChangeEvent {
+    // Run a command (or a query whose rows we ignore), failing on a non-OK status.
+    fn execCommand(self: *Self, sql: [*:0]const u8) SnapshotError!void {
         const conn = self.connection orelse return error.ConnectionFailed;
-        const resource = self.resource orelse return error.QueryFailed;
 
-        const sql = std.fmt.allocPrintSentinel(self.allocator, "FETCH FORWARD {d} FROM " ++ cursor_name, .{limit}, 0) catch return error.OutOfMemory;
-        defer self.allocator.free(sql);
+        const result = c.PQexec(conn, sql) orelse return error.OutOfMemory;
+        defer c.PQclear(result);
+
+        const status = c.PQresultStatus(result);
+        if (status != c.PGRES_COMMAND_OK and status != c.PGRES_TUPLES_OK) {
+            std.log.warn("Snapshot command failed: {s}", .{c.PQresultErrorMessage(result)});
+            return error.QueryFailed;
+        }
+    }
+};
+
+/// An open cursor over one resource. Pull rows with `next` until it returns null, then
+/// `close`. Both borrow the SnapshotReader that produced it.
+pub const TableSnapshot = struct {
+    reader: *SnapshotReader,
+    resource: []const u8,
+
+    const Self = @This();
+
+    /// Fetch up to `limit` more rows as READ events allocated in `batch_allocator`;
+    /// returns null once the cursor is exhausted. The caller owns the batch and frees
+    /// `batch_allocator` before the next call.
+    pub fn next(self: *Self, batch_allocator: std.mem.Allocator, limit: usize) SnapshotError!?[]ChangeEvent {
+        const conn = self.reader.connection orelse return error.ConnectionFailed;
+
+        const sql = std.fmt.allocPrintSentinel(self.reader.allocator, "FETCH FORWARD {d} FROM " ++ cursor_name, .{limit}, 0) catch return error.OutOfMemory;
+        defer self.reader.allocator.free(sql);
 
         const result = c.PQexec(conn, sql.ptr) orelse return error.OutOfMemory;
         defer c.PQclear(result);
@@ -134,15 +145,19 @@ pub const SnapshotReader = struct {
 
         const events = batch_allocator.alloc(ChangeEvent, n_rows) catch return error.OutOfMemory;
         for (0..n_rows) |row| {
-            events[row] = try self.buildEvent(batch_allocator, result, resource, row, n_cols);
+            events[row] = try self.buildEvent(batch_allocator, result, row, n_cols);
         }
         return events;
+    }
+
+    pub fn close(self: *Self) SnapshotError!void {
+        try self.reader.execCommand("CLOSE " ++ cursor_name);
     }
 
     // Build one READ event from a result row. Columns come back in text format, the
     // same shape mapValue promotes for streamed changes, so a READ row and an INSERT
     // of the same row serialize identically.
-    fn buildEvent(self: *Self, batch_allocator: std.mem.Allocator, result: *c.PGresult, resource: []const u8, row: usize, n_cols: usize) SnapshotError!ChangeEvent {
+    fn buildEvent(self: *Self, batch_allocator: std.mem.Allocator, result: *c.PGresult, row: usize, n_cols: usize) SnapshotError!ChangeEvent {
         const row_c: c_int = @intCast(row);
 
         // Arena-backed batch: the caller frees the whole batch at once, so no
@@ -166,25 +181,11 @@ pub const SnapshotReader = struct {
 
         var event = ChangeEvent.init(ChangeOperation.READ, .{
             .source = try batch_allocator.dupe(u8, "postgres"),
-            .resource = try batch_allocator.dupe(u8, resource),
-            .timestamp = self.timestamp,
-            .lsn = try batch_allocator.dupe(u8, self.lsn),
+            .resource = try batch_allocator.dupe(u8, self.resource),
+            .timestamp = self.reader.timestamp,
+            .lsn = try batch_allocator.dupe(u8, self.reader.lsn),
         });
         event.setInsertData(row_data);
         return event;
-    }
-
-    // Run a command (or a query whose rows we ignore), failing on a non-OK status.
-    fn execCommand(self: *Self, sql: [*:0]const u8) SnapshotError!void {
-        const conn = self.connection orelse return error.ConnectionFailed;
-
-        const result = c.PQexec(conn, sql) orelse return error.OutOfMemory;
-        defer c.PQclear(result);
-
-        const status = c.PQresultStatus(result);
-        if (status != c.PGRES_COMMAND_OK and status != c.PGRES_TUPLES_OK) {
-            std.log.warn("Snapshot command failed: {s}", .{c.PQresultErrorMessage(result)});
-            return error.QueryFailed;
-        }
     }
 };

--- a/src/source/postgres/snapshot.zig
+++ b/src/source/postgres/snapshot.zig
@@ -1,0 +1,190 @@
+const std = @import("std");
+const c = @import("c"); // C bindings (build-system translate-c)
+
+const domain = @import("../../domain/change_event.zig");
+const ChangeEvent = domain.ChangeEvent;
+const ChangeOperation = domain.ChangeOperation;
+const FieldValue = domain.FieldValue;
+const RowDataHelpers = domain.RowDataHelpers;
+const FieldValueHelpers = domain.FieldValueHelpers;
+
+const converter = @import("converter.zig");
+const mapValue = converter.mapValue;
+
+pub const SnapshotError = error{
+    ConnectionFailed,
+    QueryFailed,
+    OutOfMemory,
+};
+
+// One cursor is open at a time, so a fixed name is enough.
+const cursor_name = "outboxx_snapshot_cursor";
+
+/// Reads a table's existing rows as of an exported snapshot and emits them as READ
+/// events, so a consumer can bootstrap current state before the stream begins (#49).
+///
+/// Runs on a regular (non-replication) connection. The caller opens a cursor per
+/// resource and pulls batches with `fetch` until it returns null; the events live in
+/// the batch allocator, so a large table is bounded by fetching in chunks and freeing
+/// each batch.
+pub const SnapshotReader = struct {
+    allocator: std.mem.Allocator,
+    // Snapshot exported by CREATE_REPLICATION_SLOT. Reading under it sees the database
+    // exactly at the slot's start; the session that exported it must stay open until
+    // `connect` binds this transaction to it.
+    snapshot_name: []const u8,
+    // The slot's consistent point (pg_lsn text form), stamped as meta.lsn on every READ
+    // row so a snapshot row and the first stream change share the same dedup boundary.
+    lsn: []const u8,
+    // Wall-clock start of the snapshot, stamped as meta.timestamp on every READ row.
+    timestamp: i64,
+    connection: ?*c.PGconn = null,
+    // Resource of the open cursor; borrowed for the openCursor..closeCursor span and
+    // duped into each event's metadata.
+    resource: ?[]const u8 = null,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator, snapshot_name: []const u8, lsn: []const u8, timestamp: i64) Self {
+        return .{
+            .allocator = allocator,
+            .snapshot_name = snapshot_name,
+            .lsn = lsn,
+            .timestamp = timestamp,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        if (self.connection) |conn| {
+            // Read-only snapshot transaction: nothing to persist, so end it best-effort.
+            _ = c.PQexec(conn, "COMMIT");
+            c.PQfinish(conn);
+            self.connection = null;
+        }
+        self.resource = null;
+    }
+
+    /// Connect and enter the snapshot transaction. Must run while the session that
+    /// exported `snapshot_name` is still open, or SET TRANSACTION SNAPSHOT fails.
+    pub fn connect(self: *Self, connection_string: []const u8) SnapshotError!void {
+        const conn_str = self.allocator.dupeZ(u8, connection_string) catch return error.OutOfMemory;
+        defer self.allocator.free(conn_str);
+
+        const conn = c.PQconnectdb(conn_str.ptr);
+        if (conn == null) {
+            std.log.warn("Snapshot: failed to allocate connection", .{});
+            return error.ConnectionFailed;
+        }
+        if (c.PQstatus(conn) != c.CONNECTION_OK) {
+            std.log.warn("Snapshot: connection failed: {s}", .{c.PQerrorMessage(conn)});
+            c.PQfinish(conn);
+            return error.ConnectionFailed;
+        }
+        self.connection = conn;
+        errdefer self.deinit();
+
+        // REPEATABLE READ plus SET TRANSACTION SNAPSHOT bind this read to the exact
+        // snapshot exported at slot creation, so it sees the database as of the slot's
+        // start LSN. SET must be the first statement of the transaction.
+        try self.execCommand("BEGIN ISOLATION LEVEL REPEATABLE READ");
+
+        const set_snapshot = std.fmt.allocPrintSentinel(self.allocator, "SET TRANSACTION SNAPSHOT '{s}'", .{self.snapshot_name}, 0) catch return error.OutOfMemory;
+        defer self.allocator.free(set_snapshot);
+        try self.execCommand(set_snapshot.ptr);
+    }
+
+    /// Open a cursor over one resource. `resource` is borrowed until closeCursor.
+    pub fn openCursor(self: *Self, resource: []const u8) SnapshotError!void {
+        // resource is the operator-controlled, config-validated schema.table (the same
+        // trust as validator.zig's to_regclass interpolation). DECLARE needs a real
+        // identifier, not a string literal, so it goes straight into the FROM clause.
+        const sql = std.fmt.allocPrintSentinel(self.allocator, "DECLARE " ++ cursor_name ++ " CURSOR FOR SELECT * FROM {s}", .{resource}, 0) catch return error.OutOfMemory;
+        defer self.allocator.free(sql);
+
+        try self.execCommand(sql.ptr);
+        self.resource = resource;
+    }
+
+    pub fn closeCursor(self: *Self) SnapshotError!void {
+        try self.execCommand("CLOSE " ++ cursor_name);
+        self.resource = null;
+    }
+
+    /// Fetch up to `limit` more rows from the open cursor as READ events allocated in
+    /// `batch_allocator`; returns null once the cursor is exhausted. The caller owns the
+    /// batch and frees `batch_allocator` before the next fetch.
+    pub fn fetch(self: *Self, batch_allocator: std.mem.Allocator, limit: usize) SnapshotError!?[]ChangeEvent {
+        const conn = self.connection orelse return error.ConnectionFailed;
+        const resource = self.resource orelse return error.QueryFailed;
+
+        const sql = std.fmt.allocPrintSentinel(self.allocator, "FETCH FORWARD {d} FROM " ++ cursor_name, .{limit}, 0) catch return error.OutOfMemory;
+        defer self.allocator.free(sql);
+
+        const result = c.PQexec(conn, sql.ptr) orelse return error.OutOfMemory;
+        defer c.PQclear(result);
+        if (c.PQresultStatus(result) != c.PGRES_TUPLES_OK) {
+            std.log.warn("Snapshot fetch failed: {s}", .{c.PQresultErrorMessage(result)});
+            return error.QueryFailed;
+        }
+
+        const n_rows: usize = @intCast(c.PQntuples(result));
+        if (n_rows == 0) return null; // cursor drained
+
+        const n_cols: usize = @intCast(c.PQnfields(result));
+
+        const events = batch_allocator.alloc(ChangeEvent, n_rows) catch return error.OutOfMemory;
+        for (0..n_rows) |row| {
+            events[row] = try self.buildEvent(batch_allocator, result, resource, row, n_cols);
+        }
+        return events;
+    }
+
+    // Build one READ event from a result row. Columns come back in text format, the
+    // same shape mapValue promotes for streamed changes, so a READ row and an INSERT
+    // of the same row serialize identically.
+    fn buildEvent(self: *Self, batch_allocator: std.mem.Allocator, result: *c.PGresult, resource: []const u8, row: usize, n_cols: usize) SnapshotError!ChangeEvent {
+        const row_c: c_int = @intCast(row);
+
+        // Arena-backed batch: the caller frees the whole batch at once, so no
+        // per-field cleanup on the error path here.
+        var builder = RowDataHelpers.createBuilder(batch_allocator);
+        for (0..n_cols) |col| {
+            const col_c: c_int = @intCast(col);
+            const name = std.mem.span(c.PQfname(result, col_c));
+
+            const value: FieldValue = if (c.PQgetisnull(result, row_c, col_c) != 0)
+                FieldValueHelpers.null_value()
+            else blk: {
+                const oid: u32 = @intCast(c.PQftype(result, col_c));
+                const text = std.mem.span(c.PQgetvalue(result, row_c, col_c));
+                break :blk try mapValue(batch_allocator, oid, text);
+            };
+
+            try RowDataHelpers.put(&builder, batch_allocator, name, value);
+        }
+        const row_data = try RowDataHelpers.finalize(&builder, batch_allocator);
+
+        var event = ChangeEvent.init(ChangeOperation.READ, .{
+            .source = try batch_allocator.dupe(u8, "postgres"),
+            .resource = try batch_allocator.dupe(u8, resource),
+            .timestamp = self.timestamp,
+            .lsn = try batch_allocator.dupe(u8, self.lsn),
+        });
+        event.setInsertData(row_data);
+        return event;
+    }
+
+    // Run a command (or a query whose rows we ignore), failing on a non-OK status.
+    fn execCommand(self: *Self, sql: [*:0]const u8) SnapshotError!void {
+        const conn = self.connection orelse return error.ConnectionFailed;
+
+        const result = c.PQexec(conn, sql) orelse return error.OutOfMemory;
+        defer c.PQclear(result);
+
+        const status = c.PQresultStatus(result);
+        if (status != c.PGRES_COMMAND_OK and status != c.PGRES_TUPLES_OK) {
+            std.log.warn("Snapshot command failed: {s}", .{c.PQresultErrorMessage(result)});
+            return error.QueryFailed;
+        }
+    }
+};

--- a/src/source/postgres/snapshot_test.zig
+++ b/src/source/postgres/snapshot_test.zig
@@ -96,7 +96,7 @@ test "SnapshotReader: reads existing rows as READ events, consistent with the ex
     var reader = SnapshotReader.init(allocator, snapshot_name, lsn, timestamp);
     defer reader.deinit();
     try reader.connect(conn_str);
-    try reader.openCursor(resource);
+    var table = try reader.open(resource);
 
     // One arena for the whole read; a small fetch limit forces several FETCH round
     // trips over the five rows.
@@ -105,7 +105,7 @@ test "SnapshotReader: reads existing rows as READ events, consistent with the ex
 
     var seen = [_]bool{false} ** 7; // ids 1..5 expected; 6 must stay unseen
     var total: usize = 0;
-    while (try reader.fetch(arena.allocator(), 2)) |events| {
+    while (try table.next(arena.allocator(), 2)) |events| {
         for (events) |event| {
             try testing.expectEqualStrings("READ", event.op);
             try testing.expectEqualStrings(resource, event.meta.resource);
@@ -131,7 +131,7 @@ test "SnapshotReader: reads existing rows as READ events, consistent with the ex
             total += 1;
         }
     }
-    try reader.closeCursor();
+    try table.close();
 
     try testing.expectEqual(@as(usize, 5), total);
     for (1..6) |i| try testing.expect(seen[i]);
@@ -174,11 +174,11 @@ test "SnapshotReader: empty table yields no events" {
     var reader = SnapshotReader.init(allocator, snapshot_name, "0/0", test_helpers.nowSeconds(io));
     defer reader.deinit();
     try reader.connect(conn_str);
-    try reader.openCursor(resource);
+    var table = try reader.open(resource);
 
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
-    try testing.expect((try reader.fetch(arena.allocator(), 10)) == null);
-    try reader.closeCursor();
+    try testing.expect((try table.next(arena.allocator(), 10)) == null);
+    try table.close();
 }

--- a/src/source/postgres/snapshot_test.zig
+++ b/src/source/postgres/snapshot_test.zig
@@ -1,0 +1,184 @@
+const std = @import("std");
+const testing = std.testing;
+
+const test_helpers = @import("../../testing/test_helpers.zig");
+const getTestConnectionString = test_helpers.getTestConnectionString;
+
+const domain = @import("../../domain/change_event.zig");
+const RowDataHelpers = domain.RowDataHelpers;
+
+const SnapshotReader = @import("snapshot.zig").SnapshotReader;
+
+const c = @import("c"); // C bindings (build-system translate-c)
+
+fn createSetupConnection(allocator: std.mem.Allocator) !*c.PGconn {
+    const conn_str = try getTestConnectionString(allocator);
+    defer allocator.free(conn_str);
+    const conn_str_z = try allocator.dupeZ(u8, conn_str);
+    defer allocator.free(conn_str_z);
+
+    const conn = c.PQconnectdb(conn_str_z.ptr) orelse return error.ConnectionFailed;
+    if (c.PQstatus(conn) != c.CONNECTION_OK) {
+        c.PQfinish(conn);
+        return error.ConnectionFailed;
+    }
+    return conn;
+}
+
+fn execSQL(conn: *c.PGconn, sql: [:0]const u8) !void {
+    const result = c.PQexec(conn, sql.ptr);
+    defer c.PQclear(result);
+    const status = c.PQresultStatus(result);
+    if (status != c.PGRES_COMMAND_OK and status != c.PGRES_TUPLES_OK) {
+        std.log.warn("SQL failed: {s}\nError: {s}", .{ sql, c.PQresultErrorMessage(result) });
+        return error.SQLFailed;
+    }
+}
+
+test "SnapshotReader: reads existing rows as READ events, consistent with the exported snapshot" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+
+    const suffix = test_helpers.nowMicros(io);
+    const table_name = try std.fmt.allocPrint(allocator, "snap_{d}", .{suffix});
+    defer allocator.free(table_name);
+    const resource = try std.fmt.allocPrint(allocator, "public.{s}", .{table_name});
+    defer allocator.free(resource);
+
+    const setup_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(setup_conn);
+    defer {
+        const drop = std.fmt.allocPrintSentinel(allocator, "DROP TABLE IF EXISTS {s}", .{table_name}, 0) catch unreachable;
+        defer allocator.free(drop);
+        execSQL(setup_conn, drop) catch {};
+    }
+
+    const create = try test_helpers.formatSqlZ(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT, active BOOL, ratio DOUBLE PRECISION)", .{table_name});
+    defer allocator.free(create);
+    try execSQL(setup_conn, create);
+
+    // Five committed rows the snapshot must see, typed to exercise mapValue.
+    const seed = try test_helpers.formatSqlZ(allocator,
+        \\INSERT INTO {s} (name, active, ratio) VALUES
+        \\ ('name_1', true, 1.5),
+        \\ ('name_2', false, 2.5),
+        \\ ('name_3', true, 3.5),
+        \\ ('name_4', false, 4.5),
+        \\ ('name_5', true, 5.5)
+    , .{table_name});
+    defer allocator.free(seed);
+    try execSQL(setup_conn, seed);
+
+    // Export a snapshot from a held-open transaction, standing in for the one
+    // CREATE_REPLICATION_SLOT exports. It must stay open until the reader runs
+    // SET TRANSACTION SNAPSHOT.
+    const export_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(export_conn);
+    try execSQL(export_conn, "BEGIN ISOLATION LEVEL REPEATABLE READ");
+    const export_result = c.PQexec(export_conn, "SELECT pg_export_snapshot()");
+    defer c.PQclear(export_result);
+    try testing.expect(c.PQresultStatus(export_result) == c.PGRES_TUPLES_OK);
+    const snapshot_name = try allocator.dupe(u8, std.mem.span(c.PQgetvalue(export_result, 0, 0)));
+    defer allocator.free(snapshot_name);
+
+    // A sixth row inserted after the export: outside the snapshot, so the reader
+    // must not see it.
+    const after = try test_helpers.formatSqlZ(allocator, "INSERT INTO {s} (name, active, ratio) VALUES ('name_6', false, 6.5)", .{table_name});
+    defer allocator.free(after);
+    try execSQL(setup_conn, after);
+
+    const conn_str = try getTestConnectionString(allocator);
+    defer allocator.free(conn_str);
+
+    const lsn = "0/15D6E10";
+    const timestamp = test_helpers.nowSeconds(io);
+
+    var reader = SnapshotReader.init(allocator, snapshot_name, lsn, timestamp);
+    defer reader.deinit();
+    try reader.connect(conn_str);
+    try reader.openCursor(resource);
+
+    // One arena for the whole read; a small fetch limit forces several FETCH round
+    // trips over the five rows.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var seen = [_]bool{false} ** 7; // ids 1..5 expected; 6 must stay unseen
+    var total: usize = 0;
+    while (try reader.fetch(arena.allocator(), 2)) |events| {
+        for (events) |event| {
+            try testing.expectEqualStrings("READ", event.op);
+            try testing.expectEqualStrings(resource, event.meta.resource);
+            try testing.expectEqualStrings(lsn, event.meta.lsn.?);
+            try testing.expectEqual(timestamp, event.meta.timestamp);
+
+            try testing.expect(event.data == .insert);
+            const row = event.data.insert;
+
+            const id = RowDataHelpers.getField(row, "id").?.integer;
+            try testing.expect(id >= 1 and id <= 5);
+            try testing.expect(!seen[@intCast(id)]);
+            seen[@intCast(id)] = true;
+
+            // name typed as string, active as bool, ratio as float, same as the
+            // streamed path would map them.
+            var name_buf: [16]u8 = undefined;
+            const expected_name = try std.fmt.bufPrint(&name_buf, "name_{d}", .{id});
+            try testing.expectEqualStrings(expected_name, RowDataHelpers.getField(row, "name").?.string);
+            try testing.expect(RowDataHelpers.getField(row, "active").? == .bool);
+            try testing.expect(RowDataHelpers.getField(row, "ratio").? == .float);
+
+            total += 1;
+        }
+    }
+    try reader.closeCursor();
+
+    try testing.expectEqual(@as(usize, 5), total);
+    for (1..6) |i| try testing.expect(seen[i]);
+    try testing.expect(!seen[6]);
+}
+
+test "SnapshotReader: empty table yields no events" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+
+    const suffix = test_helpers.nowMicros(io);
+    const table_name = try std.fmt.allocPrint(allocator, "snap_empty_{d}", .{suffix});
+    defer allocator.free(table_name);
+    const resource = try std.fmt.allocPrint(allocator, "public.{s}", .{table_name});
+    defer allocator.free(resource);
+
+    const setup_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(setup_conn);
+    defer {
+        const drop = std.fmt.allocPrintSentinel(allocator, "DROP TABLE IF EXISTS {s}", .{table_name}, 0) catch unreachable;
+        defer allocator.free(drop);
+        execSQL(setup_conn, drop) catch {};
+    }
+
+    const create = try test_helpers.formatSqlZ(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT)", .{table_name});
+    defer allocator.free(create);
+    try execSQL(setup_conn, create);
+
+    const export_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(export_conn);
+    try execSQL(export_conn, "BEGIN ISOLATION LEVEL REPEATABLE READ");
+    const export_result = c.PQexec(export_conn, "SELECT pg_export_snapshot()");
+    defer c.PQclear(export_result);
+    const snapshot_name = try allocator.dupe(u8, std.mem.span(c.PQgetvalue(export_result, 0, 0)));
+    defer allocator.free(snapshot_name);
+
+    const conn_str = try getTestConnectionString(allocator);
+    defer allocator.free(conn_str);
+
+    var reader = SnapshotReader.init(allocator, snapshot_name, "0/0", test_helpers.nowSeconds(io));
+    defer reader.deinit();
+    try reader.connect(conn_str);
+    try reader.openCursor(resource);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    try testing.expect((try reader.fetch(arena.allocator(), 10)) == null);
+    try reader.closeCursor();
+}


### PR DESCRIPTION
Second PR toward the initial snapshot (#49). Groundwork only: the reader is not wired into startup yet.

## Problem

Replication starts at the slot's LSN, so a new consumer never sees rows that existed before the slot was created. #49 asks for those rows to be emitted once, up front, consistent with where the stream then begins.

## Solution

- Add `READ` to `ChangeOperation` and `"read"` to the allowed stream operations. A READ event reuses the insert payload, so serialization, `matchStreams`, and partitioning are unchanged; a stream opts into the snapshot by listing `read` in its operations.
- New `SnapshotReader` (`source/postgres/snapshot.zig`): on a regular connection it enters a `REPEATABLE READ` transaction bound to an exported snapshot (`SET TRANSACTION SNAPSHOT`), reads each table with a cursor + `FETCH` to bound memory, and emits each row as a READ event stamped with the slot's consistent point as `meta.lsn`.
- Make `converter.mapValue` public so a READ row and a streamed change of the same column map (oid, text) to the same JSON type.

## Tests

- Integration: exports a snapshot with `pg_export_snapshot()`, then checks the reader returns the pre-export rows only (a row inserted after export is not read) and that values are typed like the streamed path (int/bool/float). Plus an empty-table case.
- Unit: READ serializes to `"op":"READ"`, `read` passes config validation, and a pure `matchStreams` check that a READ event routes only to streams listing `read`.

Startup wiring, the `snapshot.mode` gate, and e2e come in the next PR.