### PR TITLE
Wire the initial snapshot into startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,16 +107,16 @@ TOML, secrets kept out of the file (see `docs/examples/config.toml`).
   (`mechanism`, `username`, `password_env`).
 - `[observability]` (optional; absent = off): `address`/`port` for a Prometheus
   `/metrics` plus `/healthz` and `/readyz` HTTP server.
-- `[snapshot].mode` (optional; absent = `initial`): `initial` runs the initial
-  snapshot, `no-snapshot` disables it. A stream opts in by listing `read` in its
-  `operations`. The snapshot runs only when the slot is created this run, the mode
-  is `initial`, and some stream lists `read`; it reads under the slot's exported
-  snapshot, before `START_REPLICATION`, so it can't gap or overlap the stream. An
-  interrupted snapshot is redone from scratch on the next start: a marker
-  publication `<publication>_snapshotting` (created before the slot, dropped once
-  the snapshot is flushed) flags an in-progress snapshot, so on restart a slot with
-  the marker still present is dropped and re-bootstrapped from a fresh consistent
-  point. The marker exists only during the snapshot, so steady state keeps a single
+- Initial snapshot: a stream opts in by listing `read` in its `operations`, and its
+  existing rows are emitted as `op="READ"` before streaming. There is no separate
+  toggle; the snapshot runs only when the slot is created this run and some stream
+  lists `read`. It reads under the slot's exported snapshot, before
+  `START_REPLICATION`, so it can't gap or overlap the stream. An interrupted
+  snapshot is redone from scratch on the next start: a marker publication
+  `<publication>_snapshotting` (created before the slot, dropped once the snapshot
+  is flushed) flags an in-progress snapshot, so on restart a slot with the marker
+  still present is dropped and re-bootstrapped from a fresh consistent point. The
+  marker exists only during the snapshot, so steady state keeps a single
   publication. pgoutput resolves the publication by name in the historical catalog
   per change, so the streaming publication must exist before the slot; that is why
   the marker is a separate publication and never passed to `START_REPLICATION`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,12 @@ for at-least-once redeliveries. pgoutput sends every value as text; the
 converter promotes int/float/bool OIDs to JSON types and keeps the rest
 (including `numeric`) as strings.
 
+`op` is `INSERT`/`UPDATE`/`DELETE` for WAL changes plus `READ` for an initial
+snapshot row (existing data read before streaming, shaped like an INSERT). A
+`READ` row carries the slot's start LSN as its `lsn`, the same boundary the
+stream then resumes from, so snapshot + stream cover every row with no gap or
+overlap. Consumers must treat `READ` as an upsert (redeliverable, like any op).
+
 ## Configuration
 
 TOML, secrets kept out of the file (see `docs/examples/config.toml`).
@@ -101,6 +107,13 @@ TOML, secrets kept out of the file (see `docs/examples/config.toml`).
   (`mechanism`, `username`, `password_env`).
 - `[observability]` (optional; absent = off): `address`/`port` for a Prometheus
   `/metrics` plus `/healthz` and `/readyz` HTTP server.
+- `[snapshot].mode` (optional; absent = `initial`): `initial` runs the initial
+  snapshot, `no-snapshot` disables it. A stream opts in by listing `read` in its
+  `operations`. The snapshot runs only when the slot is created this run, the mode
+  is `initial`, and some stream lists `read`; it reads under the slot's exported
+  snapshot, before `START_REPLICATION`, so it can't gap or overlap the stream. An
+  interrupted snapshot is not resumed (the slot then already exists, so the next
+  start skips it); re-bootstrapping means a new slot.
 - Postgres needs `wal_level = logical`, plus `REPLICA IDENTITY FULL` on tables
   whose stream tracks DELETE (validated at startup; UPDATE emits only the new
   row, so it doesn't need it). Outboxx auto-creates the slot and publication.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,8 +112,14 @@ TOML, secrets kept out of the file (see `docs/examples/config.toml`).
   `operations`. The snapshot runs only when the slot is created this run, the mode
   is `initial`, and some stream lists `read`; it reads under the slot's exported
   snapshot, before `START_REPLICATION`, so it can't gap or overlap the stream. An
-  interrupted snapshot is not resumed (the slot then already exists, so the next
-  start skips it); re-bootstrapping means a new slot.
+  interrupted snapshot is redone from scratch on the next start: a marker
+  publication `<publication>_snapshotting` (created before the slot, dropped once
+  the snapshot is flushed) flags an in-progress snapshot, so on restart a slot with
+  the marker still present is dropped and re-bootstrapped from a fresh consistent
+  point. The marker exists only during the snapshot, so steady state keeps a single
+  publication. pgoutput resolves the publication by name in the historical catalog
+  per change, so the streaming publication must exist before the slot; that is why
+  the marker is a separate publication and never passed to `START_REPLICATION`.
 - Postgres needs `wal_level = logical`, plus `REPLICA IDENTITY FULL` on tables
   whose stream tracks DELETE (validated at startup; UPDATE emits only the new
   row, so it doesn't need it). Outboxx auto-creates the slot and publication.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,12 @@ The domain model has no source/sink dependencies. The processor drives the
 pipeline batch by batch on an arena allocator (freed per batch); a background
 worker flushes Kafka and confirms the LSN off the hot path.
 
+The initial snapshot is part of the source, not the processor: `openSnapshot` /
+`receiveSnapshotBatch` / `startStreaming` hand out the same `Batch` the stream
+does, and an empty batch ends the snapshot phase. Slots, cursors, exported
+snapshots, and the marker publication stay inside `source/postgres/`, so the
+processor only picks the phase and routes domain events.
+
 ## Layout
 
 ```
@@ -55,6 +61,7 @@ src/
     replication_protocol.zig libpq streaming: connect, slot, publication, feedback
     pg_output_decoder.zig    binary pgoutput parser
     converter.zig            decoded message -> ChangeEvent (owns RelationRegistry)
+    snapshot.zig             initial-snapshot session: cursors over the exported snapshot
     relation_registry.zig    relation_id -> table metadata
     validator.zig            startup checks: version, wal_level, tables
   processor/processor.zig    pipeline, stream matching, flush/commit worker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,10 +120,12 @@ TOML, secrets kept out of the file (see `docs/examples/config.toml`).
   lists `read`. It reads under the slot's exported snapshot, before
   `START_REPLICATION`, so it can't gap or overlap the stream. An interrupted
   snapshot is redone from scratch on the next start: a marker publication
-  `<publication>_snapshotting` (created before the slot, dropped once the snapshot
-  is flushed) flags an in-progress snapshot, so on restart a slot with the marker
-  still present is dropped and re-bootstrapped from a fresh consistent point. The
-  marker exists only during the snapshot, so steady state keeps a single
+  `<slot>_snapshotting` (created before the slot, dropped once the snapshot is
+  flushed) flags an in-progress snapshot, so on restart a slot with the marker
+  still present is dropped and re-bootstrapped from a fresh consistent point. It is
+  named after the slot, not the publication, because it guards that slot's
+  bootstrap and several pipelines can share one publication. The marker exists only
+  during the snapshot, so steady state keeps a single
   publication. pgoutput resolves the publication by name in the historical catalog
   per change, so the streaming publication must exist before the slot; that is why
   the marker is a separate publication and never passed to `START_REPLICATION`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ All notable changes to Outboxx are documented here.
   emits its current rows as `op="READ"` before streaming, read under the slot's
   exported snapshot so the snapshot and the stream share one boundary (the READ
   rows carry the slot's start LSN). Runs only on a freshly created slot; gated by
-  `[snapshot].mode` (`initial` default, `no-snapshot` to disable). Consumers must
-  treat `READ` as an upsert. An interrupted snapshot is not resumed; re-bootstrap
-  by recreating the slot.
+  `[snapshot].mode` (`initial` default, `no-snapshot` to disable). An interrupted
+  snapshot is redone from scratch on the next start (tracked by a transient marker
+  publication), so no rows are missed; consumers must treat `READ` as an upsert.
 - Streams can target tables in any schema. Set `resource = "schema.table"` in a
   stream's source; a bare name still defaults to the `public` schema.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ All notable changes to Outboxx are documented here.
 - Initial snapshot of existing rows. A stream that lists `read` in `operations`
   emits its current rows as `op="READ"` before streaming, read under the slot's
   exported snapshot so the snapshot and the stream share one boundary (the READ
-  rows carry the slot's start LSN). Runs only on a freshly created slot; gated by
-  `[snapshot].mode` (`initial` default, `no-snapshot` to disable). An interrupted
-  snapshot is redone from scratch on the next start (tracked by a transient marker
-  publication), so no rows are missed; consumers must treat `READ` as an upsert.
+  rows carry the slot's start LSN). Runs once, on a freshly created slot. An
+  interrupted snapshot is redone from scratch on the next start (tracked by a
+  transient marker publication), so no rows are missed; consumers must treat
+  `READ` as an upsert.
 - Streams can target tables in any schema. Set `resource = "schema.table"` in a
   stream's source; a bare name still defaults to the `public` schema.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Outboxx are documented here.
 
 ### Added
 
+- Initial snapshot of existing rows. A stream that lists `read` in `operations`
+  emits its current rows as `op="READ"` before streaming, read under the slot's
+  exported snapshot so the snapshot and the stream share one boundary (the READ
+  rows carry the slot's start LSN). Runs only on a freshly created slot; gated by
+  `[snapshot].mode` (`initial` default, `no-snapshot` to disable). Consumers must
+  treat `READ` as an upsert. An interrupted snapshot is not resumed; re-bootstrap
+  by recreating the slot.
 - Streams can target tables in any schema. Set `resource = "schema.table"` in a
   stream's source; a bare name still defaults to the `public` schema.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Outboxx captures PostgreSQL database changes in real-time and streams them to Ka
 **Key Features:**
 - Natively fast
 - PostgreSQL streaming replication (pgoutput)
+- Initial snapshot of existing rows, consistent with the stream's start
 - Multi-table CDC streams
 - Kafka producer integration
 - TOML-based configuration

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -50,8 +50,8 @@ port = 9464          # conventional OpenTelemetry Prometheus exporter port
 # Optional initial snapshot. Omit this section to keep the default "initial".
 # "initial" reads existing rows once, only on a freshly created slot and only for
 # streams that list "read" (below), and emits them as op="READ" before streaming;
-# "no-snapshot" disables it regardless of the per-stream opt-in. Re-bootstrapping a
-# table means a new slot, since an existing slot has no consistent snapshot to read.
+# "no-snapshot" disables it regardless of the per-stream opt-in. An interrupted
+# snapshot is detected and redone from scratch automatically on the next start.
 [snapshot]
 mode = "initial"  # initial | no-snapshot
 

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -47,14 +47,6 @@ tls = true                                   # on by default; set false for loca
 address = "0.0.0.0"  # 127.0.0.1 to keep it local; 0.0.0.0 for container scraping
 port = 9464          # conventional OpenTelemetry Prometheus exporter port
 
-# Optional initial snapshot. Omit this section to keep the default "initial".
-# "initial" reads existing rows once, only on a freshly created slot and only for
-# streams that list "read" (below), and emits them as op="READ" before streaming;
-# "no-snapshot" disables it regardless of the per-stream opt-in. An interrupted
-# snapshot is detected and redone from scratch automatically on the next start.
-[snapshot]
-mode = "initial"  # initial | no-snapshot
-
 # One [[streams]] block per table -> topic mapping.
 [[streams]]
 name = "users-stream"

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -47,13 +47,21 @@ tls = true                                   # on by default; set false for loca
 address = "0.0.0.0"  # 127.0.0.1 to keep it local; 0.0.0.0 for container scraping
 port = 9464          # conventional OpenTelemetry Prometheus exporter port
 
+# Optional initial snapshot. Omit this section to keep the default "initial".
+# "initial" reads existing rows once, only on a freshly created slot and only for
+# streams that list "read" (below), and emits them as op="READ" before streaming;
+# "no-snapshot" disables it regardless of the per-stream opt-in. Re-bootstrapping a
+# table means a new slot, since an existing slot has no consistent snapshot to read.
+[snapshot]
+mode = "initial"  # initial | no-snapshot
+
 # One [[streams]] block per table -> topic mapping.
 [[streams]]
 name = "users-stream"
 
 [streams.source]
-resource = "users"                           # table; use "schema.table" for a non-public schema (default: public)
-operations = ["insert", "update", "delete"]  # subset of insert | update | delete
+resource = "users"                                   # table; use "schema.table" for a non-public schema (default: public)
+operations = ["read", "insert", "update", "delete"]  # subset of read | insert | update | delete; "read" opts into the initial snapshot
 
 [streams.flow]
 format = "json"                              # only json is supported

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -56,11 +56,11 @@ resource = "users"                                   # table; use "schema.table"
 operations = ["read", "insert", "update", "delete"]  # subset of read | insert | update | delete; "read" opts into the initial snapshot
 
 [streams.flow]
-format = "json"                              # only json is supported
+format = "json"                                      # only json is supported
 
 [streams.sink]
-destination = "public.users"                 # Kafka topic
-routing_key = "id"                           # column used as the partition key (default: id)
+destination = "public.users"                         # Kafka topic
+routing_key = "id"                                   # column used as the partition key (default: id)
 
 [[streams]]
 name = "orders-stream"

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -135,6 +135,17 @@ pub const Stream = struct {
     }
 };
 
+/// Whether any stream opts into the initial snapshot by listing `read`. The single
+/// source of truth for the snapshot gate: the caller connecting the source (to
+/// drive interrupted-snapshot recovery on the slot) and the processor running the
+/// snapshot both derive it from the same streams.
+pub fn wantsInitialSnapshot(streams: []const Stream) bool {
+    for (streams) |stream| {
+        if (stream.hasReadOperation()) return true;
+    }
+    return false;
+}
+
 pub const TableFilter = struct {
     include: []const []const u8,
     exclude: []const []const u8,
@@ -1036,6 +1047,20 @@ test "Stream.hasReadOperation reflects the configured operations" {
     var stream_only = base;
     stream_only.source.operations = &.{ "insert", "update" };
     try testing.expect(!stream_only.hasReadOperation());
+}
+
+test "wantsInitialSnapshot is driven by the read opt-in" {
+    const no_read: Stream = .{
+        .name = "s",
+        .source = .{ .resource = "users", .operations = &.{ "insert", "update" } },
+        .flow = .{ .format = "json" },
+        .sink = .{ .destination = "t", .routing_key = "id" },
+    };
+    try testing.expect(!wantsInitialSnapshot(&.{no_read}));
+
+    var with_read = no_read;
+    with_read.source.operations = &.{ "read", "insert" };
+    try testing.expect(wantsInitialSnapshot(&.{ no_read, with_read }));
 }
 
 test "Config validation - full SASL over TLS passes" {

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -213,6 +213,18 @@ pub const Config = struct {
         return readEnvVar(allocator, environ_map, postgres.connection_env);
     }
 
+    /// Whether an initial snapshot may run this session: the mode is `initial`
+    /// (default) and at least one stream opts into `read`. Gates the snapshot itself
+    /// and the interrupted-snapshot recovery on startup.
+    pub fn wantsInitialSnapshot(self: Config) bool {
+        const snapshot = self.snapshot orelse SnapshotConfig{};
+        if (!snapshot.isInitial()) return false;
+        for (self.streams) |stream| {
+            if (stream.hasReadOperation()) return true;
+        }
+        return false;
+    }
+
     // Helper validation functions
 
     fn validateEnum(allocator: std.mem.Allocator, value: []const u8, allowed_values: []const []const u8, field_name: []const u8) !void {

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -139,7 +139,7 @@ pub const Stream = struct {
 /// source of truth for the snapshot gate: the caller connecting the source (to
 /// drive interrupted-snapshot recovery on the slot) and the processor running the
 /// snapshot both derive it from the same streams.
-pub fn wantsInitialSnapshot(streams: []const Stream) bool {
+pub fn needsInitialSnapshot(streams: []const Stream) bool {
     for (streams) |stream| {
         if (stream.hasReadOperation()) return true;
     }
@@ -1049,18 +1049,18 @@ test "Stream.hasReadOperation reflects the configured operations" {
     try testing.expect(!stream_only.hasReadOperation());
 }
 
-test "wantsInitialSnapshot is driven by the read opt-in" {
+test "needsInitialSnapshot is driven by the read opt-in" {
     const no_read: Stream = .{
         .name = "s",
         .source = .{ .resource = "users", .operations = &.{ "insert", "update" } },
         .flow = .{ .format = "json" },
         .sink = .{ .destination = "t", .routing_key = "id" },
     };
-    try testing.expect(!wantsInitialSnapshot(&.{no_read}));
+    try testing.expect(!needsInitialSnapshot(&.{no_read}));
 
     var with_read = no_read;
     with_read.source.operations = &.{ "read", "insert" };
-    try testing.expect(wantsInitialSnapshot(&.{ no_read, with_read }));
+    try testing.expect(needsInitialSnapshot(&.{ no_read, with_read }));
 }
 
 test "Config validation - full SASL over TLS passes" {

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -26,9 +26,6 @@ pub const SupportedValues = struct {
     pub const FORMATS = [_][]const u8{"json"};
     // Only username/password mechanisms; GSSAPI/OAUTHBEARER need auth plumbing we don't expose yet.
     pub const KAFKA_SASL_MECHANISMS = [_][]const u8{ "PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512" };
-    // "initial" runs the snapshot on a freshly created slot for streams listing
-    // "read"; "no-snapshot" disables it regardless of the per-stream opt-in.
-    pub const SNAPSHOT_MODES = [_][]const u8{ "initial", "no-snapshot" };
 };
 
 // Configuration structures matching TOML format
@@ -150,18 +147,6 @@ pub const ObservabilityConfig = struct {
     port: u16 = 9464, // conventional OpenTelemetry Prometheus exporter port
 };
 
-/// Initial-snapshot policy. Absent section -> defaults to "initial", which still
-/// snapshots nothing unless a stream lists "read", so the default is inert.
-pub const SnapshotConfig = struct {
-    mode: []const u8 = "initial", // initial | no-snapshot
-
-    /// Whether the mode permits an initial snapshot at all (the per-stream "read"
-    /// opt-in and a freshly created slot decide the rest).
-    pub fn isInitial(self: SnapshotConfig) bool {
-        return std.mem.eql(u8, self.mode, "initial");
-    }
-};
-
 /// Configuration data, and the TOML parse target. Strings point into the arena of the
 /// returned toml.Parsed(Config), so the caller keeps that value alive while using it.
 pub const Config = struct {
@@ -171,7 +156,6 @@ pub const Config = struct {
     streams: []const Stream = &.{},
     tables: ?TableFilter = null,
     observability: ?ObservabilityConfig = null,
-    snapshot: ?SnapshotConfig = null,
 
     /// Parse a config file; caller owns and must deinit the returned result.
     pub fn loadFromTomlFile(io: std.Io, allocator: std.mem.Allocator, file_path: []const u8) !toml.Parsed(Config) {
@@ -213,12 +197,10 @@ pub const Config = struct {
         return readEnvVar(allocator, environ_map, postgres.connection_env);
     }
 
-    /// Whether an initial snapshot may run this session: the mode is `initial`
-    /// (default) and at least one stream opts into `read`. Gates the snapshot itself
-    /// and the interrupted-snapshot recovery on startup.
+    /// Whether an initial snapshot may run this session: at least one stream opts
+    /// into `read`. Gates the snapshot itself and the interrupted-snapshot recovery
+    /// on startup.
     pub fn wantsInitialSnapshot(self: Config) bool {
-        const snapshot = self.snapshot orelse SnapshotConfig{};
-        if (!snapshot.isInitial()) return false;
         for (self.streams) |stream| {
             if (stream.hasReadOperation()) return true;
         }
@@ -472,11 +454,6 @@ pub const Config = struct {
         if (self.observability) |obs| {
             try validatePort(obs.port, "observability.port");
             try validateStringLength(obs.address, ValidationLimits.MAX_HOSTNAME_LEN, "observability.address");
-        }
-
-        // 5b. SNAPSHOT VALIDATION
-        if (self.snapshot) |snapshot| {
-            try validateEnum(allocator, snapshot.mode, &SupportedValues.SNAPSHOT_MODES, "snapshot.mode");
         }
 
         // 6. STREAMS VALIDATION
@@ -1054,29 +1031,6 @@ test "Config validation - invalid SASL mechanism fails" {
     try testing.expectError(error.InvalidEnumValue, cfg.validate(testing.allocator));
 }
 
-test "Config validation - snapshot mode initial passes" {
-    var cfg = createTestDefault();
-    cfg.snapshot = .{ .mode = "initial" };
-    try cfg.validate(testing.allocator);
-}
-
-test "Config validation - snapshot mode no-snapshot passes" {
-    var cfg = createTestDefault();
-    cfg.snapshot = .{ .mode = "no-snapshot" };
-    try cfg.validate(testing.allocator);
-}
-
-test "Config validation - invalid snapshot mode fails" {
-    var cfg = createTestDefault();
-    cfg.snapshot = .{ .mode = "always" };
-    try testing.expectError(error.InvalidEnumValue, cfg.validate(testing.allocator));
-}
-
-test "SnapshotConfig.isInitial reflects the mode" {
-    try testing.expect((SnapshotConfig{ .mode = "initial" }).isInitial());
-    try testing.expect(!(SnapshotConfig{ .mode = "no-snapshot" }).isInitial());
-}
-
 test "Stream.hasReadOperation reflects the configured operations" {
     const base: Stream = .{
         .name = "s",
@@ -1092,6 +1046,26 @@ test "Stream.hasReadOperation reflects the configured operations" {
     var stream_only = base;
     stream_only.source.operations = &.{ "insert", "update" };
     try testing.expect(!stream_only.hasReadOperation());
+}
+
+test "wantsInitialSnapshot is driven by the read opt-in" {
+    var cfg = createTestDefault();
+
+    cfg.streams = &.{.{
+        .name = "s",
+        .source = .{ .resource = "users", .operations = &.{ "insert", "update" } },
+        .flow = .{ .format = "json" },
+        .sink = .{ .destination = "t", .routing_key = "id" },
+    }};
+    try testing.expect(!cfg.wantsInitialSnapshot());
+
+    cfg.streams = &.{.{
+        .name = "s",
+        .source = .{ .resource = "users", .operations = &.{ "read", "insert" } },
+        .flow = .{ .format = "json" },
+        .sink = .{ .destination = "t", .routing_key = "id" },
+    }};
+    try testing.expect(cfg.wantsInitialSnapshot());
 }
 
 test "Config validation - full SASL over TLS passes" {

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -26,6 +26,9 @@ pub const SupportedValues = struct {
     pub const FORMATS = [_][]const u8{"json"};
     // Only username/password mechanisms; GSSAPI/OAUTHBEARER need auth plumbing we don't expose yet.
     pub const KAFKA_SASL_MECHANISMS = [_][]const u8{ "PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512" };
+    // "initial" runs the snapshot on a freshly created slot for streams listing
+    // "read"; "no-snapshot" disables it regardless of the per-stream opt-in.
+    pub const SNAPSHOT_MODES = [_][]const u8{ "initial", "no-snapshot" };
 };
 
 // Configuration structures matching TOML format
@@ -124,6 +127,15 @@ pub const Stream = struct {
         }
         return false;
     }
+
+    /// Whether this stream opts into the initial snapshot (lists "read"), so its
+    /// existing rows are emitted as READ events before streaming.
+    pub fn hasReadOperation(self: Stream) bool {
+        for (self.source.operations) |op| {
+            if (std.mem.eql(u8, op, "read")) return true;
+        }
+        return false;
+    }
 };
 
 pub const TableFilter = struct {
@@ -138,6 +150,18 @@ pub const ObservabilityConfig = struct {
     port: u16 = 9464, // conventional OpenTelemetry Prometheus exporter port
 };
 
+/// Initial-snapshot policy. Absent section -> defaults to "initial", which still
+/// snapshots nothing unless a stream lists "read", so the default is inert.
+pub const SnapshotConfig = struct {
+    mode: []const u8 = "initial", // initial | no-snapshot
+
+    /// Whether the mode permits an initial snapshot at all (the per-stream "read"
+    /// opt-in and a freshly created slot decide the rest).
+    pub fn isInitial(self: SnapshotConfig) bool {
+        return std.mem.eql(u8, self.mode, "initial");
+    }
+};
+
 /// Configuration data, and the TOML parse target. Strings point into the arena of the
 /// returned toml.Parsed(Config), so the caller keeps that value alive while using it.
 pub const Config = struct {
@@ -147,6 +171,7 @@ pub const Config = struct {
     streams: []const Stream = &.{},
     tables: ?TableFilter = null,
     observability: ?ObservabilityConfig = null,
+    snapshot: ?SnapshotConfig = null,
 
     /// Parse a config file; caller owns and must deinit the returned result.
     pub fn loadFromTomlFile(io: std.Io, allocator: std.mem.Allocator, file_path: []const u8) !toml.Parsed(Config) {
@@ -435,6 +460,11 @@ pub const Config = struct {
         if (self.observability) |obs| {
             try validatePort(obs.port, "observability.port");
             try validateStringLength(obs.address, ValidationLimits.MAX_HOSTNAME_LEN, "observability.address");
+        }
+
+        // 5b. SNAPSHOT VALIDATION
+        if (self.snapshot) |snapshot| {
+            try validateEnum(allocator, snapshot.mode, &SupportedValues.SNAPSHOT_MODES, "snapshot.mode");
         }
 
         // 6. STREAMS VALIDATION
@@ -1010,6 +1040,46 @@ test "Config validation - invalid SASL mechanism fails" {
     var cfg = createTestDefault();
     cfg.sink.kafka.?.sasl = .{ .mechanism = "GSSAPI", .username = "app", .password_env = "KAFKA_PASSWORD" };
     try testing.expectError(error.InvalidEnumValue, cfg.validate(testing.allocator));
+}
+
+test "Config validation - snapshot mode initial passes" {
+    var cfg = createTestDefault();
+    cfg.snapshot = .{ .mode = "initial" };
+    try cfg.validate(testing.allocator);
+}
+
+test "Config validation - snapshot mode no-snapshot passes" {
+    var cfg = createTestDefault();
+    cfg.snapshot = .{ .mode = "no-snapshot" };
+    try cfg.validate(testing.allocator);
+}
+
+test "Config validation - invalid snapshot mode fails" {
+    var cfg = createTestDefault();
+    cfg.snapshot = .{ .mode = "always" };
+    try testing.expectError(error.InvalidEnumValue, cfg.validate(testing.allocator));
+}
+
+test "SnapshotConfig.isInitial reflects the mode" {
+    try testing.expect((SnapshotConfig{ .mode = "initial" }).isInitial());
+    try testing.expect(!(SnapshotConfig{ .mode = "no-snapshot" }).isInitial());
+}
+
+test "Stream.hasReadOperation reflects the configured operations" {
+    const base: Stream = .{
+        .name = "s",
+        .source = .{ .resource = "users", .operations = &.{} },
+        .flow = .{ .format = "json" },
+        .sink = .{ .destination = "t", .routing_key = "id" },
+    };
+
+    var read_insert = base;
+    read_insert.source.operations = &.{ "read", "insert" };
+    try testing.expect(read_insert.hasReadOperation());
+
+    var stream_only = base;
+    stream_only.source.operations = &.{ "insert", "update" };
+    try testing.expect(!stream_only.hasReadOperation());
 }
 
 test "Config validation - full SASL over TLS passes" {

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -197,16 +197,6 @@ pub const Config = struct {
         return readEnvVar(allocator, environ_map, postgres.connection_env);
     }
 
-    /// Whether an initial snapshot may run this session: at least one stream opts
-    /// into `read`. Gates the snapshot itself and the interrupted-snapshot recovery
-    /// on startup.
-    pub fn wantsInitialSnapshot(self: Config) bool {
-        for (self.streams) |stream| {
-            if (stream.hasReadOperation()) return true;
-        }
-        return false;
-    }
-
     // Helper validation functions
 
     fn validateEnum(allocator: std.mem.Allocator, value: []const u8, allowed_values: []const []const u8, field_name: []const u8) !void {
@@ -1046,26 +1036,6 @@ test "Stream.hasReadOperation reflects the configured operations" {
     var stream_only = base;
     stream_only.source.operations = &.{ "insert", "update" };
     try testing.expect(!stream_only.hasReadOperation());
-}
-
-test "wantsInitialSnapshot is driven by the read opt-in" {
-    var cfg = createTestDefault();
-
-    cfg.streams = &.{.{
-        .name = "s",
-        .source = .{ .resource = "users", .operations = &.{ "insert", "update" } },
-        .flow = .{ .format = "json" },
-        .sink = .{ .destination = "t", .routing_key = "id" },
-    }};
-    try testing.expect(!cfg.wantsInitialSnapshot());
-
-    cfg.streams = &.{.{
-        .name = "s",
-        .source = .{ .resource = "users", .operations = &.{ "read", "insert" } },
-        .flow = .{ .format = "json" },
-        .sink = .{ .destination = "t", .routing_key = "id" },
-    }};
-    try testing.expect(cfg.wantsInitialSnapshot());
 }
 
 test "Config validation - full SASL over TLS passes" {

--- a/src/e2e/cdc_test.zig
+++ b/src/e2e/cdc_test.zig
@@ -76,7 +76,7 @@ test "E2E: INSERT operation - full pipeline verification" {
     }
 
     // Connect to PostgreSQL
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
     try source.startReplication("0/0");
 
     // Create processor
@@ -216,7 +216,7 @@ test "E2E: UPDATE operation - full pipeline verification" {
         _ = c.PQexec(conn, drop_slot_sql.ptr);
     }
 
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
     try source.startReplication("0/0");
 
     // Create processor
@@ -351,7 +351,7 @@ test "E2E: DELETE operation - full pipeline verification" {
         _ = c.PQexec(conn, drop_slot_sql.ptr);
     }
 
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
     try source.startReplication("0/0");
 
     // Create processor

--- a/src/e2e/cdc_test.zig
+++ b/src/e2e/cdc_test.zig
@@ -76,7 +76,7 @@ test "E2E: INSERT operation - full pipeline verification" {
     }
 
     // Connect to PostgreSQL
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
     try source.startReplication("0/0");
 
     // Create processor
@@ -216,7 +216,7 @@ test "E2E: UPDATE operation - full pipeline verification" {
         _ = c.PQexec(conn, drop_slot_sql.ptr);
     }
 
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
     try source.startReplication("0/0");
 
     // Create processor
@@ -351,7 +351,7 @@ test "E2E: DELETE operation - full pipeline verification" {
         _ = c.PQexec(conn, drop_slot_sql.ptr);
     }
 
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
     try source.startReplication("0/0");
 
     // Create processor

--- a/src/e2e/snapshot_test.zig
+++ b/src/e2e/snapshot_test.zig
@@ -81,7 +81,7 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
     // to. want_snapshot=true also creates the snapshot marker publication.
     try source.connect(conn_str, true);
     const start_lsn = source.startLsn() orelse return error.NoConsistentPoint;
-    try testing.expect(source.snapshotName() != null); // fresh slot exported a snapshot
+    try testing.expect(source.needsBootstrap()); // fresh slot exported a snapshot
 
     const streams = try allocator.alloc(Stream, 1);
     defer allocator.free(streams);
@@ -100,7 +100,8 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
     // from its streams and drives the snapshot through the source, like any batch.
     try processor.bootstrap(std.testing.io, &stop_signal);
 
-    try processor.beginReplication();
+    // The processor owns the source by value, so streaming must begin on its copy.
+    try processor.source.startStreaming();
 
     // A live insert AFTER streaming started: it enters the WAL past the slot start,
     // so it must arrive as a streamed INSERT, not via the snapshot.

--- a/src/e2e/snapshot_test.zig
+++ b/src/e2e/snapshot_test.zig
@@ -96,9 +96,9 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
 
     var stop_signal = std.atomic.Value(bool).init(false);
 
-    // Snapshot phase, then begin streaming. The processor orchestrates the reader
-    // from the connection string and derives the read resources from its streams.
-    const completed = try processor.runInitialSnapshot(std.testing.io, conn_str, &stop_signal);
+    // Snapshot phase, then begin streaming. The processor derives the read resources
+    // from its streams and drives the snapshot through the source, like any batch.
+    const completed = try processor.runInitialSnapshot(std.testing.io, &stop_signal);
     try testing.expect(completed);
 
     try processor.beginReplication();

--- a/src/e2e/snapshot_test.zig
+++ b/src/e2e/snapshot_test.zig
@@ -98,8 +98,7 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
 
     // Snapshot phase, then begin streaming. The processor derives the read resources
     // from its streams and drives the snapshot through the source, like any batch.
-    const completed = try processor.bootstrap(std.testing.io, &stop_signal);
-    try testing.expect(completed);
+    try processor.bootstrap(std.testing.io, &stop_signal);
 
     try processor.beginReplication();
 

--- a/src/e2e/snapshot_test.zig
+++ b/src/e2e/snapshot_test.zig
@@ -5,7 +5,6 @@ const test_helpers = @import("../testing/test_helpers.zig");
 const Processor = @import("../processor/processor.zig").Processor;
 const Observability = @import("../processor/processor.zig").Observability;
 const PostgresSource = @import("../source/postgres/source.zig").PostgresSource;
-const SnapshotReader = @import("../source/postgres/snapshot.zig").SnapshotReader;
 const KafkaProducer = @import("../sink/kafka/producer.zig").KafkaProducer;
 const Stream = @import("../config/config.zig").Stream;
 const c = test_helpers.c;
@@ -82,7 +81,7 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
     // to. want_snapshot=true also creates the snapshot marker publication.
     try source.connect(conn_str, true);
     const start_lsn = source.startLsn() orelse return error.NoConsistentPoint;
-    const snapshot_name = source.snapshotName() orelse return error.NoExportedSnapshot;
+    try testing.expect(source.snapshotName() != null); // fresh slot exported a snapshot
 
     const streams = try allocator.alloc(Stream, 1);
     defer allocator.free(streams);
@@ -97,19 +96,12 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
 
     var stop_signal = std.atomic.Value(bool).init(false);
 
-    // Run the snapshot, then start streaming from the slot's start LSN.
-    {
-        const snap_ts = test_helpers.nowSeconds(std.testing.io);
-        var reader = SnapshotReader.init(allocator, snapshot_name, start_lsn, snap_ts);
-        defer reader.deinit();
-        try reader.connect(conn_str);
+    // Snapshot phase, then begin streaming. The processor orchestrates the reader
+    // from the connection string and derives the read resources from its streams.
+    const completed = try processor.runInitialSnapshot(std.testing.io, conn_str, &stop_signal);
+    try testing.expect(completed);
 
-        const resources = [_][]const u8{stream_config.source.resource};
-        const completed = try processor.runInitialSnapshot(&reader, &resources, &stop_signal);
-        try testing.expect(completed);
-    }
-
-    try processor.beginReplication(start_lsn);
+    try processor.beginReplication();
 
     // A live insert AFTER streaming started: it enters the WAL past the slot start,
     // so it must arrive as a streamed INSERT, not via the snapshot.

--- a/src/e2e/snapshot_test.zig
+++ b/src/e2e/snapshot_test.zig
@@ -72,10 +72,15 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
         const drop_slot_z = allocator.dupeZ(u8, drop_slot) catch unreachable;
         defer allocator.free(drop_slot_z);
         _ = c.PQexec(conn, drop_slot_z.ptr);
+        // Streaming publication and the snapshot marker outboxx creates.
+        const drop_pubs = std.fmt.allocPrintSentinel(allocator, "DROP PUBLICATION IF EXISTS {s}; DROP PUBLICATION IF EXISTS {s}_snapshotting;", .{ pub_name, pub_name }, 0) catch unreachable;
+        defer allocator.free(drop_pubs);
+        _ = c.PQexec(conn, drop_pubs.ptr);
     }
 
-    // Create the slot without streaming; this exports the snapshot the reader binds to.
-    try source.connect(conn_str);
+    // Create the slot without streaming; this exports the snapshot the reader binds
+    // to. want_snapshot=true also creates the snapshot marker publication.
+    try source.connect(conn_str, true);
     const start_lsn = source.startLsn() orelse return error.NoConsistentPoint;
     const snapshot_name = source.snapshotName() orelse return error.NoExportedSnapshot;
 
@@ -100,7 +105,8 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
         try reader.connect(conn_str);
 
         const resources = [_][]const u8{stream_config.source.resource};
-        try processor.runInitialSnapshot(&reader, &resources, &stop_signal);
+        const completed = try processor.runInitialSnapshot(&reader, &resources, &stop_signal);
+        try testing.expect(completed);
     }
 
     try processor.beginReplication(start_lsn);

--- a/src/e2e/snapshot_test.zig
+++ b/src/e2e/snapshot_test.zig
@@ -98,7 +98,7 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
 
     // Snapshot phase, then begin streaming. The processor derives the read resources
     // from its streams and drives the snapshot through the source, like any batch.
-    const completed = try processor.runInitialSnapshot(std.testing.io, &stop_signal);
+    const completed = try processor.bootstrap(std.testing.io, &stop_signal);
     try testing.expect(completed);
 
     try processor.beginReplication();

--- a/src/e2e/snapshot_test.zig
+++ b/src/e2e/snapshot_test.zig
@@ -1,0 +1,159 @@
+const std = @import("std");
+const testing = std.testing;
+const test_helpers = @import("../testing/test_helpers.zig");
+
+const Processor = @import("../processor/processor.zig").Processor;
+const Observability = @import("../processor/processor.zig").Observability;
+const PostgresSource = @import("../source/postgres/source.zig").PostgresSource;
+const SnapshotReader = @import("../source/postgres/snapshot.zig").SnapshotReader;
+const KafkaProducer = @import("../sink/kafka/producer.zig").KafkaProducer;
+const Stream = @import("../config/config.zig").Stream;
+const c = test_helpers.c;
+
+// E2E Test: initial snapshot + streaming boundary
+//
+// Proves the #49 consistency contract end to end: rows that existed before the
+// slot was created arrive as READ events (from the exported snapshot), a row
+// inserted after streaming starts arrives as an INSERT, and the two meet with no
+// gap or overlap. The READ rows carry the slot's start LSN, the same boundary the
+// stream begins from.
+
+pub const std_options: std.Options = .{
+    .log_level = .debug,
+};
+
+test "E2E: initial snapshot emits pre-existing rows as READ, then streams live changes" {
+    const allocator = testing.allocator;
+
+    const conn_str = try test_helpers.getTestConnectionString(allocator);
+    defer allocator.free(conn_str);
+
+    const conn_str_z = try allocator.dupeZ(u8, conn_str);
+    defer allocator.free(conn_str_z);
+
+    const conn = c.PQconnectdb(conn_str_z.ptr) orelse return error.ConnectionFailed;
+    defer c.PQfinish(conn);
+    if (c.PQstatus(conn) != c.CONNECTION_OK) {
+        std.log.err("PostgreSQL connection failed - E2E test requires PostgreSQL to be running", .{});
+        return error.ConnectionFailed;
+    }
+
+    const timestamp = test_helpers.nowSeconds(std.testing.io);
+    const table_name = try std.fmt.allocPrint(allocator, "snap_e2e_{d}", .{timestamp});
+    defer allocator.free(table_name);
+    const topic_name = try std.fmt.allocPrint(allocator, "topic.snap.e2e.{d}", .{timestamp});
+    defer allocator.free(topic_name);
+    const slot_name = try std.fmt.allocPrint(allocator, "snap_e2e_slot_{d}", .{timestamp});
+    defer allocator.free(slot_name);
+    const pub_name = try std.fmt.allocPrint(allocator, "snap_e2e_pub_{d}", .{timestamp});
+    defer allocator.free(pub_name);
+
+    try test_helpers.createTestTable(conn, allocator, table_name);
+
+    // Seed three rows BEFORE the slot exists, so they never enter the WAL stream;
+    // only the snapshot can surface them.
+    const seed = try test_helpers.formatSqlZ(allocator,
+        \\INSERT INTO {s} (name, value) VALUES ('Alice', 100), ('Bob', 200), ('Carol', 300)
+    , .{table_name});
+    defer allocator.free(seed);
+    _ = c.PQexec(conn, seed.ptr);
+
+    // A stream that opts into the snapshot (read) and also tracks live inserts.
+    var stream_config = try test_helpers.createTestStreamConfig(allocator, table_name, topic_name);
+    defer allocator.free(stream_config.name);
+    defer allocator.free(stream_config.source.resource);
+    stream_config.source.operations = &.{ "read", "insert" };
+
+    // NOTE: source will be deinit'd by processor.deinit().
+    var source = PostgresSource.init(allocator, slot_name, pub_name);
+    defer {
+        const drop_slot = std.fmt.allocPrint(allocator, "SELECT pg_drop_replication_slot('{s}');", .{slot_name}) catch unreachable;
+        defer allocator.free(drop_slot);
+        const drop_slot_z = allocator.dupeZ(u8, drop_slot) catch unreachable;
+        defer allocator.free(drop_slot_z);
+        _ = c.PQexec(conn, drop_slot_z.ptr);
+    }
+
+    // Create the slot without streaming; this exports the snapshot the reader binds to.
+    try source.connect(conn_str);
+    const start_lsn = source.startLsn() orelse return error.NoConsistentPoint;
+    const snapshot_name = source.snapshotName() orelse return error.NoExportedSnapshot;
+
+    const streams = try allocator.alloc(Stream, 1);
+    defer allocator.free(streams);
+    streams[0] = stream_config;
+
+    var producer = try KafkaProducer.init(allocator, "localhost:9092", null);
+    try producer.testConnection();
+
+    var obs = Observability.noop();
+    var processor = Processor.init(allocator, source, producer, streams, &obs);
+    defer processor.deinit();
+
+    var stop_signal = std.atomic.Value(bool).init(false);
+
+    // Run the snapshot, then start streaming from the slot's start LSN.
+    {
+        const snap_ts = test_helpers.nowSeconds(std.testing.io);
+        var reader = SnapshotReader.init(allocator, snapshot_name, start_lsn, snap_ts);
+        defer reader.deinit();
+        try reader.connect(conn_str);
+
+        const resources = [_][]const u8{stream_config.source.resource};
+        try processor.runInitialSnapshot(&reader, &resources, &stop_signal);
+    }
+
+    try processor.beginReplication(start_lsn);
+
+    // A live insert AFTER streaming started: it enters the WAL past the slot start,
+    // so it must arrive as a streamed INSERT, not via the snapshot.
+    const live = try test_helpers.formatSqlZ(allocator, "INSERT INTO {s} (name, value) VALUES ('Dave', 400)", .{table_name});
+    defer allocator.free(live);
+    _ = c.PQexec(conn, live.ptr);
+    test_helpers.sleepNs(std.testing.io, 200_000_000);
+
+    var batch_arena = std.heap.ArenaAllocator.init(allocator);
+    defer batch_arena.deinit();
+    try processor.processChangesToKafka(std.testing.io, &stop_signal, batch_arena.allocator(), 100);
+
+    const messages = try test_helpers.consumeAllMessages(std.testing.io, allocator, topic_name, 10000);
+    defer test_helpers.cleanupJsonMessages(messages, allocator);
+
+    // Three seeded rows as READ + one live row as INSERT.
+    try testing.expectEqual(@as(usize, 4), messages.len);
+
+    var read_count: usize = 0;
+    var insert_count: usize = 0;
+    var seen_ids = [_]bool{false} ** 5; // ids 1..4
+
+    for (messages) |msg| {
+        const op = msg.value.object.get("op").?.string;
+        const data = msg.value.object.get("data").?.object;
+        const id = data.get("id").?.integer;
+
+        if (std.mem.eql(u8, op, "READ")) {
+            read_count += 1;
+            // The dedup boundary: every READ row carries the slot's start LSN, the
+            // point streaming then resumes from.
+            try test_helpers.assertJsonField(msg, "meta.lsn", start_lsn);
+            try test_helpers.assertJsonField(msg, "meta.resource", stream_config.source.resource);
+            try testing.expect(id >= 1 and id <= 3); // seeded rows
+        } else if (std.mem.eql(u8, op, "INSERT")) {
+            insert_count += 1;
+            try test_helpers.assertJsonField(msg, "data.name", "Dave");
+            try testing.expectEqual(@as(i64, 4), id); // the live row, not in the snapshot
+        }
+        try testing.expect(!seen_ids[@intCast(id)]);
+        seen_ids[@intCast(id)] = true;
+    }
+
+    try testing.expectEqual(@as(usize, 3), read_count);
+    try testing.expectEqual(@as(usize, 1), insert_count);
+
+    // No gap, no overlap: the snapshot covered ids 1..3, the stream covered id 4.
+    for (1..5) |i| try testing.expect(seen_ids[i]);
+
+    // Single-partition dev topic: the snapshot rows were produced before the live
+    // insert, so they precede it in the log.
+    try test_helpers.assertJsonField(messages[messages.len - 1], "op", "INSERT");
+}

--- a/src/e2e/snapshot_test.zig
+++ b/src/e2e/snapshot_test.zig
@@ -72,7 +72,7 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
         defer allocator.free(drop_slot_z);
         _ = c.PQexec(conn, drop_slot_z.ptr);
         // Streaming publication and the snapshot marker outboxx creates.
-        const drop_pubs = std.fmt.allocPrintSentinel(allocator, "DROP PUBLICATION IF EXISTS {s}; DROP PUBLICATION IF EXISTS {s}_snapshotting;", .{ pub_name, pub_name }, 0) catch unreachable;
+        const drop_pubs = std.fmt.allocPrintSentinel(allocator, "DROP PUBLICATION IF EXISTS {s}; DROP PUBLICATION IF EXISTS {s}_snapshotting;", .{ pub_name, slot_name }, 0) catch unreachable;
         defer allocator.free(drop_pubs);
         _ = c.PQexec(conn, drop_pubs.ptr);
     }

--- a/src/e2e/snapshot_test.zig
+++ b/src/e2e/snapshot_test.zig
@@ -78,8 +78,8 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
     }
 
     // Create the slot without streaming; this exports the snapshot the reader binds
-    // to. want_snapshot=true also creates the snapshot marker publication.
-    try source.connect(conn_str, true);
+    // to. .with_snapshot also creates the snapshot marker publication.
+    try source.connect(conn_str, .with_snapshot);
     const start_lsn = source.startLsn() orelse return error.NoConsistentPoint;
     try testing.expect(source.needsBootstrap()); // fresh slot exported a snapshot
 

--- a/src/e2e/snapshot_test.zig
+++ b/src/e2e/snapshot_test.zig
@@ -96,12 +96,9 @@ test "E2E: initial snapshot emits pre-existing rows as READ, then streams live c
 
     var stop_signal = std.atomic.Value(bool).init(false);
 
-    // Snapshot phase, then begin streaming. The processor derives the read resources
-    // from its streams and drives the snapshot through the source, like any batch.
+    // Snapshot phase, which also opens the stream. The processor derives the read
+    // resources from its streams and drives the snapshot through the source.
     try processor.bootstrap(std.testing.io, &stop_signal);
-
-    // The processor owns the source by value, so streaming must begin on its copy.
-    try processor.source.startStreaming();
 
     // A live insert AFTER streaming started: it enters the WAL past the slot start,
     // so it must arrive as a streamed INSERT, not via the snapshot.

--- a/src/e2e_test_root.zig
+++ b/src/e2e_test_root.zig
@@ -2,4 +2,5 @@
 // the other suite roots; see src/unit_test_root.zig.
 comptime {
     _ = @import("e2e/cdc_test.zig");
+    _ = @import("e2e/snapshot_test.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -117,7 +117,15 @@ fn run(init: std.process.Init) !void {
     printStatus("Starting processor for {} stream(s)...\n", .{config.streams.len});
     printStatus("Using PostgreSQL streaming replication (pgoutput protocol)\n", .{});
 
-    const source = PostgresSource.init(allocator, postgres.slot_name, postgres.publication_name);
+    var source = PostgresSource.init(allocator, postgres.slot_name, postgres.publication_name);
+
+    printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
+    // Connect and ensure the slot exists, without streaming yet, so the initial
+    // snapshot (if any) runs under the slot's exported snapshot first. Whether it
+    // may run (which also drives interrupted-snapshot recovery on the slot) is
+    // derived from the streams' `read` opt-in.
+    const want_snapshot = config_mod.wantsInitialSnapshot(config.streams);
+    try source.connect(conninfo, want_snapshot);
     // NOTE: source will be deinit'd by processor.deinit()
 
     const producer = try initKafkaProducer(allocator, config.sink.kafka.?, kafka_sasl_pw);
@@ -125,11 +133,6 @@ fn run(init: std.process.Init) !void {
 
     var processor = Processor.init(allocator, source, producer, config.streams, &obs);
     defer processor.deinit();
-
-    printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
-    // Connect and ensure the slot exists, without streaming yet, so the initial
-    // snapshot (if any) runs under the slot's exported snapshot first.
-    try processor.connect(conninfo);
 
     // Initial snapshot: the first phase of the pipeline. A false return means a
     // shutdown signal interrupted it; the snapshot marker stays in place, so stop

--- a/src/main.zig
+++ b/src/main.zig
@@ -124,7 +124,7 @@ fn run(init: std.process.Init) !void {
     // snapshot (if any) runs under the slot's exported snapshot first. Whether it
     // may run (which also drives interrupted-snapshot recovery on the slot) is
     // derived from the streams' `read` opt-in.
-    const want_snapshot = config_mod.wantsInitialSnapshot(config.streams);
+    const want_snapshot = config_mod.needsInitialSnapshot(config.streams);
     try source.connect(conninfo, want_snapshot);
     // NOTE: source will be deinit'd by processor.deinit()
 
@@ -135,10 +135,9 @@ fn run(init: std.process.Init) !void {
     defer processor.deinit();
 
     // Initial snapshot: the first phase of the pipeline. A false return means a
-    // shutdown signal interrupted it; the snapshot marker stays in place, so stop
-    // here and let the next start redo the bootstrap rather than stream past unread
-    // rows. startStreaming below begins replication once the snapshot is done.
-    if (!try processor.runInitialSnapshot(init.io, conninfo, &shutdown_requested)) {
+    // shutdown signal interrupted it, so stop here and let the next start redo the
+    // bootstrap rather than stream past unread rows.
+    if (!try processor.runInitialSnapshot(init.io, &shutdown_requested)) {
         printStatus("\nInitial snapshot interrupted; the bootstrap will restart on the next launch.\n", .{});
         return;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -124,8 +124,10 @@ fn run(init: std.process.Init) !void {
 
     printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
     // Connect and ensure the slot exists, without streaming yet, so the initial
-    // snapshot (if any) runs under the slot's exported snapshot first.
-    try source.connect(conninfo);
+    // snapshot (if any) runs under the slot's exported snapshot first. want_snapshot
+    // also drives interrupted-snapshot recovery on the slot (see source.ensureSlot).
+    const want_snapshot = config.wantsInitialSnapshot();
+    try source.connect(conninfo, want_snapshot);
 
     // Capture before the source is moved into the processor. A freshly created
     // slot exposes its start LSN and exported snapshot; stream from that LSN so we
@@ -142,9 +144,17 @@ fn run(init: std.process.Init) !void {
 
     // Initial snapshot before streaming: only on a freshly created slot, only in
     // `initial` mode, and only for streams opting into `read`. START_REPLICATION
-    // (below) invalidates the exported snapshot, so it must follow this.
-    try maybeRunInitialSnapshot(allocator, init.io, config, &processor, conninfo, snapshot_name, start_lsn, &shutdown_requested);
+    // (below) invalidates the exported snapshot, so it must follow this. A false
+    // return means a shutdown signal interrupted the snapshot; the marker is left in
+    // place, so stop here and let the next start redo the bootstrap rather than
+    // stream past unread rows.
+    const snapshot_done = try maybeRunInitialSnapshot(allocator, init.io, config, &processor, conninfo, snapshot_name, start_lsn, &shutdown_requested);
+    if (!snapshot_done) {
+        printStatus("\nInitial snapshot interrupted; the bootstrap will restart on the next launch.\n", .{});
+        return;
+    }
 
+    // Drops the snapshot marker (back to one publication) and starts streaming.
     try processor.beginReplication(start_lsn);
 
     printStatus("\nProcessor initialized successfully with slot: {s}\n", .{postgres.slot_name});
@@ -197,11 +207,13 @@ fn initKafkaProducer(allocator: std.mem.Allocator, kafka: config_mod.KafkaSink, 
     return producer;
 }
 
-// Run the initial snapshot when it applies, else return without touching Postgres.
-// It applies only when the slot was created this run (snapshot_name is set), the
-// mode is `initial`, and at least one stream lists `read`. The reader opens a
-// second, regular connection and binds it to the slot's exported snapshot, so the
-// replication connection must stay idle (no START_REPLICATION) until this returns.
+// Run the initial snapshot when it applies. Returns true when the snapshot is not
+// needed or ran to completion, false when a shutdown signal interrupted it (the
+// caller then stops instead of streaming). It applies only when the slot was created
+// this run (snapshot_name is set), the mode is `initial`, and at least one stream
+// lists `read`. The reader opens a second, regular connection and binds it to the
+// slot's exported snapshot, so the replication connection must stay idle (no
+// START_REPLICATION) until this returns.
 fn maybeRunInitialSnapshot(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -211,18 +223,16 @@ fn maybeRunInitialSnapshot(
     snapshot_name: ?[]const u8,
     start_lsn: []const u8,
     stop_signal: *std.atomic.Value(bool),
-) !void {
+) !bool {
     // No exported snapshot means the slot already existed, so there is nothing to
     // bootstrap (a snapshot is only consistent with a freshly created slot).
-    const snap = snapshot_name orelse return;
+    const snap = snapshot_name orelse return true;
 
-    // Absent [snapshot] defaults to `initial`; `no-snapshot` disables it globally.
-    const snapshot_cfg: config_mod.SnapshotConfig = config.snapshot orelse .{};
-    if (!snapshot_cfg.isInitial()) return;
+    if (!config.wantsInitialSnapshot()) return true;
 
     const resources = try collectReadResources(allocator, config.streams);
     defer allocator.free(resources);
-    if (resources.len == 0) return;
+    if (resources.len == 0) return true;
 
     printStatus("\nRunning initial snapshot for {} resource(s)...\n", .{resources.len});
 
@@ -234,9 +244,9 @@ fn maybeRunInitialSnapshot(
     defer reader.deinit();
     try reader.connect(conninfo);
 
-    try processor.runInitialSnapshot(&reader, resources, stop_signal);
-
-    printStatus("Initial snapshot complete.\n", .{});
+    const completed = try processor.runInitialSnapshot(&reader, resources, stop_signal);
+    if (completed) printStatus("Initial snapshot complete.\n", .{});
+    return completed;
 }
 
 // The distinct resources of streams that opt into `read`, so a table read by

--- a/src/main.zig
+++ b/src/main.zig
@@ -134,13 +134,10 @@ fn run(init: std.process.Init) !void {
     var processor = Processor.init(allocator, source, producer, config.streams, &obs);
     defer processor.deinit();
 
-    // Initial snapshot: the first phase of the pipeline. A false return means a
-    // shutdown signal interrupted it, so stop here and let the next start redo the
-    // bootstrap rather than stream past unread rows.
-    if (!try processor.bootstrap(init.io, &shutdown_requested)) {
-        printStatus("\nInitial snapshot interrupted; the bootstrap will restart on the next launch.\n", .{});
-        return;
-    }
+    // Initial snapshot: the first phase of the pipeline. Any error (a shutdown signal
+    // included) stops the run before streaming, so the next start redoes the bootstrap
+    // rather than streaming past unread rows.
+    try processor.bootstrap(init.io, &shutdown_requested);
 
     printStatus("\nProcessor initialized successfully with slot: {s}\n", .{postgres.slot_name});
     printStatus("\nCDC processor started successfully!\n", .{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -134,10 +134,10 @@ fn run(init: std.process.Init) !void {
     var processor = Processor.init(allocator, source, producer, config.streams, &obs);
     defer processor.deinit();
 
-    // Initial snapshot: the first phase of the pipeline. A shutdown signal stops the
-    // run before streaming, so the next start redoes the bootstrap rather than
-    // streaming past unread rows. It is a graceful stop, like one during streaming,
-    // so it exits cleanly instead of through the fatal handler.
+    // First phase: the initial snapshot (if any), then the stream is opened, so `run`
+    // below only has to loop. A shutdown here is a graceful stop, like one during
+    // streaming, so it exits cleanly instead of through the fatal handler; the next
+    // start redoes the bootstrap rather than streaming past unread rows.
     processor.bootstrap(init.io, &shutdown_requested) catch |err| switch (err) {
         error.Shutdown => {
             printStatus("\nInitial snapshot interrupted; the bootstrap will restart on the next launch.\n", .{});
@@ -167,9 +167,9 @@ fn run(init: std.process.Init) !void {
             metrics_future.cancel(init.io);
             std.log.debug("main: metrics server cancelled", .{});
         }
-        try processor.startStreaming(init.io, &shutdown_requested);
+        try processor.run(init.io, &shutdown_requested);
     } else {
-        try processor.startStreaming(init.io, &shutdown_requested);
+        try processor.run(init.io, &shutdown_requested);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -124,8 +124,11 @@ fn run(init: std.process.Init) !void {
     // snapshot (if any) runs under the slot's exported snapshot first. Whether it
     // may run (which also drives interrupted-snapshot recovery on the slot) is
     // derived from the streams' `read` opt-in.
-    const want_snapshot = config_mod.needsInitialSnapshot(config.streams);
-    try source.connect(conninfo, want_snapshot);
+    const bootstrap: PostgresSource.Bootstrap = if (config_mod.needsInitialSnapshot(config.streams))
+        .with_snapshot
+    else
+        .stream_only;
+    try source.connect(conninfo, bootstrap);
     // NOTE: source will be deinit'd by processor.deinit()
 
     const producer = try initKafkaProducer(allocator, config.sink.kafka.?, kafka_sasl_pw);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 const config_mod = @import("config/config.zig");
 const Config = config_mod.Config;
-const Stream = config_mod.Stream;
 const Processor = @import("processor/processor.zig").Processor;
 const PostgresSource = @import("source/postgres/source.zig").PostgresSource;
-const SnapshotReader = @import("source/postgres/snapshot.zig").SnapshotReader;
 const kafka_producer = @import("sink/kafka/producer.zig");
 const KafkaProducer = kafka_producer.KafkaProducer;
 const PostgresValidator = @import("source/postgres/validator.zig").PostgresValidator;
@@ -119,22 +117,8 @@ fn run(init: std.process.Init) !void {
     printStatus("Starting processor for {} stream(s)...\n", .{config.streams.len});
     printStatus("Using PostgreSQL streaming replication (pgoutput protocol)\n", .{});
 
-    var source = PostgresSource.init(allocator, postgres.slot_name, postgres.publication_name);
+    const source = PostgresSource.init(allocator, postgres.slot_name, postgres.publication_name);
     // NOTE: source will be deinit'd by processor.deinit()
-
-    printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
-    // Connect and ensure the slot exists, without streaming yet, so the initial
-    // snapshot (if any) runs under the slot's exported snapshot first. want_snapshot
-    // also drives interrupted-snapshot recovery on the slot (see source.ensureSlot).
-    const want_snapshot = config.wantsInitialSnapshot();
-    try source.connect(conninfo, want_snapshot);
-
-    // Capture before the source is moved into the processor. A freshly created
-    // slot exposes its start LSN and exported snapshot; stream from that LSN so we
-    // begin exactly at the slot's start. An existing slot exposes neither, so
-    // resume from its confirmed position ("0/0") and run no snapshot.
-    const start_lsn = source.startLsn() orelse "0/0";
-    const snapshot_name = source.snapshotName();
 
     const producer = try initKafkaProducer(allocator, config.sink.kafka.?, kafka_sasl_pw);
     // NOTE: producer will be deinit'd by processor.deinit()
@@ -142,20 +126,19 @@ fn run(init: std.process.Init) !void {
     var processor = Processor.init(allocator, source, producer, config.streams, &obs);
     defer processor.deinit();
 
-    // Initial snapshot before streaming: only on a freshly created slot, only in
-    // `initial` mode, and only for streams opting into `read`. START_REPLICATION
-    // (below) invalidates the exported snapshot, so it must follow this. A false
-    // return means a shutdown signal interrupted the snapshot; the marker is left in
-    // place, so stop here and let the next start redo the bootstrap rather than
-    // stream past unread rows.
-    const snapshot_done = try maybeRunInitialSnapshot(allocator, init.io, config, &processor, conninfo, snapshot_name, start_lsn, &shutdown_requested);
-    if (!snapshot_done) {
+    printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
+    // Connect and ensure the slot exists, without streaming yet, so the initial
+    // snapshot (if any) runs under the slot's exported snapshot first.
+    try processor.connect(conninfo);
+
+    // Initial snapshot: the first phase of the pipeline. A false return means a
+    // shutdown signal interrupted it; the snapshot marker stays in place, so stop
+    // here and let the next start redo the bootstrap rather than stream past unread
+    // rows. startStreaming below begins replication once the snapshot is done.
+    if (!try processor.runInitialSnapshot(init.io, conninfo, &shutdown_requested)) {
         printStatus("\nInitial snapshot interrupted; the bootstrap will restart on the next launch.\n", .{});
         return;
     }
-
-    // Drops the snapshot marker (back to one publication) and starts streaming.
-    try processor.beginReplication(start_lsn);
 
     printStatus("\nProcessor initialized successfully with slot: {s}\n", .{postgres.slot_name});
     printStatus("\nCDC processor started successfully!\n", .{});
@@ -205,71 +188,6 @@ fn initKafkaProducer(allocator: std.mem.Allocator, kafka: config_mod.KafkaSink, 
 
     try producer.testConnection();
     return producer;
-}
-
-// Run the initial snapshot when it applies. Returns true when the snapshot is not
-// needed or ran to completion, false when a shutdown signal interrupted it (the
-// caller then stops instead of streaming). It applies only when the slot was created
-// this run (snapshot_name is set), the mode is `initial`, and at least one stream
-// lists `read`. The reader opens a second, regular connection and binds it to the
-// slot's exported snapshot, so the replication connection must stay idle (no
-// START_REPLICATION) until this returns.
-fn maybeRunInitialSnapshot(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    config: Config,
-    processor: *Processor,
-    conninfo: []const u8,
-    snapshot_name: ?[]const u8,
-    start_lsn: []const u8,
-    stop_signal: *std.atomic.Value(bool),
-) !bool {
-    // No exported snapshot means the slot already existed, so there is nothing to
-    // bootstrap (a snapshot is only consistent with a freshly created slot).
-    const snap = snapshot_name orelse return true;
-
-    if (!config.wantsInitialSnapshot()) return true;
-
-    const resources = try collectReadResources(allocator, config.streams);
-    defer allocator.free(resources);
-    if (resources.len == 0) return true;
-
-    printStatus("\nRunning initial snapshot for {} resource(s)...\n", .{resources.len});
-
-    // meta.timestamp for READ rows: the snapshot's wall-clock start. meta.lsn is
-    // the slot's start LSN, so a snapshot row shares the dedup boundary with the
-    // first streamed change.
-    const timestamp = std.Io.Timestamp.now(io, .real).toSeconds();
-    var reader = SnapshotReader.init(allocator, snap, start_lsn, timestamp);
-    defer reader.deinit();
-    try reader.connect(conninfo);
-
-    const completed = try processor.runInitialSnapshot(&reader, resources, stop_signal);
-    if (completed) printStatus("Initial snapshot complete.\n", .{});
-    return completed;
-}
-
-// The distinct resources of streams that opt into `read`, so a table read by
-// several streams is snapshotted once. Caller owns the returned slice; the
-// resource strings are borrowed from the config.
-fn collectReadResources(allocator: std.mem.Allocator, streams: []const Stream) ![]const []const u8 {
-    var resources = std.ArrayList([]const u8).empty;
-    errdefer resources.deinit(allocator);
-
-    for (streams) |stream| {
-        if (!stream.hasReadOperation()) continue;
-
-        var seen = false;
-        for (resources.items) |r| {
-            if (std.mem.eql(u8, r, stream.source.resource)) {
-                seen = true;
-                break;
-            }
-        }
-        if (!seen) try resources.append(allocator, stream.source.resource);
-    }
-
-    return resources.toOwnedSlice(allocator);
 }
 
 // Print user-facing messages to stdout. Use for status/config output; logs and

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,8 +1,10 @@
 const std = @import("std");
 const config_mod = @import("config/config.zig");
 const Config = config_mod.Config;
+const Stream = config_mod.Stream;
 const Processor = @import("processor/processor.zig").Processor;
 const PostgresSource = @import("source/postgres/source.zig").PostgresSource;
+const SnapshotReader = @import("source/postgres/snapshot.zig").SnapshotReader;
 const kafka_producer = @import("sink/kafka/producer.zig");
 const KafkaProducer = kafka_producer.KafkaProducer;
 const PostgresValidator = @import("source/postgres/validator.zig").PostgresValidator;
@@ -121,19 +123,29 @@ fn run(init: std.process.Init) !void {
     // NOTE: source will be deinit'd by processor.deinit()
 
     printStatus("Connecting to PostgreSQL streaming replication...\n", .{});
+    // Connect and ensure the slot exists, without streaming yet, so the initial
+    // snapshot (if any) runs under the slot's exported snapshot first.
     try source.connect(conninfo);
 
-    // A freshly created slot exposes its start LSN; stream from it so we begin
-    // exactly at the slot's start. An existing slot has none, so resume from its
-    // confirmed position, which "0/0" selects.
+    // Capture before the source is moved into the processor. A freshly created
+    // slot exposes its start LSN and exported snapshot; stream from that LSN so we
+    // begin exactly at the slot's start. An existing slot exposes neither, so
+    // resume from its confirmed position ("0/0") and run no snapshot.
     const start_lsn = source.startLsn() orelse "0/0";
-    try source.startReplication(start_lsn);
+    const snapshot_name = source.snapshotName();
 
     const producer = try initKafkaProducer(allocator, config.sink.kafka.?, kafka_sasl_pw);
     // NOTE: producer will be deinit'd by processor.deinit()
 
     var processor = Processor.init(allocator, source, producer, config.streams, &obs);
     defer processor.deinit();
+
+    // Initial snapshot before streaming: only on a freshly created slot, only in
+    // `initial` mode, and only for streams opting into `read`. START_REPLICATION
+    // (below) invalidates the exported snapshot, so it must follow this.
+    try maybeRunInitialSnapshot(allocator, init.io, config, &processor, conninfo, snapshot_name, start_lsn, &shutdown_requested);
+
+    try processor.beginReplication(start_lsn);
 
     printStatus("\nProcessor initialized successfully with slot: {s}\n", .{postgres.slot_name});
     printStatus("\nCDC processor started successfully!\n", .{});
@@ -183,6 +195,71 @@ fn initKafkaProducer(allocator: std.mem.Allocator, kafka: config_mod.KafkaSink, 
 
     try producer.testConnection();
     return producer;
+}
+
+// Run the initial snapshot when it applies, else return without touching Postgres.
+// It applies only when the slot was created this run (snapshot_name is set), the
+// mode is `initial`, and at least one stream lists `read`. The reader opens a
+// second, regular connection and binds it to the slot's exported snapshot, so the
+// replication connection must stay idle (no START_REPLICATION) until this returns.
+fn maybeRunInitialSnapshot(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    config: Config,
+    processor: *Processor,
+    conninfo: []const u8,
+    snapshot_name: ?[]const u8,
+    start_lsn: []const u8,
+    stop_signal: *std.atomic.Value(bool),
+) !void {
+    // No exported snapshot means the slot already existed, so there is nothing to
+    // bootstrap (a snapshot is only consistent with a freshly created slot).
+    const snap = snapshot_name orelse return;
+
+    // Absent [snapshot] defaults to `initial`; `no-snapshot` disables it globally.
+    const snapshot_cfg: config_mod.SnapshotConfig = config.snapshot orelse .{};
+    if (!snapshot_cfg.isInitial()) return;
+
+    const resources = try collectReadResources(allocator, config.streams);
+    defer allocator.free(resources);
+    if (resources.len == 0) return;
+
+    printStatus("\nRunning initial snapshot for {} resource(s)...\n", .{resources.len});
+
+    // meta.timestamp for READ rows: the snapshot's wall-clock start. meta.lsn is
+    // the slot's start LSN, so a snapshot row shares the dedup boundary with the
+    // first streamed change.
+    const timestamp = std.Io.Timestamp.now(io, .real).toSeconds();
+    var reader = SnapshotReader.init(allocator, snap, start_lsn, timestamp);
+    defer reader.deinit();
+    try reader.connect(conninfo);
+
+    try processor.runInitialSnapshot(&reader, resources, stop_signal);
+
+    printStatus("Initial snapshot complete.\n", .{});
+}
+
+// The distinct resources of streams that opt into `read`, so a table read by
+// several streams is snapshotted once. Caller owns the returned slice; the
+// resource strings are borrowed from the config.
+fn collectReadResources(allocator: std.mem.Allocator, streams: []const Stream) ![]const []const u8 {
+    var resources = std.ArrayList([]const u8).empty;
+    errdefer resources.deinit(allocator);
+
+    for (streams) |stream| {
+        if (!stream.hasReadOperation()) continue;
+
+        var seen = false;
+        for (resources.items) |r| {
+            if (std.mem.eql(u8, r, stream.source.resource)) {
+                seen = true;
+                break;
+            }
+        }
+        if (!seen) try resources.append(allocator, stream.source.resource);
+    }
+
+    return resources.toOwnedSlice(allocator);
 }
 
 // Print user-facing messages to stdout. Use for status/config output; logs and

--- a/src/main.zig
+++ b/src/main.zig
@@ -137,7 +137,7 @@ fn run(init: std.process.Init) !void {
     // Initial snapshot: the first phase of the pipeline. A false return means a
     // shutdown signal interrupted it, so stop here and let the next start redo the
     // bootstrap rather than stream past unread rows.
-    if (!try processor.runInitialSnapshot(init.io, &shutdown_requested)) {
+    if (!try processor.bootstrap(init.io, &shutdown_requested)) {
         printStatus("\nInitial snapshot interrupted; the bootstrap will restart on the next launch.\n", .{});
         return;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -134,10 +134,17 @@ fn run(init: std.process.Init) !void {
     var processor = Processor.init(allocator, source, producer, config.streams, &obs);
     defer processor.deinit();
 
-    // Initial snapshot: the first phase of the pipeline. Any error (a shutdown signal
-    // included) stops the run before streaming, so the next start redoes the bootstrap
-    // rather than streaming past unread rows.
-    try processor.bootstrap(init.io, &shutdown_requested);
+    // Initial snapshot: the first phase of the pipeline. A shutdown signal stops the
+    // run before streaming, so the next start redoes the bootstrap rather than
+    // streaming past unread rows. It is a graceful stop, like one during streaming,
+    // so it exits cleanly instead of through the fatal handler.
+    processor.bootstrap(init.io, &shutdown_requested) catch |err| switch (err) {
+        error.Shutdown => {
+            printStatus("\nInitial snapshot interrupted; the bootstrap will restart on the next launch.\n", .{});
+            return;
+        },
+        else => return err,
+    };
 
     printStatus("\nProcessor initialized successfully with slot: {s}\n", .{postgres.slot_name});
     printStatus("\nCDC processor started successfully!\n", .{});

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 
 const PostgresSource = @import("../source/postgres/source.zig").PostgresSource;
-const Batch = @import("../source/postgres/source.zig").Batch;
 
 const KafkaProducer = @import("../sink/kafka/producer.zig").KafkaProducer;
 const config_mod = @import("../config/config.zig");
@@ -252,13 +251,6 @@ pub const Processor = struct {
             error.PartitionKeyUnavailable;
     }
 
-    /// Finish the bootstrap and start streaming on the owned source. Separate from
-    /// the constructor because the source is held by value here, so streaming must
-    /// begin on this copy, not the caller's.
-    pub fn beginReplication(self: *Self) !void {
-        try self.source.startStreaming();
-    }
-
     /// Run the bootstrap phase of the pipeline: pull the read-opted resources from the
     /// source and produce their rows as READ events, before streaming. Returning
     /// without an error means the bootstrap is done, whether it read anything or was
@@ -349,8 +341,9 @@ pub const Processor = struct {
     /// until stop_signal is set, with a background flush/commit worker.
     pub fn startStreaming(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
         // Safe only once bootstrap is done: starting the stream ends the source's
-        // snapshot phase for good.
-        try self.beginReplication();
+        // snapshot phase for good. On the source, not the caller's copy: it is held
+        // by value here.
+        try self.source.startStreaming();
 
         // The source is connected and validated before we get here, so readiness's
         // connection signal goes up now; markStreaming follows on the first batch.

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -5,7 +5,8 @@ const Batch = @import("../source/postgres/source.zig").Batch;
 const SnapshotReader = @import("../source/postgres/snapshot.zig").SnapshotReader;
 
 const KafkaProducer = @import("../sink/kafka/producer.zig").KafkaProducer;
-const Stream = @import("../config/config.zig").Stream;
+const config_mod = @import("../config/config.zig");
+const Stream = config_mod.Stream;
 
 const domain = @import("../domain/change_event.zig");
 const ChangeEvent = domain.ChangeEvent;
@@ -147,14 +148,6 @@ pub const Processor = struct {
         std.log.debug("processor.deinit: done", .{});
     }
 
-    /// Connect the owned source and ensure its publication and slot exist, without
-    /// streaming. Whether an initial snapshot may run (which also drives
-    /// interrupted-snapshot recovery on the slot) is derived from the streams' `read`
-    /// opt-in, so the pipeline decides it, not the caller.
-    pub fn connect(self: *Self, conninfo: []const u8) !void {
-        try self.source.connect(conninfo, self.wantsSnapshot());
-    }
-
     /// Receive one batch, route each change to its streams, and stage the batch LSN for commit.
     pub fn processChangesToKafka(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool), batch_allocator: std.mem.Allocator, limit: u32) !void {
         var batch = try self.source.receiveBatch(io, batch_allocator, limit);
@@ -283,7 +276,7 @@ pub const Processor = struct {
     pub fn runInitialSnapshot(self: *Self, io: std.Io, conninfo: []const u8, stop_signal: *std.atomic.Value(bool)) !bool {
         // No exported snapshot means the slot already existed: nothing to bootstrap.
         const snapshot_name = self.source.snapshotName() orelse return true;
-        if (!self.wantsSnapshot()) return true;
+        if (!config_mod.wantsInitialSnapshot(self.streams)) return true;
 
         const resources = try self.readResources();
         defer self.allocator.free(resources);
@@ -300,14 +293,6 @@ pub const Processor = struct {
         try reader.connect(conninfo);
 
         return self.snapshotToKafka(&reader, resources, stop_signal);
-    }
-
-    // Whether any stream opts into the initial snapshot by listing `read`.
-    fn wantsSnapshot(self: *Self) bool {
-        for (self.streams) |stream| {
-            if (stream.hasReadOperation()) return true;
-        }
-        return false;
     }
 
     // The distinct resources of the read-opted streams, so a table read by several

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -3,8 +3,8 @@ const std = @import("std");
 const PostgresSource = @import("../source/postgres/source.zig").PostgresSource;
 
 const KafkaProducer = @import("../sink/kafka/producer.zig").KafkaProducer;
-const config_mod = @import("../config/config.zig");
-const Stream = config_mod.Stream;
+const Stream = @import("../config/config.zig").Stream;
+const needsInitialSnapshot = @import("../config/config.zig").needsInitialSnapshot;
 
 const domain = @import("../domain/change_event.zig");
 const ChangeEvent = domain.ChangeEvent;
@@ -259,7 +259,7 @@ pub const Processor = struct {
     /// order cannot be got wrong from outside. A shutdown signal mid-snapshot fails
     /// with error.Shutdown, leaving the stream unopened so the next start redoes it.
     pub fn bootstrap(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
-        if (config_mod.needsInitialSnapshot(self.streams) and self.source.needsBootstrap()) {
+        if (needsInitialSnapshot(self.streams) and self.source.needsBootstrap()) {
             const resources = try self.readResources();
             defer self.allocator.free(resources);
 

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 
 const PostgresSource = @import("../source/postgres/source.zig").PostgresSource;
 const Batch = @import("../source/postgres/source.zig").Batch;
-const SnapshotReader = @import("../source/postgres/snapshot.zig").SnapshotReader;
 
 const KafkaProducer = @import("../sink/kafka/producer.zig").KafkaProducer;
 const config_mod = @import("../config/config.zig");
@@ -149,8 +148,8 @@ pub const Processor = struct {
     }
 
     /// Receive one batch, route each change to its streams, and stage the batch LSN for commit.
-    pub fn processChangesToKafka(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool), batch_allocator: std.mem.Allocator, limit: u32) !void {
-        var batch = try self.source.receiveBatch(io, batch_allocator, limit);
+    pub fn processChangesToKafka(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool), allocator: std.mem.Allocator, limit: u32) !void {
+        var batch = try self.source.receiveBatch(io, allocator, limit);
         defer batch.deinit();
 
         // A successful receive (even an empty batch) means we are connected and
@@ -174,10 +173,10 @@ pub const Processor = struct {
         // combo per batch instead of one per routed change.
         self.obs.setLag(batch.replication_lag_seconds);
         var event_counts = std.ArrayList(EventCount).empty;
-        defer event_counts.deinit(batch_allocator);
+        defer event_counts.deinit(allocator);
 
         for (batch.changes) |change_event| {
-            try self.produceEvent(batch_allocator, stop_signal, change_event, &event_counts);
+            try self.produceEvent(allocator, stop_signal, change_event, &event_counts);
         }
 
         for (event_counts.items) |e| self.obs.addEvents(e.count, e.stream, e.operation);
@@ -191,23 +190,23 @@ pub const Processor = struct {
     // same serialize/match/partition/produce path.
     fn produceEvent(
         self: *Self,
-        batch_allocator: std.mem.Allocator,
+        allocator: std.mem.Allocator,
         stop_signal: *std.atomic.Value(bool),
         change_event: ChangeEvent,
         event_counts: *std.ArrayList(EventCount),
     ) !void {
-        var matched = try matchStreams(batch_allocator, self.streams, change_event);
-        defer matched.deinit(batch_allocator);
+        var matched = try matchStreams(allocator, self.streams, change_event);
+        defer matched.deinit(allocator);
 
         if (matched.items.len == 0) {
             return;
         }
 
-        const json_bytes = try self.serializer.serialize(change_event, batch_allocator);
+        const json_bytes = try self.serializer.serialize(change_event, allocator);
 
         for (matched.items) |stream| {
             const topic_name = stream.sink.destination;
-            const partition_key = try self.getPartitionKey(batch_allocator, change_event, stream);
+            const partition_key = try self.getPartitionKey(allocator, change_event, stream);
 
             // A full queue is backpressure, not failure: send blocks (stalling
             // the WAL read, so Postgres slows too) and retries. Shutdown and a
@@ -221,7 +220,7 @@ pub const Processor = struct {
                 },
             };
 
-            try tallyEvent(event_counts, batch_allocator, stream.name, change_event.op);
+            try tallyEvent(event_counts, allocator, stream.name, change_event.op);
 
             self.events_processed += 1;
             if (self.events_processed % 10000 == 0) {
@@ -253,46 +252,29 @@ pub const Processor = struct {
             error.PartitionKeyUnavailable;
     }
 
-    /// Finish the bootstrap and start replication on the owned source: drop the
-    /// snapshot marker (steady state returns to one publication) then
-    /// START_REPLICATION from the slot's start LSN (or "0/0" to resume an existing
-    /// slot). Call only after a completed snapshot (if any), so the slot's exported
-    /// snapshot outlived the reads; START_REPLICATION invalidates it. Separate from
+    /// Finish the bootstrap and start streaming on the owned source. Separate from
     /// the constructor because the source is held by value here, so streaming must
     /// begin on this copy, not the caller's.
     pub fn beginReplication(self: *Self) !void {
-        try self.source.finishSnapshot();
-        try self.source.startReplication(self.source.startLsn() orelse "0/0");
+        try self.source.startStreaming();
     }
 
-    /// Run the initial-snapshot phase of the pipeline: read the read-opted resources
-    /// under the slot's exported snapshot and produce their rows as READ events,
-    /// before streaming. A no-op returning true when the slot already existed
-    /// (nothing to bootstrap) or no stream opts into `read`. Returns false when a
-    /// shutdown signal interrupted it, so the caller stops before streaming and the
-    /// next start redoes the bootstrap (the snapshot marker stays in place). Opens
-    /// its own regular connection from `conninfo`, since the replication connection
-    /// must stay idle until START_REPLICATION.
-    pub fn runInitialSnapshot(self: *Self, io: std.Io, conninfo: []const u8, stop_signal: *std.atomic.Value(bool)) !bool {
-        // No exported snapshot means the slot already existed: nothing to bootstrap.
-        const snapshot_name = self.source.snapshotName() orelse return true;
-        if (!config_mod.wantsInitialSnapshot(self.streams)) return true;
+    /// Run the initial-snapshot phase of the pipeline: pull the read-opted resources
+    /// from the source and produce their rows as READ events, before streaming. A
+    /// no-op returning true when no stream opts into `read` or the source has nothing
+    /// to bootstrap. Returns false when a shutdown signal interrupted it, so the
+    /// caller stops before streaming and the next start redoes the bootstrap.
+    pub fn runInitialSnapshot(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !bool {
+        if (!config_mod.needsInitialSnapshot(self.streams)) return true;
 
         const resources = try self.readResources();
         defer self.allocator.free(resources);
-        if (resources.len == 0) return true;
+
+        if (!try self.source.openSnapshot(io, resources)) return true;
 
         std.log.info("Running initial snapshot for {} resource(s)", .{resources.len});
 
-        // meta.timestamp for READ rows: the snapshot's wall-clock start. meta.lsn is
-        // the slot's start LSN, so a snapshot row shares the dedup boundary with the
-        // first streamed change.
-        const timestamp = std.Io.Timestamp.now(io, .real).toSeconds();
-        var reader = SnapshotReader.init(self.allocator, snapshot_name, self.source.startLsn() orelse "0/0", timestamp);
-        defer reader.deinit();
-        try reader.connect(conninfo);
-
-        return self.snapshotToKafka(&reader, resources, stop_signal);
+        return self.snapshotToKafka(stop_signal);
     }
 
     // The distinct resources of the read-opted streams, so a table read by several
@@ -318,52 +300,39 @@ pub const Processor = struct {
         return resources.toOwnedSlice(self.allocator);
     }
 
-    // Read each resource's rows via the snapshot reader and produce them as READ
-    // events through the same path as streamed changes (produceEvent), mirroring
-    // processChangesToKafka. Returns true once every resource is fully read and
+    // Drain the source's snapshot batches and produce them as READ events through the
+    // same path as streamed changes (produceEvent), mirroring processChangesToKafka.
+    // Returns true once an empty batch marks the snapshot read out and everything is
     // flushed to Kafka; false if a shutdown signal interrupted it. The LSN is not
     // advanced (pending_lsn stays 0): the slot moves only once the stream is
     // confirmed. Consumers must treat READ as an upsert.
-    fn snapshotToKafka(
-        self: *Self,
-        reader: *SnapshotReader,
-        resources: []const []const u8,
-        stop_signal: *std.atomic.Value(bool),
-    ) !bool {
-        for (resources) |resource| {
-            var table = try reader.open(resource);
+    fn snapshotToKafka(self: *Self, stop_signal: *std.atomic.Value(bool)) !bool {
+        while (true) {
+            if (stop_signal.load(.monotonic)) return false;
 
-            // One arena per FETCH batch, freed each turn; the events only need to
-            // live long enough to be serialized and copied into librdkafka.
-            drain: while (true) {
-                if (stop_signal.load(.monotonic)) {
-                    try table.close();
-                    return false;
-                }
+            // One arena per batch, freed each turn; the events only need to live long
+            // enough to be serialized and copied into librdkafka.
+            var batch_arena = std.heap.ArenaAllocator.init(self.allocator);
+            defer batch_arena.deinit();
+            const batch_alloc = batch_arena.allocator();
 
-                var batch_arena = std.heap.ArenaAllocator.init(self.allocator);
-                defer batch_arena.deinit();
-                const batch_alloc = batch_arena.allocator();
+            var batch = try self.source.receiveSnapshotBatch(batch_alloc, constants.CDC.BATCH_SIZE);
+            defer batch.deinit();
 
-                const events = (try table.next(batch_alloc, constants.CDC.BATCH_SIZE)) orelse break :drain;
+            if (batch.changes.len == 0) break;
 
-                var event_counts = std.ArrayList(EventCount).empty;
-                defer event_counts.deinit(batch_alloc);
+            var event_counts = std.ArrayList(EventCount).empty;
+            defer event_counts.deinit(batch_alloc);
 
-                for (events) |event| {
-                    // Backpressure saw stop_signal mid-produce: treat it as an
-                    // interrupted snapshot, like the between-batch check above.
-                    self.produceEvent(batch_alloc, stop_signal, event, &event_counts) catch |err| switch (err) {
-                        error.Shutdown => {
-                            try table.close();
-                            return false;
-                        },
-                        else => return err,
-                    };
-                }
-                for (event_counts.items) |e| self.obs.addEvents(e.count, e.stream, e.operation);
+            for (batch.changes) |change_event| {
+                // Backpressure saw stop_signal mid-produce: treat it as an interrupted
+                // snapshot, like the between-batch check above.
+                self.produceEvent(batch_alloc, stop_signal, change_event, &event_counts) catch |err| switch (err) {
+                    error.Shutdown => return false,
+                    else => return err,
+                };
             }
-            try table.close();
+            for (event_counts.items) |e| self.obs.addEvents(e.count, e.stream, e.operation);
         }
 
         // Durability barrier: the flush/commit worker is not running yet, so drain
@@ -382,8 +351,8 @@ pub const Processor = struct {
     /// Begin replication (after the initial snapshot, if any) and run the batch loop
     /// until stop_signal is set, with a background flush/commit worker.
     pub fn startStreaming(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
-        // Drop the snapshot marker and START_REPLICATION; the exported snapshot has
-        // already been read by runInitialSnapshot, so it is safe to invalidate now.
+        // Safe only once runInitialSnapshot is done: starting the stream ends the
+        // source's snapshot phase for good.
         try self.beginReplication();
 
         // The source is connected and validated before we get here, so readiness's

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -252,48 +252,57 @@ pub const Processor = struct {
             error.PartitionKeyUnavailable;
     }
 
-    /// Start replication on the owned source. Call after the initial snapshot (if
-    /// any) so the slot's exported snapshot outlives the reads; START_REPLICATION
-    /// invalidates it. Separate from the constructor because the source is held by
-    /// value here, so streaming must begin on this copy, not the caller's.
+    /// Finish the bootstrap and start streaming on the owned source: drop the
+    /// snapshot marker (steady state returns to one publication) then
+    /// START_REPLICATION. Call only after a completed snapshot (if any), so the
+    /// slot's exported snapshot outlived the reads; START_REPLICATION invalidates
+    /// it. Separate from the constructor because the source is held by value here,
+    /// so streaming must begin on this copy, not the caller's.
     pub fn beginReplication(self: *Self, start_lsn: []const u8) !void {
+        try self.source.finishSnapshot();
         try self.source.startReplication(start_lsn);
     }
 
-    /// Read the existing rows of each resource under the slot's exported snapshot
-    /// and produce them as READ events, before streaming. `reader` is connected and
-    /// bound to the snapshot by the caller. Every READ event is flushed to Kafka
-    /// before returning, but the LSN is not advanced (pending_lsn stays 0): the slot
-    /// moves only once the stream is confirmed, so an interrupted snapshot re-runs
-    /// from the slot's start. Consumers must treat READ as an upsert.
+    /// Read the existing rows of each resource under the slot's exported snapshot and
+    /// produce them as READ events, before streaming. `reader` is connected and bound
+    /// to the snapshot by the caller. Returns true once every resource is fully read
+    /// and flushed to Kafka; returns false if a shutdown signal interrupted it (the
+    /// caller then leaves the snapshot marker in place so the next start redoes it).
+    /// The LSN is not advanced (pending_lsn stays 0): the slot moves only once the
+    /// stream is confirmed. Consumers must treat READ as an upsert.
     pub fn runInitialSnapshot(
         self: *Self,
         reader: *SnapshotReader,
         resources: []const []const u8,
         stop_signal: *std.atomic.Value(bool),
-    ) !void {
-        outer: for (resources) |resource| {
+    ) !bool {
+        for (resources) |resource| {
             var table = try reader.open(resource);
 
             // One arena per FETCH batch, freed each turn; the events only need to
             // live long enough to be serialized and copied into librdkafka.
-            while (!stop_signal.load(.monotonic)) {
+            drain: while (true) {
+                if (stop_signal.load(.monotonic)) {
+                    try table.close();
+                    return false;
+                }
+
                 var batch_arena = std.heap.ArenaAllocator.init(self.allocator);
                 defer batch_arena.deinit();
                 const batch_alloc = batch_arena.allocator();
 
-                const events = (try table.next(batch_alloc, constants.CDC.BATCH_SIZE)) orelse break;
+                const events = (try table.next(batch_alloc, constants.CDC.BATCH_SIZE)) orelse break :drain;
 
                 var event_counts = std.ArrayList(EventCount).empty;
                 defer event_counts.deinit(batch_alloc);
 
                 for (events) |event| {
-                    // Backpressure saw stop_signal mid-produce: stop cleanly and
-                    // flush what we already queued, like the streaming loop does.
+                    // Backpressure saw stop_signal mid-produce: treat it as an
+                    // interrupted snapshot, like the between-batch check above.
                     self.produceEvent(batch_alloc, stop_signal, event, &event_counts) catch |err| switch (err) {
                         error.Shutdown => {
                             try table.close();
-                            break :outer;
+                            return false;
                         },
                         else => return err,
                     };
@@ -313,6 +322,7 @@ pub const Processor = struct {
         }
 
         std.log.info("Initial snapshot complete: {} READ events produced", .{self.events_processed});
+        return true;
     }
 
     /// Run the batch loop until stop_signal is set, with a background flush/commit worker.

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -266,11 +266,12 @@ pub const Processor = struct {
     /// caller stops before streaming and the next start redoes the bootstrap.
     pub fn runInitialSnapshot(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !bool {
         if (!config_mod.needsInitialSnapshot(self.streams)) return true;
+        if (!self.source.needsBootstrap()) return true;
 
         const resources = try self.readResources();
         defer self.allocator.free(resources);
 
-        if (!try self.source.openSnapshot(io, resources)) return true;
+        try self.source.openSnapshot(io, resources);
 
         std.log.info("Running initial snapshot for {} resource(s)", .{resources.len});
 

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -259,12 +259,12 @@ pub const Processor = struct {
         try self.source.startStreaming();
     }
 
-    /// Run the initial-snapshot phase of the pipeline: pull the read-opted resources
-    /// from the source and produce their rows as READ events, before streaming. A
-    /// no-op returning true when no stream opts into `read` or the source has nothing
-    /// to bootstrap. Returns false when a shutdown signal interrupted it, so the
-    /// caller stops before streaming and the next start redoes the bootstrap.
-    pub fn runInitialSnapshot(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !bool {
+    /// Run the bootstrap phase of the pipeline: pull the read-opted resources from the
+    /// source and produce their rows as READ events, before streaming. A no-op
+    /// returning true when no stream opts into `read` or the source has nothing to
+    /// bootstrap. Returns false when a shutdown signal interrupted it, so the caller
+    /// stops before streaming and the next start redoes the bootstrap.
+    pub fn bootstrap(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !bool {
         if (!config_mod.needsInitialSnapshot(self.streams)) return true;
         if (!self.source.needsBootstrap()) return true;
 
@@ -352,8 +352,8 @@ pub const Processor = struct {
     /// Begin replication (after the initial snapshot, if any) and run the batch loop
     /// until stop_signal is set, with a background flush/commit worker.
     pub fn startStreaming(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
-        // Safe only once runInitialSnapshot is done: starting the stream ends the
-        // source's snapshot phase for good.
+        // Safe only once bootstrap is done: starting the stream ends the source's
+        // snapshot phase for good.
         try self.beginReplication();
 
         // The source is connected and validated before we get here, so readiness's

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -260,13 +260,14 @@ pub const Processor = struct {
     }
 
     /// Run the bootstrap phase of the pipeline: pull the read-opted resources from the
-    /// source and produce their rows as READ events, before streaming. A no-op
-    /// returning true when no stream opts into `read` or the source has nothing to
-    /// bootstrap. Returns false when a shutdown signal interrupted it, so the caller
-    /// stops before streaming and the next start redoes the bootstrap.
-    pub fn bootstrap(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !bool {
-        if (!config_mod.needsInitialSnapshot(self.streams)) return true;
-        if (!self.source.needsBootstrap()) return true;
+    /// source and produce their rows as READ events, before streaming. Returning
+    /// without an error means the bootstrap is done, whether it read anything or was
+    /// a no-op (no stream opts into `read`, or the source has nothing to bootstrap).
+    /// A shutdown signal mid-bootstrap fails with error.Shutdown, so the caller stops
+    /// before streaming and the next start redoes it.
+    pub fn bootstrap(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
+        if (!config_mod.needsInitialSnapshot(self.streams)) return;
+        if (!self.source.needsBootstrap()) return;
 
         const resources = try self.readResources();
         defer self.allocator.free(resources);
@@ -275,7 +276,7 @@ pub const Processor = struct {
 
         std.log.info("Running initial snapshot for {} resource(s)", .{resources.len});
 
-        return self.snapshotToKafka(stop_signal);
+        try self.snapshotToKafka(stop_signal);
     }
 
     // The distinct resources of the read-opted streams, so a table read by several
@@ -303,13 +304,12 @@ pub const Processor = struct {
 
     // Drain the source's snapshot batches and produce them as READ events through the
     // same path as streamed changes (produceEvent), mirroring processChangesToKafka.
-    // Returns true once an empty batch marks the snapshot read out and everything is
-    // flushed to Kafka; false if a shutdown signal interrupted it. The LSN is not
-    // advanced (pending_lsn stays 0): the slot moves only once the stream is
-    // confirmed. Consumers must treat READ as an upsert.
-    fn snapshotToKafka(self: *Self, stop_signal: *std.atomic.Value(bool)) !bool {
+    // Returns once an empty batch marks the snapshot read out and everything is
+    // flushed to Kafka. The LSN is not advanced (pending_lsn stays 0): the slot moves
+    // only once the stream is confirmed. Consumers must treat READ as an upsert.
+    fn snapshotToKafka(self: *Self, stop_signal: *std.atomic.Value(bool)) !void {
         while (true) {
-            if (stop_signal.load(.monotonic)) return false;
+            if (stop_signal.load(.monotonic)) return error.Shutdown;
 
             // One arena per batch, freed each turn; the events only need to live long
             // enough to be serialized and copied into librdkafka.
@@ -326,12 +326,9 @@ pub const Processor = struct {
             defer event_counts.deinit(batch_alloc);
 
             for (batch.changes) |change_event| {
-                // Backpressure saw stop_signal mid-produce: treat it as an interrupted
-                // snapshot, like the between-batch check above.
-                self.produceEvent(batch_alloc, stop_signal, change_event, &event_counts) catch |err| switch (err) {
-                    error.Shutdown => return false,
-                    else => return err,
-                };
+                // produceEvent surfaces a shutdown during backpressure as error.Shutdown,
+                // the same signal the between-batch check raises, so let it propagate.
+                try self.produceEvent(batch_alloc, stop_signal, change_event, &event_counts);
             }
             for (event_counts.items) |e| self.obs.addEvents(e.count, e.stream, e.operation);
         }
@@ -346,7 +343,6 @@ pub const Processor = struct {
         }
 
         std.log.info("Initial snapshot complete: {} READ events produced", .{self.events_processed});
-        return true;
     }
 
     /// Begin replication (after the initial snapshot, if any) and run the batch loop

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -147,6 +147,14 @@ pub const Processor = struct {
         std.log.debug("processor.deinit: done", .{});
     }
 
+    /// Connect the owned source and ensure its publication and slot exist, without
+    /// streaming. Whether an initial snapshot may run (which also drives
+    /// interrupted-snapshot recovery on the slot) is derived from the streams' `read`
+    /// opt-in, so the pipeline decides it, not the caller.
+    pub fn connect(self: *Self, conninfo: []const u8) !void {
+        try self.source.connect(conninfo, self.wantsSnapshot());
+    }
+
     /// Receive one batch, route each change to its streams, and stage the batch LSN for commit.
     pub fn processChangesToKafka(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool), batch_allocator: std.mem.Allocator, limit: u32) !void {
         var batch = try self.source.receiveBatch(io, batch_allocator, limit);
@@ -252,25 +260,86 @@ pub const Processor = struct {
             error.PartitionKeyUnavailable;
     }
 
-    /// Finish the bootstrap and start streaming on the owned source: drop the
+    /// Finish the bootstrap and start replication on the owned source: drop the
     /// snapshot marker (steady state returns to one publication) then
-    /// START_REPLICATION. Call only after a completed snapshot (if any), so the
-    /// slot's exported snapshot outlived the reads; START_REPLICATION invalidates
-    /// it. Separate from the constructor because the source is held by value here,
-    /// so streaming must begin on this copy, not the caller's.
-    pub fn beginReplication(self: *Self, start_lsn: []const u8) !void {
+    /// START_REPLICATION from the slot's start LSN (or "0/0" to resume an existing
+    /// slot). Call only after a completed snapshot (if any), so the slot's exported
+    /// snapshot outlived the reads; START_REPLICATION invalidates it. Separate from
+    /// the constructor because the source is held by value here, so streaming must
+    /// begin on this copy, not the caller's.
+    pub fn beginReplication(self: *Self) !void {
         try self.source.finishSnapshot();
-        try self.source.startReplication(start_lsn);
+        try self.source.startReplication(self.source.startLsn() orelse "0/0");
     }
 
-    /// Read the existing rows of each resource under the slot's exported snapshot and
-    /// produce them as READ events, before streaming. `reader` is connected and bound
-    /// to the snapshot by the caller. Returns true once every resource is fully read
-    /// and flushed to Kafka; returns false if a shutdown signal interrupted it (the
-    /// caller then leaves the snapshot marker in place so the next start redoes it).
-    /// The LSN is not advanced (pending_lsn stays 0): the slot moves only once the
-    /// stream is confirmed. Consumers must treat READ as an upsert.
-    pub fn runInitialSnapshot(
+    /// Run the initial-snapshot phase of the pipeline: read the read-opted resources
+    /// under the slot's exported snapshot and produce their rows as READ events,
+    /// before streaming. A no-op returning true when the slot already existed
+    /// (nothing to bootstrap) or no stream opts into `read`. Returns false when a
+    /// shutdown signal interrupted it, so the caller stops before streaming and the
+    /// next start redoes the bootstrap (the snapshot marker stays in place). Opens
+    /// its own regular connection from `conninfo`, since the replication connection
+    /// must stay idle until START_REPLICATION.
+    pub fn runInitialSnapshot(self: *Self, io: std.Io, conninfo: []const u8, stop_signal: *std.atomic.Value(bool)) !bool {
+        // No exported snapshot means the slot already existed: nothing to bootstrap.
+        const snapshot_name = self.source.snapshotName() orelse return true;
+        if (!self.wantsSnapshot()) return true;
+
+        const resources = try self.readResources();
+        defer self.allocator.free(resources);
+        if (resources.len == 0) return true;
+
+        std.log.info("Running initial snapshot for {} resource(s)", .{resources.len});
+
+        // meta.timestamp for READ rows: the snapshot's wall-clock start. meta.lsn is
+        // the slot's start LSN, so a snapshot row shares the dedup boundary with the
+        // first streamed change.
+        const timestamp = std.Io.Timestamp.now(io, .real).toSeconds();
+        var reader = SnapshotReader.init(self.allocator, snapshot_name, self.source.startLsn() orelse "0/0", timestamp);
+        defer reader.deinit();
+        try reader.connect(conninfo);
+
+        return self.snapshotToKafka(&reader, resources, stop_signal);
+    }
+
+    // Whether any stream opts into the initial snapshot by listing `read`.
+    fn wantsSnapshot(self: *Self) bool {
+        for (self.streams) |stream| {
+            if (stream.hasReadOperation()) return true;
+        }
+        return false;
+    }
+
+    // The distinct resources of the read-opted streams, so a table read by several
+    // streams is snapshotted once. Caller owns the returned slice; the strings are
+    // borrowed from the streams.
+    fn readResources(self: *Self) ![]const []const u8 {
+        var resources = std.ArrayList([]const u8).empty;
+        errdefer resources.deinit(self.allocator);
+
+        for (self.streams) |stream| {
+            if (!stream.hasReadOperation()) continue;
+
+            var seen = false;
+            for (resources.items) |r| {
+                if (std.mem.eql(u8, r, stream.source.resource)) {
+                    seen = true;
+                    break;
+                }
+            }
+            if (!seen) try resources.append(self.allocator, stream.source.resource);
+        }
+
+        return resources.toOwnedSlice(self.allocator);
+    }
+
+    // Read each resource's rows via the snapshot reader and produce them as READ
+    // events through the same path as streamed changes (produceEvent), mirroring
+    // processChangesToKafka. Returns true once every resource is fully read and
+    // flushed to Kafka; false if a shutdown signal interrupted it. The LSN is not
+    // advanced (pending_lsn stays 0): the slot moves only once the stream is
+    // confirmed. Consumers must treat READ as an upsert.
+    fn snapshotToKafka(
         self: *Self,
         reader: *SnapshotReader,
         resources: []const []const u8,
@@ -325,8 +394,13 @@ pub const Processor = struct {
         return true;
     }
 
-    /// Run the batch loop until stop_signal is set, with a background flush/commit worker.
+    /// Begin replication (after the initial snapshot, if any) and run the batch loop
+    /// until stop_signal is set, with a background flush/commit worker.
     pub fn startStreaming(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
+        // Drop the snapshot marker and START_REPLICATION; the exported snapshot has
+        // already been read by runInitialSnapshot, so it is safe to invalidate now.
+        try self.beginReplication();
+
         // The source is connected and validated before we get here, so readiness's
         // connection signal goes up now; markStreaming follows on the first batch.
         self.obs.markConnected(true);

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -251,24 +251,27 @@ pub const Processor = struct {
             error.PartitionKeyUnavailable;
     }
 
-    /// Run the bootstrap phase of the pipeline: pull the read-opted resources from the
-    /// source and produce their rows as READ events, before streaming. Returning
-    /// without an error means the bootstrap is done, whether it read anything or was
-    /// a no-op (no stream opts into `read`, or the source has nothing to bootstrap).
-    /// A shutdown signal mid-bootstrap fails with error.Shutdown, so the caller stops
-    /// before streaming and the next start redoes it.
+    /// Bring the pipeline up and leave the source streaming: produce the read-opted
+    /// resources as READ events, then open the replication stream. The snapshot part
+    /// is skipped when no stream opts into `read` or the source has nothing to
+    /// bootstrap; the stream is opened either way, so `run` can assume it. Opening
+    /// the stream ends the snapshot phase for good, so both steps live here and the
+    /// order cannot be got wrong from outside. A shutdown signal mid-snapshot fails
+    /// with error.Shutdown, leaving the stream unopened so the next start redoes it.
     pub fn bootstrap(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
-        if (!config_mod.needsInitialSnapshot(self.streams)) return;
-        if (!self.source.needsBootstrap()) return;
+        if (config_mod.needsInitialSnapshot(self.streams) and self.source.needsBootstrap()) {
+            const resources = try self.readResources();
+            defer self.allocator.free(resources);
 
-        const resources = try self.readResources();
-        defer self.allocator.free(resources);
+            try self.source.openSnapshot(io, resources);
 
-        try self.source.openSnapshot(io, resources);
+            std.log.info("Running initial snapshot for {} resource(s)", .{resources.len});
 
-        std.log.info("Running initial snapshot for {} resource(s)", .{resources.len});
+            try self.snapshotToKafka(stop_signal);
+        }
 
-        try self.snapshotToKafka(stop_signal);
+        // On the source, not the caller's copy: it is held by value here.
+        try self.source.startStreaming();
     }
 
     // The distinct resources of the read-opted streams, so a table read by several
@@ -309,6 +312,8 @@ pub const Processor = struct {
             defer batch_arena.deinit();
             const batch_alloc = batch_arena.allocator();
 
+            // Deliberately the stream's batch size: a bulk read may well want another
+            // value, but nothing measured says so yet.
             var batch = try self.source.receiveSnapshotBatch(batch_alloc, constants.CDC.BATCH_SIZE);
             defer batch.deinit();
 
@@ -337,14 +342,9 @@ pub const Processor = struct {
         std.log.info("Initial snapshot complete: {} READ events produced", .{self.events_processed});
     }
 
-    /// Begin replication (after the initial snapshot, if any) and run the batch loop
-    /// until stop_signal is set, with a background flush/commit worker.
-    pub fn startStreaming(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
-        // Safe only once bootstrap is done: starting the stream ends the source's
-        // snapshot phase for good. On the source, not the caller's copy: it is held
-        // by value here.
-        try self.source.startStreaming();
-
+    /// Run the batch loop until stop_signal is set, with a background flush/commit
+    /// worker. Call after bootstrap, which leaves the source streaming.
+    pub fn run(self: *Self, io: std.Io, stop_signal: *std.atomic.Value(bool)) !void {
         // The source is connected and validated before we get here, so readiness's
         // connection signal goes up now; markStreaming follows on the first batch.
         self.obs.markConnected(true);

--- a/src/processor/processor.zig
+++ b/src/processor/processor.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const PostgresSource = @import("../source/postgres/source.zig").PostgresSource;
 const Batch = @import("../source/postgres/source.zig").Batch;
+const SnapshotReader = @import("../source/postgres/snapshot.zig").SnapshotReader;
 
 const KafkaProducer = @import("../sink/kafka/producer.zig").KafkaProducer;
 const Stream = @import("../config/config.zig").Stream;
@@ -175,43 +176,57 @@ pub const Processor = struct {
         defer event_counts.deinit(batch_allocator);
 
         for (batch.changes) |change_event| {
-            var matched = try matchStreams(batch_allocator, self.streams, change_event);
-            defer matched.deinit(batch_allocator);
-
-            if (matched.items.len == 0) {
-                continue;
-            }
-
-            const json_bytes = try self.serializer.serialize(change_event, batch_allocator);
-
-            for (matched.items) |stream| {
-                const topic_name = stream.sink.destination;
-                const partition_key = try self.getPartitionKey(batch_allocator, change_event, stream);
-
-                // A full queue is backpressure, not failure: send blocks (stalling
-                // the WAL read, so Postgres slows too) and retries. Shutdown and a
-                // permanent delivery failure propagate as-is; anything else is a
-                // produce error worth recording before it fails the pipeline.
-                self.producer.send(stop_signal, topic_name, partition_key, json_bytes) catch |err| switch (err) {
-                    error.Shutdown, error.DeliveryFailed => return err,
-                    else => {
-                        self.obs.recordProduceError();
-                        return err;
-                    },
-                };
-
-                try tallyEvent(&event_counts, batch_allocator, stream.name, change_event.op);
-
-                self.events_processed += 1;
-                if (self.events_processed % 10000 == 0) {
-                    std.log.info("Processed {} CDC events", .{self.events_processed});
-                }
-            }
+            try self.produceEvent(batch_allocator, stop_signal, change_event, &event_counts);
         }
 
         for (event_counts.items) |e| self.obs.addEvents(e.count, e.stream, e.operation);
 
         self.pending_lsn.store(batch.last_lsn, .release);
+    }
+
+    // Route one change to its matching streams and produce it to Kafka, tallying
+    // each produced (stream, operation) into event_counts. Shared by the streaming
+    // loop and the initial snapshot, so a READ row and a streamed change take the
+    // same serialize/match/partition/produce path.
+    fn produceEvent(
+        self: *Self,
+        batch_allocator: std.mem.Allocator,
+        stop_signal: *std.atomic.Value(bool),
+        change_event: ChangeEvent,
+        event_counts: *std.ArrayList(EventCount),
+    ) !void {
+        var matched = try matchStreams(batch_allocator, self.streams, change_event);
+        defer matched.deinit(batch_allocator);
+
+        if (matched.items.len == 0) {
+            return;
+        }
+
+        const json_bytes = try self.serializer.serialize(change_event, batch_allocator);
+
+        for (matched.items) |stream| {
+            const topic_name = stream.sink.destination;
+            const partition_key = try self.getPartitionKey(batch_allocator, change_event, stream);
+
+            // A full queue is backpressure, not failure: send blocks (stalling
+            // the WAL read, so Postgres slows too) and retries. Shutdown and a
+            // permanent delivery failure propagate as-is; anything else is a
+            // produce error worth recording before it fails the pipeline.
+            self.producer.send(stop_signal, topic_name, partition_key, json_bytes) catch |err| switch (err) {
+                error.Shutdown, error.DeliveryFailed => return err,
+                else => {
+                    self.obs.recordProduceError();
+                    return err;
+                },
+            };
+
+            try tallyEvent(event_counts, batch_allocator, stream.name, change_event.op);
+
+            self.events_processed += 1;
+            if (self.events_processed % 10000 == 0) {
+                std.log.info("Processed {} CDC events", .{self.events_processed});
+            }
+        }
     }
 
     fn getPartitionKey(
@@ -235,6 +250,69 @@ pub const Processor = struct {
         // rather than collapse the change onto a table-name partition.
         return try change_event.getPartitionKeyValue(allocator, key_field) orelse
             error.PartitionKeyUnavailable;
+    }
+
+    /// Start replication on the owned source. Call after the initial snapshot (if
+    /// any) so the slot's exported snapshot outlives the reads; START_REPLICATION
+    /// invalidates it. Separate from the constructor because the source is held by
+    /// value here, so streaming must begin on this copy, not the caller's.
+    pub fn beginReplication(self: *Self, start_lsn: []const u8) !void {
+        try self.source.startReplication(start_lsn);
+    }
+
+    /// Read the existing rows of each resource under the slot's exported snapshot
+    /// and produce them as READ events, before streaming. `reader` is connected and
+    /// bound to the snapshot by the caller. Every READ event is flushed to Kafka
+    /// before returning, but the LSN is not advanced (pending_lsn stays 0): the slot
+    /// moves only once the stream is confirmed, so an interrupted snapshot re-runs
+    /// from the slot's start. Consumers must treat READ as an upsert.
+    pub fn runInitialSnapshot(
+        self: *Self,
+        reader: *SnapshotReader,
+        resources: []const []const u8,
+        stop_signal: *std.atomic.Value(bool),
+    ) !void {
+        outer: for (resources) |resource| {
+            var table = try reader.open(resource);
+
+            // One arena per FETCH batch, freed each turn; the events only need to
+            // live long enough to be serialized and copied into librdkafka.
+            while (!stop_signal.load(.monotonic)) {
+                var batch_arena = std.heap.ArenaAllocator.init(self.allocator);
+                defer batch_arena.deinit();
+                const batch_alloc = batch_arena.allocator();
+
+                const events = (try table.next(batch_alloc, constants.CDC.BATCH_SIZE)) orelse break;
+
+                var event_counts = std.ArrayList(EventCount).empty;
+                defer event_counts.deinit(batch_alloc);
+
+                for (events) |event| {
+                    // Backpressure saw stop_signal mid-produce: stop cleanly and
+                    // flush what we already queued, like the streaming loop does.
+                    self.produceEvent(batch_alloc, stop_signal, event, &event_counts) catch |err| switch (err) {
+                        error.Shutdown => {
+                            try table.close();
+                            break :outer;
+                        },
+                        else => return err,
+                    };
+                }
+                for (event_counts.items) |e| self.obs.addEvents(e.count, e.stream, e.operation);
+            }
+            try table.close();
+        }
+
+        // Durability barrier: the flush/commit worker is not running yet, so drain
+        // the producer here and fail fast if any READ event was not delivered,
+        // before streaming begins to advance the slot past them.
+        try self.producer.flush(null);
+        if (self.producer.deliveryErrorCount() > 0 or self.producer.fatalError()) {
+            std.log.warn("Kafka delivery failed during initial snapshot; exiting for restart", .{});
+            return error.DeliveryFailed;
+        }
+
+        std.log.info("Initial snapshot complete: {} READ events produced", .{self.events_processed});
     }
 
     /// Run the batch loop until stop_signal is set, with a background flush/commit worker.

--- a/src/processor/routing_integration_test.zig
+++ b/src/processor/routing_integration_test.zig
@@ -117,7 +117,7 @@ test "matchStreams: each change is routed to the stream matching its schema" {
 
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
     try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);

--- a/src/processor/routing_integration_test.zig
+++ b/src/processor/routing_integration_test.zig
@@ -117,7 +117,7 @@ test "matchStreams: each change is routed to the stream matching its schema" {
 
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
     try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);

--- a/src/source/postgres/integration_test.zig
+++ b/src/source/postgres/integration_test.zig
@@ -159,7 +159,7 @@ test "Streaming source: receive and convert INSERT messages to ChangeEvents" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit(); // Source defer - declared SECOND, executes FIRST (before cleanup)
 
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
     try source.startReplication(start_lsn);
 
     std.log.info("Streaming source connected, receiving batch...", .{});
@@ -227,7 +227,7 @@ test "ReplicationProtocol: mixed-case slot and publication names are idempotent 
 
         try proto.connect(conn_str);
         try proto.createPublicationIfNotExists();
-        try proto.createSlotIfNotExists();
+        if (!try proto.slotExists()) try proto.createSlot();
     }
 }
 
@@ -303,7 +303,7 @@ test "Streaming source: UPDATE operation E2E with old and new tuples" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
     try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);
@@ -432,7 +432,7 @@ test "Streaming source: unchanged TOAST column becomes the placeholder" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
     try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);
@@ -547,7 +547,7 @@ test "Streaming source: DELETE operation E2E" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
     try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);
@@ -658,7 +658,7 @@ test "Streaming source: Multiple batches with limit parameter" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
     try source.startReplication(start_lsn);
 
     var total_changes: usize = 0;
@@ -748,7 +748,7 @@ test "Streaming source: Timeout behavior with no data" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
     try source.startReplication(start_lsn);
 
     std.log.info("Waiting for timeout with no data (1 second)...", .{});
@@ -806,7 +806,7 @@ test "Streaming source: created slot captures the consistent point and streams f
 
     // Create the publication and slot through the protocol (not pre-created via
     // SQL), so CREATE_REPLICATION_SLOT runs and its start LSN is captured.
-    try source.connect(conn_str);
+    try source.connect(conn_str, false);
 
     try testing.expect(source.startLsn() != null);
     const start_lsn = source.startLsn().?;

--- a/src/source/postgres/integration_test.zig
+++ b/src/source/postgres/integration_test.zig
@@ -159,7 +159,7 @@ test "Streaming source: receive and convert INSERT messages to ChangeEvents" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit(); // Source defer - declared SECOND, executes FIRST (before cleanup)
 
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
     try source.startReplication(start_lsn);
 
     std.log.info("Streaming source connected, receiving batch...", .{});
@@ -303,7 +303,7 @@ test "Streaming source: UPDATE operation E2E with old and new tuples" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
     try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);
@@ -432,7 +432,7 @@ test "Streaming source: unchanged TOAST column becomes the placeholder" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
     try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);
@@ -547,7 +547,7 @@ test "Streaming source: DELETE operation E2E" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
     try source.startReplication(start_lsn);
 
     const batch = try source.receiveBatch(std.testing.io, allocator, 10);
@@ -658,7 +658,7 @@ test "Streaming source: Multiple batches with limit parameter" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
     try source.startReplication(start_lsn);
 
     var total_changes: usize = 0;
@@ -748,7 +748,7 @@ test "Streaming source: Timeout behavior with no data" {
     var source = PostgresSource.init(allocator, slot_name, pub_name);
     defer source.deinit();
 
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
     try source.startReplication(start_lsn);
 
     std.log.info("Waiting for timeout with no data (1 second)...", .{});
@@ -806,7 +806,7 @@ test "Streaming source: created slot captures the consistent point and streams f
 
     // Create the publication and slot through the protocol (not pre-created via
     // SQL), so CREATE_REPLICATION_SLOT runs and its start LSN is captured.
-    try source.connect(conn_str, false);
+    try source.connect(conn_str, .stream_only);
 
     try testing.expect(source.startLsn() != null);
     const start_lsn = source.startLsn().?;

--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -72,6 +72,11 @@ pub const ReplicationProtocol = struct {
     // slot's start point (and, later, aligns with the slot's exported snapshot)
     // instead of relying on "0/0" resolving to the same place.
     consistent_point: ?[]const u8 = null,
+    // snapshot_name from CREATE_REPLICATION_SLOT: the exported snapshot valid as
+    // of consistent_point, importable with SET TRANSACTION SNAPSHOT while this
+    // connection stays open. Set only on a freshly created slot, so its presence
+    // is also the "was the slot created this run" signal for the initial snapshot.
+    snapshot_name: ?[]const u8 = null,
 
     const Self = @This();
 
@@ -86,6 +91,7 @@ pub const ReplicationProtocol = struct {
 
     pub fn deinit(self: *Self) void {
         if (self.consistent_point) |cp| self.allocator.free(cp);
+        if (self.snapshot_name) |sn| self.allocator.free(sn);
         if (self.connection) |conn| {
             c.PQfinish(conn);
             self.connection = null;
@@ -96,6 +102,13 @@ pub const ReplicationProtocol = struct {
     /// null if the slot already existed.
     pub fn startLsn(self: *const Self) ?[]const u8 {
         return self.consistent_point;
+    }
+
+    /// The slot's exported snapshot name, captured when the slot was created in
+    /// this run; null if the slot already existed (no snapshot to import). Valid
+    /// only while this connection stays open and idle.
+    pub fn snapshotName(self: *const Self) ?[]const u8 {
+        return self.snapshot_name;
     }
 
     pub fn connect(self: *Self, connection_string: []const u8) ReplicationError!void {
@@ -271,6 +284,16 @@ pub const ReplicationProtocol = struct {
             std.log.debug("Slot consistent point: {s}", .{self.consistent_point.?});
         } else {
             std.log.warn("CREATE_REPLICATION_SLOT returned no consistent_point; starting from 0/0", .{});
+        }
+
+        // snapshot_name from the same row: the exported snapshot the initial
+        // snapshot reads under. Best-effort like consistent_point; without it the
+        // caller simply runs no snapshot.
+        const sn_col = c.PQfnumber(create_result, "snapshot_name");
+        if (sn_col >= 0 and c.PQntuples(create_result) > 0 and c.PQgetisnull(create_result, 0, sn_col) == 0) {
+            const sn = std.mem.span(c.PQgetvalue(create_result, 0, sn_col));
+            self.snapshot_name = self.allocator.dupe(u8, sn) catch return ReplicationError.OutOfMemory;
+            std.log.debug("Slot exported snapshot: {s}", .{self.snapshot_name.?});
         }
     }
 

--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -146,154 +146,191 @@ pub const ReplicationProtocol = struct {
         std.log.debug("Replication connection established", .{});
     }
 
-    /// Create publication if it doesn't exist (for all tables)
+    /// Create the streaming publication (FOR ALL TABLES) if absent. Must run before
+    /// the slot is created: pgoutput resolves the publication by name in the
+    /// historical catalog for each change, so a change whose LSN predates the
+    /// publication cannot be decoded (a change before the slot's start would fail
+    /// with "publication does not exist"). Creating the publication first keeps the
+    /// slot's consistent point after it, so every streamed change decodes.
     pub fn createPublicationIfNotExists(self: *Self) ReplicationError!void {
         if (self.connection == null) return ReplicationError.ConnectionFailed;
 
-        // Postgres folds unquoted identifiers to lowercase. We fold slot and
-        // publication names the same way so the existence check, CREATE, and
-        // START_REPLICATION all reference one name; a mixed-case name would be
-        // created folded but never re-found, and CREATE would fail "already
-        // exists" on every restart -- a crash loop.
-        const pub_name = try std.ascii.allocLowerString(self.allocator, self.publication_name);
+        const pub_name = try self.lowerName(self.publication_name);
         defer self.allocator.free(pub_name);
 
-        // Check if publication exists
-        const check_sql_tmp = std.fmt.allocPrint(
-            self.allocator,
-            "SELECT pubname FROM pg_publication WHERE pubname = '{s}'",
-            .{pub_name},
-        ) catch return ReplicationError.OutOfMemory;
-        defer self.allocator.free(check_sql_tmp);
-
-        const check_sql = self.allocator.dupeZ(u8, check_sql_tmp) catch return ReplicationError.OutOfMemory;
-        defer self.allocator.free(check_sql);
-
-        const check_result = c.PQexec(self.connection, check_sql.ptr);
-        defer c.PQclear(check_result);
-
-        const check_status = c.PQresultStatus(check_result);
-        if (check_status != c.PGRES_TUPLES_OK) {
-            const error_msg = c.PQresultErrorMessage(check_result);
-            std.log.warn("Failed to check publication: {s}", .{error_msg});
-            return ReplicationError.ConnectionFailed;
-        }
-
-        const num_rows = c.PQntuples(check_result);
-        if (num_rows > 0) {
+        if (try self.objectExists("pg_publication", "pubname", pub_name)) {
             std.log.info("Publication '{s}' already exists", .{pub_name});
             return;
         }
 
-        // Publication doesn't exist, create it for all tables
-        const create_sql_tmp = std.fmt.allocPrint(
-            self.allocator,
-            "CREATE PUBLICATION {s} FOR ALL TABLES",
-            .{pub_name},
-        ) catch return ReplicationError.OutOfMemory;
-        defer self.allocator.free(create_sql_tmp);
-
-        const create_sql = self.allocator.dupeZ(u8, create_sql_tmp) catch return ReplicationError.OutOfMemory;
-        defer self.allocator.free(create_sql);
+        const sql = std.fmt.allocPrintSentinel(self.allocator, "CREATE PUBLICATION {s} FOR ALL TABLES", .{pub_name}, 0) catch return ReplicationError.OutOfMemory;
+        defer self.allocator.free(sql);
 
         std.log.info("Creating publication: {s}", .{pub_name});
-
-        const create_result = c.PQexec(self.connection, create_sql.ptr);
-        defer c.PQclear(create_result);
-
-        const create_status = c.PQresultStatus(create_result);
-        if (create_status != c.PGRES_COMMAND_OK) {
-            const error_msg = c.PQresultErrorMessage(create_result);
-            std.log.warn("Failed to create publication: {s}", .{error_msg});
-            return ReplicationError.ConnectionFailed;
-        }
-
+        try self.execSimple(sql.ptr, "CREATE PUBLICATION");
         std.log.info("Publication '{s}' created successfully", .{pub_name});
     }
 
-    /// Create replication slot if it doesn't exist
-    pub fn createSlotIfNotExists(self: *Self) ReplicationError!void {
+    /// Whether the snapshot marker publication exists, i.e. a prior initial snapshot
+    /// was interrupted before it finished. See createSnapshotMarker.
+    pub fn snapshotMarkerExists(self: *Self) ReplicationError!bool {
+        if (self.connection == null) return ReplicationError.ConnectionFailed;
+        const name = try self.markerName();
+        defer self.allocator.free(name);
+        return self.objectExists("pg_publication", "pubname", name);
+    }
+
+    /// Create the snapshot marker publication if absent (idempotent). It is an empty
+    /// publication used only as a durable "snapshot in progress" flag: created before
+    /// the slot at bootstrap and dropped once the snapshot is flushed, so its presence
+    /// on startup means the snapshot did not finish. It is never passed to
+    /// START_REPLICATION, so it takes no part in decoding.
+    pub fn createSnapshotMarker(self: *Self) ReplicationError!void {
+        if (self.connection == null) return ReplicationError.ConnectionFailed;
+        const name = try self.markerName();
+        defer self.allocator.free(name);
+
+        if (try self.objectExists("pg_publication", "pubname", name)) return;
+
+        const sql = std.fmt.allocPrintSentinel(self.allocator, "CREATE PUBLICATION {s}", .{name}, 0) catch return ReplicationError.OutOfMemory;
+        defer self.allocator.free(sql);
+
+        std.log.info("Creating snapshot marker: {s}", .{name});
+        try self.execSimple(sql.ptr, "CREATE PUBLICATION (snapshot marker)");
+    }
+
+    /// Drop the snapshot marker publication if present (idempotent). Called once the
+    /// snapshot is flushed, returning steady state to a single publication.
+    pub fn dropSnapshotMarker(self: *Self) ReplicationError!void {
+        if (self.connection == null) return ReplicationError.ConnectionFailed;
+        const name = try self.markerName();
+        defer self.allocator.free(name);
+
+        const sql = std.fmt.allocPrintSentinel(self.allocator, "DROP PUBLICATION IF EXISTS {s}", .{name}, 0) catch return ReplicationError.OutOfMemory;
+        defer self.allocator.free(sql);
+
+        std.log.info("Dropping snapshot marker: {s}", .{name});
+        try self.execSimple(sql.ptr, "DROP PUBLICATION (snapshot marker)");
+    }
+
+    /// Whether the replication slot already exists.
+    pub fn slotExists(self: *Self) ReplicationError!bool {
+        if (self.connection == null) return ReplicationError.ConnectionFailed;
+        const slot_name = try self.lowerName(self.slot_name);
+        defer self.allocator.free(slot_name);
+        return self.objectExists("pg_replication_slots", "slot_name", slot_name);
+    }
+
+    /// Create the replication slot and capture its consistent point and exported
+    /// snapshot. Assumes the slot does not exist (check slotExists first).
+    pub fn createSlot(self: *Self) ReplicationError!void {
         if (self.connection == null) return ReplicationError.ConnectionFailed;
 
-        // Fold to lowercase like Postgres does for unquoted identifiers (see
-        // createPublicationIfNotExists).
-        const slot_name = try std.ascii.allocLowerString(self.allocator, self.slot_name);
+        const slot_name = try self.lowerName(self.slot_name);
         defer self.allocator.free(slot_name);
 
-        // Check if slot exists
-        const check_sql_tmp = std.fmt.allocPrint(
-            self.allocator,
-            "SELECT slot_name FROM pg_replication_slots WHERE slot_name = '{s}'",
-            .{slot_name},
-        ) catch return ReplicationError.OutOfMemory;
-        defer self.allocator.free(check_sql_tmp);
-
-        const check_sql = self.allocator.dupeZ(u8, check_sql_tmp) catch return ReplicationError.OutOfMemory;
-        defer self.allocator.free(check_sql);
-
-        const check_result = c.PQexec(self.connection, check_sql.ptr);
-        defer c.PQclear(check_result);
-
-        const check_status = c.PQresultStatus(check_result);
-        if (check_status != c.PGRES_TUPLES_OK) {
-            const error_msg = c.PQresultErrorMessage(check_result);
-            std.log.warn("Failed to check replication slot: {s}", .{error_msg});
-            return ReplicationError.ConnectionFailed;
+        // A re-create after dropSlot (interrupted snapshot) must not leak the values
+        // captured for the discarded slot.
+        if (self.consistent_point) |cp| {
+            self.allocator.free(cp);
+            self.consistent_point = null;
+        }
+        if (self.snapshot_name) |sn| {
+            self.allocator.free(sn);
+            self.snapshot_name = null;
         }
 
-        const num_rows = c.PQntuples(check_result);
-        if (num_rows > 0) {
-            std.log.info("Replication slot '{s}' already exists", .{slot_name});
-            return;
-        }
-
-        // Slot doesn't exist, create it
-        const create_sql_tmp = std.fmt.allocPrint(
-            self.allocator,
-            "CREATE_REPLICATION_SLOT {s} LOGICAL pgoutput",
-            .{slot_name},
-        ) catch return ReplicationError.OutOfMemory;
-        defer self.allocator.free(create_sql_tmp);
-
-        const create_sql = self.allocator.dupeZ(u8, create_sql_tmp) catch return ReplicationError.OutOfMemory;
-        defer self.allocator.free(create_sql);
+        const sql = std.fmt.allocPrintSentinel(self.allocator, "CREATE_REPLICATION_SLOT {s} LOGICAL pgoutput", .{slot_name}, 0) catch return ReplicationError.OutOfMemory;
+        defer self.allocator.free(sql);
 
         std.log.info("Creating replication slot: {s}", .{slot_name});
 
-        const create_result = c.PQexec(self.connection, create_sql.ptr);
-        defer c.PQclear(create_result);
-
-        const create_status = c.PQresultStatus(create_result);
-        if (create_status != c.PGRES_TUPLES_OK) {
-            const error_msg = c.PQresultErrorMessage(create_result);
-            std.log.warn("Failed to create replication slot: {s}", .{error_msg});
+        const result = c.PQexec(self.connection, sql.ptr);
+        defer c.PQclear(result);
+        if (c.PQresultStatus(result) != c.PGRES_TUPLES_OK) {
+            std.log.warn("Failed to create replication slot: {s}", .{c.PQresultErrorMessage(result)});
             return ReplicationError.ConnectionFailed;
         }
-
         std.log.info("Replication slot '{s}' created successfully", .{slot_name});
 
         // CREATE_REPLICATION_SLOT returns one row: slot_name, consistent_point,
-        // snapshot_name, output_plugin. Capture consistent_point (the slot's
-        // start LSN) so streaming can begin exactly there. Best-effort: if it is
-        // ever absent we leave it null and fall back to "0/0", which resolves to
-        // the same freshly created position.
-        const cp_col = c.PQfnumber(create_result, "consistent_point");
-        if (cp_col >= 0 and c.PQntuples(create_result) > 0 and c.PQgetisnull(create_result, 0, cp_col) == 0) {
-            const cp = std.mem.span(c.PQgetvalue(create_result, 0, cp_col));
+        // snapshot_name, output_plugin. Capture consistent_point (the slot's start
+        // LSN) so streaming can begin exactly there. Best-effort: if it is ever
+        // absent we leave it null and fall back to "0/0", which resolves to the same
+        // freshly created position.
+        const cp_col = c.PQfnumber(result, "consistent_point");
+        if (cp_col >= 0 and c.PQntuples(result) > 0 and c.PQgetisnull(result, 0, cp_col) == 0) {
+            const cp = std.mem.span(c.PQgetvalue(result, 0, cp_col));
             self.consistent_point = self.allocator.dupe(u8, cp) catch return ReplicationError.OutOfMemory;
             std.log.debug("Slot consistent point: {s}", .{self.consistent_point.?});
         } else {
             std.log.warn("CREATE_REPLICATION_SLOT returned no consistent_point; starting from 0/0", .{});
         }
 
-        // snapshot_name from the same row: the exported snapshot the initial
-        // snapshot reads under. Best-effort like consistent_point; without it the
-        // caller simply runs no snapshot.
-        const sn_col = c.PQfnumber(create_result, "snapshot_name");
-        if (sn_col >= 0 and c.PQntuples(create_result) > 0 and c.PQgetisnull(create_result, 0, sn_col) == 0) {
-            const sn = std.mem.span(c.PQgetvalue(create_result, 0, sn_col));
+        // snapshot_name from the same row: the exported snapshot the initial snapshot
+        // reads under. Best-effort like consistent_point; without it the caller runs
+        // no snapshot.
+        const sn_col = c.PQfnumber(result, "snapshot_name");
+        if (sn_col >= 0 and c.PQntuples(result) > 0 and c.PQgetisnull(result, 0, sn_col) == 0) {
+            const sn = std.mem.span(c.PQgetvalue(result, 0, sn_col));
             self.snapshot_name = self.allocator.dupe(u8, sn) catch return ReplicationError.OutOfMemory;
             std.log.debug("Slot exported snapshot: {s}", .{self.snapshot_name.?});
+        }
+    }
+
+    /// Drop the replication slot. Used to discard an orphaned slot left by an
+    /// interrupted snapshot. Fails fast if the slot is still active (e.g. another
+    /// reader), rather than waiting.
+    pub fn dropSlot(self: *Self) ReplicationError!void {
+        if (self.connection == null) return ReplicationError.ConnectionFailed;
+        const slot_name = try self.lowerName(self.slot_name);
+        defer self.allocator.free(slot_name);
+
+        const sql = std.fmt.allocPrintSentinel(self.allocator, "DROP_REPLICATION_SLOT {s}", .{slot_name}, 0) catch return ReplicationError.OutOfMemory;
+        defer self.allocator.free(sql);
+
+        std.log.info("Dropping replication slot: {s}", .{slot_name});
+        try self.execSimple(sql.ptr, "DROP_REPLICATION_SLOT");
+    }
+
+    // Postgres folds unquoted identifiers to lowercase. We fold slot and publication
+    // names the same way so the existence check, CREATE, and START_REPLICATION all
+    // reference one name; a mixed-case name would be created folded but never
+    // re-found, so CREATE would fail "already exists" on every restart (a crash loop).
+    fn lowerName(self: *Self, name: []const u8) ReplicationError![]u8 {
+        return std.ascii.allocLowerString(self.allocator, name) catch return ReplicationError.OutOfMemory;
+    }
+
+    // The snapshot marker publication name, derived from the streaming publication.
+    fn markerName(self: *Self) ReplicationError![]u8 {
+        const pub_name = try self.lowerName(self.publication_name);
+        defer self.allocator.free(pub_name);
+        return std.fmt.allocPrint(self.allocator, "{s}_snapshotting", .{pub_name}) catch return ReplicationError.OutOfMemory;
+    }
+
+    // Existence probe: true if any row matches `column = 'name'` in `relation`.
+    fn objectExists(self: *Self, relation: []const u8, column: []const u8, name: []const u8) ReplicationError!bool {
+        const sql = std.fmt.allocPrintSentinel(self.allocator, "SELECT 1 FROM {s} WHERE {s} = '{s}'", .{ relation, column, name }, 0) catch return ReplicationError.OutOfMemory;
+        defer self.allocator.free(sql);
+
+        const result = c.PQexec(self.connection, sql.ptr);
+        defer c.PQclear(result);
+        if (c.PQresultStatus(result) != c.PGRES_TUPLES_OK) {
+            std.log.warn("Existence check failed: {s}", .{c.PQresultErrorMessage(result)});
+            return ReplicationError.ConnectionFailed;
+        }
+        return c.PQntuples(result) > 0;
+    }
+
+    // Run a command that returns no rows (CREATE/DROP), failing on a non-OK status.
+    // Accepts TUPLES_OK too, since some replication commands report a result set.
+    fn execSimple(self: *Self, sql: [*:0]const u8, ctx: []const u8) ReplicationError!void {
+        const result = c.PQexec(self.connection, sql);
+        defer c.PQclear(result);
+        const status = c.PQresultStatus(result);
+        if (status != c.PGRES_COMMAND_OK and status != c.PGRES_TUPLES_OK) {
+            std.log.warn("{s} failed: {s}", .{ ctx, c.PQresultErrorMessage(result) });
+            return ReplicationError.ConnectionFailed;
         }
     }
 

--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -301,7 +301,6 @@ pub const ReplicationProtocol = struct {
         return std.ascii.allocLowerString(self.allocator, name) catch return ReplicationError.OutOfMemory;
     }
 
-    // The snapshot marker publication name, derived from the streaming publication.
     // Named after the slot, not the publication: the marker guards the slot's
     // bootstrap, and several pipelines can share one FOR ALL TABLES publication while
     // each owns its slot. Keying it on the publication would let one pipeline drop a

--- a/src/source/postgres/replication_protocol.zig
+++ b/src/source/postgres/replication_protocol.zig
@@ -302,10 +302,14 @@ pub const ReplicationProtocol = struct {
     }
 
     // The snapshot marker publication name, derived from the streaming publication.
+    // Named after the slot, not the publication: the marker guards the slot's
+    // bootstrap, and several pipelines can share one FOR ALL TABLES publication while
+    // each owns its slot. Keying it on the publication would let one pipeline drop a
+    // marker guarding another's unfinished snapshot.
     fn markerName(self: *Self) ReplicationError![]u8 {
-        const pub_name = try self.lowerName(self.publication_name);
-        defer self.allocator.free(pub_name);
-        return std.fmt.allocPrint(self.allocator, "{s}_snapshotting", .{pub_name}) catch return ReplicationError.OutOfMemory;
+        const slot_name = try self.lowerName(self.slot_name);
+        defer self.allocator.free(slot_name);
+        return std.fmt.allocPrint(self.allocator, "{s}_snapshotting", .{slot_name}) catch return ReplicationError.OutOfMemory;
     }
 
     // Existence probe: true if any row matches `column = 'name'` in `relation`.

--- a/src/source/postgres/snapshot.zig
+++ b/src/source/postgres/snapshot.zig
@@ -17,15 +17,15 @@ pub const SnapshotError = error{
     OutOfMemory,
 };
 
-// One cursor is open at a time (close before opening the next table), so a fixed
-// name is enough.
+// One cursor is open at a time (the session reads resources one after another), so
+// a fixed name is enough.
 const cursor_name = "outboxx_snapshot_cursor";
 
 /// A snapshot session: a regular (non-replication) connection inside a REPEATABLE READ
 /// transaction bound to the slot's exported snapshot. It reads the database exactly as
 /// of the slot's start, so existing rows can be emitted as READ events before streaming
-/// begins (#49). Open one `TableSnapshot` per resource to pull its rows.
-pub const SnapshotReader = struct {
+/// begins (#49). `next` walks the resources in order, one cursor at a time.
+pub const SnapshotSession = struct {
     allocator: std.mem.Allocator,
     // Snapshot exported by CREATE_REPLICATION_SLOT. The session that exported it must
     // stay open until `connect` binds this transaction to it.
@@ -35,23 +35,36 @@ pub const SnapshotReader = struct {
     lsn: []const u8,
     // Wall-clock start of the snapshot, stamped as meta.timestamp on every READ row.
     timestamp: i64,
+    // Borrowed from the caller; must outlive the session.
+    resources: []const []const u8,
     connection: ?*c.PGconn = null,
+    // Resource being read now; equals resources.len once every one is drained.
+    current: usize = 0,
+    cursor_open: bool = false,
 
     const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator, snapshot_name: []const u8, lsn: []const u8, timestamp: i64) Self {
+    pub fn init(
+        allocator: std.mem.Allocator,
+        snapshot_name: []const u8,
+        lsn: []const u8,
+        timestamp: i64,
+        resources: []const []const u8,
+    ) Self {
         return .{
             .allocator = allocator,
             .snapshot_name = snapshot_name,
             .lsn = lsn,
             .timestamp = timestamp,
+            .resources = resources,
         };
     }
 
     pub fn deinit(self: *Self) void {
         if (self.connection) |conn| {
             // The read-only snapshot transaction has nothing to persist; closing the
-            // connection rolls it back server-side, so there is no command to run here.
+            // connection rolls it back server-side and drops any open cursor with it,
+            // so there is no command to run here.
             c.PQfinish(conn);
             self.connection = null;
         }
@@ -86,9 +99,49 @@ pub const SnapshotReader = struct {
         try self.execCommand(set_snapshot.ptr);
     }
 
-    /// Open a cursor over one resource. The returned TableSnapshot borrows this reader
-    /// and `resource`; close it before opening the next.
-    pub fn open(self: *Self, resource: []const u8) SnapshotError!TableSnapshot {
+    /// Fetch up to `limit` more rows as READ events allocated in `allocator`, moving on
+    /// to the next resource when the current one runs out. An empty slice means every
+    /// resource has been read. The caller owns the batch and frees it before the next
+    /// call.
+    pub fn next(self: *Self, allocator: std.mem.Allocator, limit: usize) SnapshotError![]ChangeEvent {
+        const conn = self.connection orelse return error.ConnectionFailed;
+
+        while (self.current < self.resources.len) {
+            if (!self.cursor_open) {
+                try self.declareCursor(self.resources[self.current]);
+                self.cursor_open = true;
+            }
+
+            const sql = std.fmt.allocPrintSentinel(self.allocator, "FETCH FORWARD {d} FROM " ++ cursor_name, .{limit}, 0) catch return error.OutOfMemory;
+            defer self.allocator.free(sql);
+
+            const result = c.PQexec(conn, sql.ptr) orelse return error.OutOfMemory;
+            defer c.PQclear(result);
+            if (c.PQresultStatus(result) != c.PGRES_TUPLES_OK) {
+                std.log.warn("Snapshot fetch failed: {s}", .{c.PQresultErrorMessage(result)});
+                return error.QueryFailed;
+            }
+
+            const n_rows: usize = @intCast(c.PQntuples(result));
+            if (n_rows == 0) {
+                try self.execCommand("CLOSE " ++ cursor_name);
+                self.cursor_open = false;
+                self.current += 1;
+                continue;
+            }
+
+            const n_cols: usize = @intCast(c.PQnfields(result));
+            const events = allocator.alloc(ChangeEvent, n_rows) catch return error.OutOfMemory;
+            for (0..n_rows) |row| {
+                events[row] = try self.buildEvent(allocator, result, row, n_cols);
+            }
+            return events;
+        }
+
+        return allocator.alloc(ChangeEvent, 0) catch return error.OutOfMemory;
+    }
+
+    fn declareCursor(self: *Self, resource: []const u8) SnapshotError!void {
         // resource is the operator-controlled, config-validated schema.table (the same
         // trust as validator.zig's to_regclass interpolation). DECLARE needs a real
         // identifier, not a string literal, so it goes straight into the FROM clause.
@@ -96,7 +149,41 @@ pub const SnapshotReader = struct {
         defer self.allocator.free(sql);
 
         try self.execCommand(sql.ptr);
-        return .{ .reader = self, .resource = resource };
+    }
+
+    // Build one READ event from a result row. Columns come back in text format, the
+    // same shape mapValue promotes for streamed changes, so a READ row and an INSERT
+    // of the same row serialize identically.
+    fn buildEvent(self: *Self, allocator: std.mem.Allocator, result: *c.PGresult, row: usize, n_cols: usize) SnapshotError!ChangeEvent {
+        const row_c: c_int = @intCast(row);
+
+        // Arena-backed batch: the caller frees the whole batch at once, so no
+        // per-field cleanup on the error path here.
+        var builder = RowDataHelpers.createBuilder(allocator);
+        for (0..n_cols) |col| {
+            const col_c: c_int = @intCast(col);
+            const name = std.mem.span(c.PQfname(result, col_c));
+
+            const value: FieldValue = if (c.PQgetisnull(result, row_c, col_c) != 0)
+                FieldValueHelpers.null_value()
+            else blk: {
+                const oid: u32 = @intCast(c.PQftype(result, col_c));
+                const text = std.mem.span(c.PQgetvalue(result, row_c, col_c));
+                break :blk try mapValue(allocator, oid, text);
+            };
+
+            try RowDataHelpers.put(&builder, allocator, name, value);
+        }
+        const row_data = try RowDataHelpers.finalize(&builder, allocator);
+
+        var event = ChangeEvent.init(ChangeOperation.READ, .{
+            .source = try allocator.dupe(u8, "postgres"),
+            .resource = try allocator.dupe(u8, self.resources[self.current]),
+            .timestamp = self.timestamp,
+            .lsn = try allocator.dupe(u8, self.lsn),
+        });
+        event.setInsertData(row_data);
+        return event;
     }
 
     // Run a command (or a query whose rows we ignore), failing on a non-OK status.
@@ -111,81 +198,5 @@ pub const SnapshotReader = struct {
             std.log.warn("Snapshot command failed: {s}", .{c.PQresultErrorMessage(result)});
             return error.QueryFailed;
         }
-    }
-};
-
-/// An open cursor over one resource. Pull rows with `next` until it returns null, then
-/// `close`. Both borrow the SnapshotReader that produced it.
-pub const TableSnapshot = struct {
-    reader: *SnapshotReader,
-    resource: []const u8,
-
-    const Self = @This();
-
-    /// Fetch up to `limit` more rows as READ events allocated in `batch_allocator`;
-    /// returns null once the cursor is exhausted. The caller owns the batch and frees
-    /// `batch_allocator` before the next call.
-    pub fn next(self: *Self, batch_allocator: std.mem.Allocator, limit: usize) SnapshotError!?[]ChangeEvent {
-        const conn = self.reader.connection orelse return error.ConnectionFailed;
-
-        const sql = std.fmt.allocPrintSentinel(self.reader.allocator, "FETCH FORWARD {d} FROM " ++ cursor_name, .{limit}, 0) catch return error.OutOfMemory;
-        defer self.reader.allocator.free(sql);
-
-        const result = c.PQexec(conn, sql.ptr) orelse return error.OutOfMemory;
-        defer c.PQclear(result);
-        if (c.PQresultStatus(result) != c.PGRES_TUPLES_OK) {
-            std.log.warn("Snapshot fetch failed: {s}", .{c.PQresultErrorMessage(result)});
-            return error.QueryFailed;
-        }
-
-        const n_rows: usize = @intCast(c.PQntuples(result));
-        if (n_rows == 0) return null; // cursor drained
-
-        const n_cols: usize = @intCast(c.PQnfields(result));
-
-        const events = batch_allocator.alloc(ChangeEvent, n_rows) catch return error.OutOfMemory;
-        for (0..n_rows) |row| {
-            events[row] = try self.buildEvent(batch_allocator, result, row, n_cols);
-        }
-        return events;
-    }
-
-    pub fn close(self: *Self) SnapshotError!void {
-        try self.reader.execCommand("CLOSE " ++ cursor_name);
-    }
-
-    // Build one READ event from a result row. Columns come back in text format, the
-    // same shape mapValue promotes for streamed changes, so a READ row and an INSERT
-    // of the same row serialize identically.
-    fn buildEvent(self: *Self, batch_allocator: std.mem.Allocator, result: *c.PGresult, row: usize, n_cols: usize) SnapshotError!ChangeEvent {
-        const row_c: c_int = @intCast(row);
-
-        // Arena-backed batch: the caller frees the whole batch at once, so no
-        // per-field cleanup on the error path here.
-        var builder = RowDataHelpers.createBuilder(batch_allocator);
-        for (0..n_cols) |col| {
-            const col_c: c_int = @intCast(col);
-            const name = std.mem.span(c.PQfname(result, col_c));
-
-            const value: FieldValue = if (c.PQgetisnull(result, row_c, col_c) != 0)
-                FieldValueHelpers.null_value()
-            else blk: {
-                const oid: u32 = @intCast(c.PQftype(result, col_c));
-                const text = std.mem.span(c.PQgetvalue(result, row_c, col_c));
-                break :blk try mapValue(batch_allocator, oid, text);
-            };
-
-            try RowDataHelpers.put(&builder, batch_allocator, name, value);
-        }
-        const row_data = try RowDataHelpers.finalize(&builder, batch_allocator);
-
-        var event = ChangeEvent.init(ChangeOperation.READ, .{
-            .source = try batch_allocator.dupe(u8, "postgres"),
-            .resource = try batch_allocator.dupe(u8, self.resource),
-            .timestamp = self.reader.timestamp,
-            .lsn = try batch_allocator.dupe(u8, self.reader.lsn),
-        });
-        event.setInsertData(row_data);
-        return event;
     }
 };

--- a/src/source/postgres/snapshot_test.zig
+++ b/src/source/postgres/snapshot_test.zig
@@ -8,8 +8,17 @@ const domain = @import("../../domain/change_event.zig");
 const RowDataHelpers = domain.RowDataHelpers;
 
 const SnapshotReader = @import("snapshot.zig").SnapshotReader;
+const PostgresSource = @import("source.zig").PostgresSource;
 
 const c = @import("c"); // C bindings (build-system translate-c)
+
+fn publicationExists(conn: *c.PGconn, allocator: std.mem.Allocator, name: []const u8) !bool {
+    const sql = try std.fmt.allocPrintSentinel(allocator, "SELECT 1 FROM pg_publication WHERE pubname = '{s}'", .{name}, 0);
+    defer allocator.free(sql);
+    const result = c.PQexec(conn, sql.ptr);
+    defer c.PQclear(result);
+    return c.PQntuples(result) > 0;
+}
 
 fn createSetupConnection(allocator: std.mem.Allocator) !*c.PGconn {
     const conn_str = try getTestConnectionString(allocator);
@@ -181,4 +190,103 @@ test "SnapshotReader: empty table yields no events" {
 
     try testing.expect((try table.next(arena.allocator(), 10)) == null);
     try table.close();
+}
+
+test "reconciliation: an interrupted snapshot drops the orphaned slot and recreates it" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+
+    const suffix = test_helpers.nowMicros(io);
+    const slot_name = try std.fmt.allocPrint(allocator, "recon_slot_{d}", .{suffix});
+    defer allocator.free(slot_name);
+    const pub_name = try std.fmt.allocPrint(allocator, "recon_pub_{d}", .{suffix});
+    defer allocator.free(pub_name);
+    const marker_name = try std.fmt.allocPrint(allocator, "{s}_snapshotting", .{pub_name});
+    defer allocator.free(marker_name);
+
+    const conn_str = try getTestConnectionString(allocator);
+    defer allocator.free(conn_str);
+
+    const setup_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(setup_conn);
+    defer {
+        const drop = std.fmt.allocPrintSentinel(allocator, "SELECT pg_drop_replication_slot('{s}') FROM pg_replication_slots WHERE slot_name='{s}'; DROP PUBLICATION IF EXISTS {s}; DROP PUBLICATION IF EXISTS {s};", .{ slot_name, slot_name, pub_name, marker_name }, 0) catch unreachable;
+        defer allocator.free(drop);
+        _ = c.PQexec(setup_conn, drop.ptr);
+    }
+
+    // First bootstrap: creates the streaming publication, the snapshot marker, and
+    // the slot, then "crashes" (deinit without finishSnapshot or streaming).
+    const first_lsn = blk: {
+        var source = PostgresSource.init(allocator, slot_name, pub_name);
+        defer source.deinit();
+        try source.connect(conn_str, true);
+        try testing.expect(source.startLsn() != null); // fresh slot
+        break :blk try allocator.dupe(u8, source.startLsn().?);
+    };
+    defer allocator.free(first_lsn);
+
+    // Marker and slot survive the crash: the bootstrap is not marked complete.
+    try testing.expect(try publicationExists(setup_conn, allocator, marker_name));
+
+    // Move the WAL so a recreated slot lands on a later consistent point.
+    try execSQL(setup_conn, "SELECT pg_logical_emit_message(true, 'outboxx', 'recon')");
+
+    // Second start with the same names: the marker signals an interrupted snapshot,
+    // so the orphaned slot is dropped and a fresh one is created.
+    {
+        var source = PostgresSource.init(allocator, slot_name, pub_name);
+        defer source.deinit();
+        try source.connect(conn_str, true);
+        try testing.expect(source.startLsn() != null); // redo -> a fresh slot
+        try testing.expect(!std.mem.eql(u8, first_lsn, source.startLsn().?));
+    }
+
+    // Still mid-bootstrap: the marker stays until a snapshot completes.
+    try testing.expect(try publicationExists(setup_conn, allocator, marker_name));
+}
+
+test "reconciliation: a completed snapshot resumes without recreating the slot" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+
+    const suffix = test_helpers.nowMicros(io);
+    const slot_name = try std.fmt.allocPrint(allocator, "recon_done_slot_{d}", .{suffix});
+    defer allocator.free(slot_name);
+    const pub_name = try std.fmt.allocPrint(allocator, "recon_done_pub_{d}", .{suffix});
+    defer allocator.free(pub_name);
+    const marker_name = try std.fmt.allocPrint(allocator, "{s}_snapshotting", .{pub_name});
+    defer allocator.free(marker_name);
+
+    const conn_str = try getTestConnectionString(allocator);
+    defer allocator.free(conn_str);
+
+    const setup_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(setup_conn);
+    defer {
+        const drop = std.fmt.allocPrintSentinel(allocator, "SELECT pg_drop_replication_slot('{s}') FROM pg_replication_slots WHERE slot_name='{s}'; DROP PUBLICATION IF EXISTS {s}; DROP PUBLICATION IF EXISTS {s};", .{ slot_name, slot_name, pub_name, marker_name }, 0) catch unreachable;
+        defer allocator.free(drop);
+        _ = c.PQexec(setup_conn, drop.ptr);
+    }
+
+    // First bootstrap that completes: finishSnapshot drops the marker.
+    {
+        var source = PostgresSource.init(allocator, slot_name, pub_name);
+        defer source.deinit();
+        try source.connect(conn_str, true);
+        try testing.expect(source.startLsn() != null);
+        try source.finishSnapshot();
+    }
+
+    // Marker gone, streaming publication remains: steady state is one publication.
+    try testing.expect(!try publicationExists(setup_conn, allocator, marker_name));
+    try testing.expect(try publicationExists(setup_conn, allocator, pub_name));
+
+    // Second start: slot exists and no marker -> resume, no re-snapshot.
+    {
+        var source = PostgresSource.init(allocator, slot_name, pub_name);
+        defer source.deinit();
+        try source.connect(conn_str, true);
+        try testing.expect(source.startLsn() == null); // resumed, not recreated
+    }
 }

--- a/src/source/postgres/snapshot_test.zig
+++ b/src/source/postgres/snapshot_test.zig
@@ -277,7 +277,7 @@ test "reconciliation: an interrupted snapshot drops the orphaned slot and recrea
     defer allocator.free(slot_name);
     const pub_name = try std.fmt.allocPrint(allocator, "recon_pub_{d}", .{suffix});
     defer allocator.free(pub_name);
-    const marker_name = try std.fmt.allocPrint(allocator, "{s}_snapshotting", .{pub_name});
+    const marker_name = try std.fmt.allocPrint(allocator, "{s}_snapshotting", .{slot_name});
     defer allocator.free(marker_name);
 
     const conn_str = try getTestConnectionString(allocator);
@@ -331,7 +331,7 @@ test "reconciliation: a completed snapshot resumes without recreating the slot" 
     defer allocator.free(slot_name);
     const pub_name = try std.fmt.allocPrint(allocator, "recon_done_pub_{d}", .{suffix});
     defer allocator.free(pub_name);
-    const marker_name = try std.fmt.allocPrint(allocator, "{s}_snapshotting", .{pub_name});
+    const marker_name = try std.fmt.allocPrint(allocator, "{s}_snapshotting", .{slot_name});
     defer allocator.free(marker_name);
 
     const conn_str = try getTestConnectionString(allocator);

--- a/src/source/postgres/snapshot_test.zig
+++ b/src/source/postgres/snapshot_test.zig
@@ -296,7 +296,7 @@ test "reconciliation: an interrupted snapshot drops the orphaned slot and recrea
     const first_lsn = blk: {
         var source = PostgresSource.init(allocator, slot_name, pub_name);
         defer source.deinit();
-        try source.connect(conn_str, true);
+        try source.connect(conn_str, .with_snapshot);
         try testing.expect(source.startLsn() != null); // fresh slot
         break :blk try allocator.dupe(u8, source.startLsn().?);
     };
@@ -313,7 +313,7 @@ test "reconciliation: an interrupted snapshot drops the orphaned slot and recrea
     {
         var source = PostgresSource.init(allocator, slot_name, pub_name);
         defer source.deinit();
-        try source.connect(conn_str, true);
+        try source.connect(conn_str, .with_snapshot);
         try testing.expect(source.startLsn() != null); // redo -> a fresh slot
         try testing.expect(!std.mem.eql(u8, first_lsn, source.startLsn().?));
     }
@@ -349,7 +349,7 @@ test "reconciliation: a completed snapshot resumes without recreating the slot" 
     {
         var source = PostgresSource.init(allocator, slot_name, pub_name);
         defer source.deinit();
-        try source.connect(conn_str, true);
+        try source.connect(conn_str, .with_snapshot);
         try testing.expect(source.startLsn() != null);
         try source.finishSnapshot();
     }
@@ -362,7 +362,7 @@ test "reconciliation: a completed snapshot resumes without recreating the slot" 
     {
         var source = PostgresSource.init(allocator, slot_name, pub_name);
         defer source.deinit();
-        try source.connect(conn_str, true);
+        try source.connect(conn_str, .with_snapshot);
         try testing.expect(source.startLsn() == null); // resumed, not recreated
     }
 }

--- a/src/source/postgres/snapshot_test.zig
+++ b/src/source/postgres/snapshot_test.zig
@@ -7,7 +7,7 @@ const getTestConnectionString = test_helpers.getTestConnectionString;
 const domain = @import("../../domain/change_event.zig");
 const RowDataHelpers = domain.RowDataHelpers;
 
-const SnapshotReader = @import("snapshot.zig").SnapshotReader;
+const SnapshotSession = @import("snapshot.zig").SnapshotSession;
 const PostgresSource = @import("source.zig").PostgresSource;
 
 const c = @import("c"); // C bindings (build-system translate-c)
@@ -44,7 +44,7 @@ fn execSQL(conn: *c.PGconn, sql: [:0]const u8) !void {
     }
 }
 
-test "SnapshotReader: reads existing rows as READ events, consistent with the exported snapshot" {
+test "SnapshotSession: reads existing rows as READ events, consistent with the exported snapshot" {
     const allocator = testing.allocator;
     const io = testing.io;
 
@@ -102,10 +102,10 @@ test "SnapshotReader: reads existing rows as READ events, consistent with the ex
     const lsn = "0/15D6E10";
     const timestamp = test_helpers.nowSeconds(io);
 
-    var reader = SnapshotReader.init(allocator, snapshot_name, lsn, timestamp);
-    defer reader.deinit();
-    try reader.connect(conn_str);
-    var table = try reader.open(resource);
+    const resources = [_][]const u8{resource};
+    var session = SnapshotSession.init(allocator, snapshot_name, lsn, timestamp, &resources);
+    defer session.deinit();
+    try session.connect(conn_str);
 
     // One arena for the whole read; a small fetch limit forces several FETCH round
     // trips over the five rows.
@@ -114,7 +114,10 @@ test "SnapshotReader: reads existing rows as READ events, consistent with the ex
 
     var seen = [_]bool{false} ** 7; // ids 1..5 expected; 6 must stay unseen
     var total: usize = 0;
-    while (try table.next(arena.allocator(), 2)) |events| {
+    while (true) {
+        const events = try session.next(arena.allocator(), 2);
+        if (events.len == 0) break;
+
         for (events) |event| {
             try testing.expectEqualStrings("READ", event.op);
             try testing.expectEqualStrings(resource, event.meta.resource);
@@ -140,14 +143,13 @@ test "SnapshotReader: reads existing rows as READ events, consistent with the ex
             total += 1;
         }
     }
-    try table.close();
 
     try testing.expectEqual(@as(usize, 5), total);
     for (1..6) |i| try testing.expect(seen[i]);
     try testing.expect(!seen[6]);
 }
 
-test "SnapshotReader: empty table yields no events" {
+test "SnapshotSession: empty table yields no events" {
     const allocator = testing.allocator;
     const io = testing.io;
 
@@ -180,16 +182,90 @@ test "SnapshotReader: empty table yields no events" {
     const conn_str = try getTestConnectionString(allocator);
     defer allocator.free(conn_str);
 
-    var reader = SnapshotReader.init(allocator, snapshot_name, "0/0", test_helpers.nowSeconds(io));
-    defer reader.deinit();
-    try reader.connect(conn_str);
-    var table = try reader.open(resource);
+    const resources = [_][]const u8{resource};
+    var session = SnapshotSession.init(allocator, snapshot_name, "0/0", test_helpers.nowSeconds(io), &resources);
+    defer session.deinit();
+    try session.connect(conn_str);
 
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
-    try testing.expect((try table.next(arena.allocator(), 10)) == null);
-    try table.close();
+    try testing.expectEqual(@as(usize, 0), (try session.next(arena.allocator(), 10)).len);
+}
+
+test "SnapshotSession: reads several resources in one session" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+
+    const suffix = test_helpers.nowMicros(io);
+    const first_table = try std.fmt.allocPrint(allocator, "snap_multi_a_{d}", .{suffix});
+    defer allocator.free(first_table);
+    const second_table = try std.fmt.allocPrint(allocator, "snap_multi_b_{d}", .{suffix});
+    defer allocator.free(second_table);
+
+    const first_resource = try std.fmt.allocPrint(allocator, "public.{s}", .{first_table});
+    defer allocator.free(first_resource);
+    const second_resource = try std.fmt.allocPrint(allocator, "public.{s}", .{second_table});
+    defer allocator.free(second_resource);
+
+    const setup_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(setup_conn);
+    defer {
+        const drop = std.fmt.allocPrintSentinel(allocator, "DROP TABLE IF EXISTS {s}; DROP TABLE IF EXISTS {s};", .{ first_table, second_table }, 0) catch unreachable;
+        defer allocator.free(drop);
+        execSQL(setup_conn, drop) catch {};
+    }
+
+    // Two rows each, so a fetch limit of 1 forces the session to cross from one
+    // cursor to the next mid-read.
+    for ([_][]const u8{ first_table, second_table }) |table| {
+        const create = try test_helpers.formatSqlZ(allocator, "CREATE TABLE {s} (id SERIAL PRIMARY KEY, name TEXT)", .{table});
+        defer allocator.free(create);
+        try execSQL(setup_conn, create);
+
+        const seed = try test_helpers.formatSqlZ(allocator, "INSERT INTO {s} (name) VALUES ('one'), ('two')", .{table});
+        defer allocator.free(seed);
+        try execSQL(setup_conn, seed);
+    }
+
+    const export_conn = try createSetupConnection(allocator);
+    defer c.PQfinish(export_conn);
+    try execSQL(export_conn, "BEGIN ISOLATION LEVEL REPEATABLE READ");
+    const export_result = c.PQexec(export_conn, "SELECT pg_export_snapshot()");
+    defer c.PQclear(export_result);
+    const snapshot_name = try allocator.dupe(u8, std.mem.span(c.PQgetvalue(export_result, 0, 0)));
+    defer allocator.free(snapshot_name);
+
+    const conn_str = try getTestConnectionString(allocator);
+    defer allocator.free(conn_str);
+
+    const resources = [_][]const u8{ first_resource, second_resource };
+    var session = SnapshotSession.init(allocator, snapshot_name, "0/0", test_helpers.nowSeconds(io), &resources);
+    defer session.deinit();
+    try session.connect(conn_str);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    var per_resource = [_]usize{ 0, 0 };
+    while (true) {
+        const events = try session.next(arena.allocator(), 1);
+        if (events.len == 0) break;
+
+        for (events) |event| {
+            try testing.expectEqualStrings("READ", event.op);
+            if (std.mem.eql(u8, event.meta.resource, first_resource)) {
+                per_resource[0] += 1;
+            } else if (std.mem.eql(u8, event.meta.resource, second_resource)) {
+                per_resource[1] += 1;
+            } else {
+                return error.UnexpectedResource;
+            }
+        }
+    }
+
+    try testing.expectEqual(@as(usize, 2), per_resource[0]);
+    try testing.expectEqual(@as(usize, 2), per_resource[1]);
 }
 
 test "reconciliation: an interrupted snapshot drops the orphaned slot and recreates it" {

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -64,6 +64,9 @@ pub const PostgresSourceError = error{
     ReplicationFailed,
     DecodeFailed,
     ConversionFailed,
+    // openSnapshot without a bootstrap to run (see needsBootstrap), or a snapshot
+    // batch requested outside an open session.
+    SnapshotUnavailable,
     OutOfMemory,
 };
 
@@ -180,15 +183,18 @@ pub const PostgresSource = struct {
         self.protocol.createSlot() catch return PostgresSourceError.ConnectionFailed;
     }
 
-    /// Open an initial-snapshot session over `resources` and report whether one is
-    /// running. False means this run has nothing to bootstrap, so the caller goes
-    /// straight to streaming: either the slot already existed (no exported snapshot)
-    /// or no resource was asked for. The `resources` slice is copied; the names in it
-    /// are borrowed and must outlive the snapshot.
-    pub fn openSnapshot(self: *Self, io: std.Io, resources: []const []const u8) PostgresSourceError!bool {
-        const snapshot_name = self.protocol.snapshotName() orelse return false;
-        if (resources.len == 0) return false;
+    /// Whether this run still has to bootstrap: the slot was created now, so its
+    /// exported snapshot can still be read. False when the slot already existed, which
+    /// means it carries a confirmed position and streaming just resumes from it.
+    pub fn needsBootstrap(self: *const Self) bool {
+        return self.protocol.snapshotName() != null;
+    }
 
+    /// Open an initial-snapshot session over `resources`, to be drained with
+    /// receiveSnapshotBatch. Call only while needsBootstrap holds. The `resources`
+    /// slice is copied; the names in it are borrowed and must outlive the snapshot.
+    pub fn openSnapshot(self: *Self, io: std.Io, resources: []const []const u8) PostgresSourceError!void {
+        const snapshot_name = self.protocol.snapshotName() orelse return PostgresSourceError.SnapshotUnavailable;
         const conninfo = self.conninfo orelse return PostgresSourceError.ConnectionFailed;
 
         const owned_resources = self.allocator.dupe([]const u8, resources) catch return PostgresSourceError.OutOfMemory;
@@ -211,15 +217,13 @@ pub const PostgresSource = struct {
 
         self.snapshot_resources = owned_resources;
         self.snapshot = session;
-        return true;
     }
 
     /// Receive a batch of snapshot rows as READ changes, shaped like receiveBatch. An
     /// empty batch means every resource has been read out, so the caller can finish the
-    /// snapshot and move on to streaming. Call only while openSnapshot reported a
-    /// running session.
+    /// snapshot and move on to streaming. Call only after openSnapshot.
     pub fn receiveSnapshotBatch(self: *Self, allocator: std.mem.Allocator, limit: usize) PostgresSourceError!Batch {
-        const session = if (self.snapshot) |*s| s else return PostgresSourceError.ConnectionFailed;
+        const session = if (self.snapshot) |*s| s else return PostgresSourceError.SnapshotUnavailable;
 
         const changes = session.next(allocator, limit) catch |err| switch (err) {
             error.OutOfMemory => return PostgresSourceError.OutOfMemory,

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -145,6 +145,13 @@ pub const PostgresSource = struct {
         return self.protocol.startLsn();
     }
 
+    /// The slot's exported snapshot name when it was created in this run, or null
+    /// if the slot already existed. Present only alongside a fresh startLsn, so it
+    /// gates the initial snapshot. Valid until streaming starts on this connection.
+    pub fn snapshotName(self: *const Self) ?[]const u8 {
+        return self.protocol.snapshotName();
+    }
+
     /// Receive batch of changes from PostgreSQL (default wait time from constants)
     /// Wrapper for compatibility with polling source API
     pub fn receiveBatch(self: *Self, io: std.Io, batch_allocator: std.mem.Allocator, limit: usize) PostgresSourceError!Batch {

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -129,7 +129,7 @@ pub const PostgresSource = struct {
     /// Connect to PostgreSQL and ensure the publication and replication slot exist,
     /// without starting the stream, so a caller can run an initial snapshot between
     /// slot creation and streaming. On a freshly created slot the start LSN and
-    /// exported snapshot are captured here (see startLsn/snapshotName).
+    /// exported snapshot are captured here (see startLsn/needsBootstrap).
     ///
     /// `want_snapshot` says whether this run may run an initial snapshot, which
     /// drives interrupted-snapshot recovery (see ensureSlot).
@@ -286,13 +286,6 @@ pub const PostgresSource = struct {
     /// already existed (pass "0/0" to resume from its confirmed position).
     pub fn startLsn(self: *const Self) ?[]const u8 {
         return self.protocol.startLsn();
-    }
-
-    /// The slot's exported snapshot name when it was created in this run, or null
-    /// if the slot already existed. Present only alongside a fresh startLsn, so it
-    /// gates the initial snapshot. Valid until streaming starts on this connection.
-    pub fn snapshotName(self: *const Self) ?[]const u8 {
-        return self.protocol.snapshotName();
     }
 
     /// Receive batch of changes from PostgreSQL (default wait time from constants)

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -100,6 +100,19 @@ pub const PostgresSource = struct {
 
     const Self = @This();
 
+    /// What connect should prepare the slot for. Passing `stream_only` on a run that
+    /// may snapshot clears the marker, which would read an interrupted bootstrap as a
+    /// completed one.
+    pub const Bootstrap = enum {
+        /// This run may read an initial snapshot, so reconcile the slot against the
+        /// marker: one left by an interrupted bootstrap discards the slot and starts
+        /// over from a fresh consistent point.
+        with_snapshot,
+        /// This run only streams. An existing slot is resumed as is, so its confirmed
+        /// position survives.
+        stream_only,
+    };
+
     /// Initialize streaming source
     pub fn init(
         allocator: std.mem.Allocator,
@@ -131,9 +144,9 @@ pub const PostgresSource = struct {
     /// slot creation and streaming. On a freshly created slot the start LSN and
     /// exported snapshot are captured here (see startLsn/needsBootstrap).
     ///
-    /// `want_snapshot` says whether this run may run an initial snapshot, which
-    /// drives interrupted-snapshot recovery (see ensureSlot).
-    pub fn connect(self: *Self, connection_string: []const u8, want_snapshot: bool) PostgresSourceError!void {
+    /// `bootstrap` says whether this run may read an initial snapshot, which drives
+    /// interrupted-snapshot recovery (see ensureSlot).
+    pub fn connect(self: *Self, connection_string: []const u8, bootstrap: Bootstrap) PostgresSourceError!void {
         self.conninfo = self.allocator.dupe(u8, connection_string) catch return PostgresSourceError.OutOfMemory;
 
         self.protocol.connect(connection_string) catch |err| {
@@ -148,7 +161,7 @@ pub const PostgresSource = struct {
             return PostgresSourceError.ConnectionFailed;
         };
 
-        try self.ensureSlot(want_snapshot);
+        try self.ensureSlot(bootstrap);
     }
 
     // Reconcile the replication slot for this run using the snapshot marker as a
@@ -162,10 +175,10 @@ pub const PostgresSource = struct {
     // The marker is created before the slot, so a crash between the two leaves
     // "no slot, marker present", which reads as a fresh bootstrap, never a false
     // "completed".
-    fn ensureSlot(self: *Self, want_snapshot: bool) PostgresSourceError!void {
+    fn ensureSlot(self: *Self, bootstrap: Bootstrap) PostgresSourceError!void {
         const slot_exists = self.protocol.slotExists() catch return PostgresSourceError.ConnectionFailed;
 
-        if (!want_snapshot) {
+        if (bootstrap == .stream_only) {
             self.protocol.dropSnapshotMarker() catch return PostgresSourceError.ConnectionFailed;
             if (!slot_exists) self.protocol.createSlot() catch return PostgresSourceError.ConnectionFailed;
             return;

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -106,27 +106,66 @@ pub const PostgresSource = struct {
         self.converter.deinit();
     }
 
-    /// Connect to PostgreSQL and ensure the publication and replication slot
-    /// exist, without starting the stream. Split from startReplication so a
-    /// caller can run an initial snapshot between slot creation and streaming;
-    /// on a freshly created slot the start LSN is captured here (see startLsn).
-    pub fn connect(self: *Self, connection_string: []const u8) PostgresSourceError!void {
+    /// Connect to PostgreSQL and ensure the publication and replication slot exist,
+    /// without starting the stream, so a caller can run an initial snapshot between
+    /// slot creation and streaming. On a freshly created slot the start LSN and
+    /// exported snapshot are captured here (see startLsn/snapshotName).
+    ///
+    /// `want_snapshot` says whether this run may run an initial snapshot, which
+    /// drives interrupted-snapshot recovery (see ensureSlot).
+    pub fn connect(self: *Self, connection_string: []const u8, want_snapshot: bool) PostgresSourceError!void {
         self.protocol.connect(connection_string) catch |err| {
             std.log.warn("Failed to connect with replication protocol: {}", .{err});
             return PostgresSourceError.ConnectionFailed;
         };
 
-        // Create publication if it doesn't exist
+        // The streaming publication must exist before the slot, so the slot's start
+        // LSN falls after it and every streamed change decodes (see the protocol).
         self.protocol.createPublicationIfNotExists() catch |err| {
             std.log.warn("Failed to create publication: {}", .{err});
             return PostgresSourceError.ConnectionFailed;
         };
 
-        // Create replication slot if it doesn't exist
-        self.protocol.createSlotIfNotExists() catch |err| {
-            std.log.warn("Failed to create replication slot: {}", .{err});
-            return PostgresSourceError.ConnectionFailed;
-        };
+        try self.ensureSlot(want_snapshot);
+    }
+
+    // Reconcile the replication slot for this run using the snapshot marker as a
+    // durable "snapshot in progress" flag (see the protocol's createSnapshotMarker):
+    // - snapshot run, slot present, no marker: a prior bootstrap completed, resume.
+    // - snapshot run, slot present, marker present: the snapshot was interrupted,
+    //   drop the orphaned slot and redo from a fresh consistent point.
+    // - snapshot run, no slot: fresh bootstrap.
+    // - no snapshot: resume an existing slot, create one if absent, and clear any
+    //   stale marker so steady state keeps a single publication.
+    // The marker is created before the slot, so a crash between the two leaves
+    // "no slot, marker present", which reads as a fresh bootstrap, never a false
+    // "completed".
+    fn ensureSlot(self: *Self, want_snapshot: bool) PostgresSourceError!void {
+        const slot_exists = self.protocol.slotExists() catch return PostgresSourceError.ConnectionFailed;
+
+        if (!want_snapshot) {
+            self.protocol.dropSnapshotMarker() catch return PostgresSourceError.ConnectionFailed;
+            if (!slot_exists) self.protocol.createSlot() catch return PostgresSourceError.ConnectionFailed;
+            return;
+        }
+
+        if (slot_exists) {
+            const marker = self.protocol.snapshotMarkerExists() catch return PostgresSourceError.ConnectionFailed;
+            if (!marker) return; // completed bootstrap: resume, no snapshot
+
+            std.log.warn("Snapshot marker present: a prior initial snapshot was interrupted; restarting the bootstrap", .{});
+            self.protocol.dropSlot() catch return PostgresSourceError.ConnectionFailed;
+        }
+
+        self.protocol.createSnapshotMarker() catch return PostgresSourceError.ConnectionFailed;
+        self.protocol.createSlot() catch return PostgresSourceError.ConnectionFailed;
+    }
+
+    /// Drop the snapshot marker once the initial snapshot is flushed, returning
+    /// steady state to a single publication. Idempotent, so it is safe to call even
+    /// when this run ran no snapshot.
+    pub fn finishSnapshot(self: *Self) PostgresSourceError!void {
+        self.protocol.dropSnapshotMarker() catch return PostgresSourceError.ConnectionFailed;
     }
 
     /// Start logical replication from start_lsn. Call after connect.

--- a/src/source/postgres/source.zig
+++ b/src/source/postgres/source.zig
@@ -17,6 +17,8 @@ const relation_registry = @import("relation_registry.zig");
 const converter = @import("converter.zig");
 pub const Converter = converter.Converter;
 
+const SnapshotSession = @import("snapshot.zig").SnapshotSession;
+
 // Re-export types for benchmarks (public API)
 pub const PgOutputMessage = pg_output_decoder.PgOutputMessage;
 pub const InsertMessage = pg_output_decoder.InsertMessage;
@@ -82,6 +84,16 @@ pub const PostgresSource = struct {
     // The stream does not expose the server WAL head during a backlog, so lag is
     // measured as wall-clock time behind this commit, like Debezium.
     last_commit_time: i64,
+    // Owned copy of the conninfo passed to connect. The initial snapshot needs a
+    // second, regular connection (the replication one must stay idle until
+    // START_REPLICATION), so the source keeps the string instead of asking for it
+    // again. Never log it: it carries the password.
+    conninfo: ?[]u8 = null,
+    // Live only between openSnapshot and finishSnapshot.
+    snapshot: ?SnapshotSession = null,
+    // Backs the session's resource list: the caller's slice may go away as soon as
+    // the snapshot is drained, while the session outlives it until finishSnapshot.
+    snapshot_resources: ?[][]const u8 = null,
 
     const Self = @This();
 
@@ -102,6 +114,11 @@ pub const PostgresSource = struct {
     }
 
     pub fn deinit(self: *Self) void {
+        self.closeSnapshot();
+        if (self.conninfo) |conninfo| {
+            self.allocator.free(conninfo);
+            self.conninfo = null;
+        }
         self.protocol.deinit();
         self.converter.deinit();
     }
@@ -114,6 +131,8 @@ pub const PostgresSource = struct {
     /// `want_snapshot` says whether this run may run an initial snapshot, which
     /// drives interrupted-snapshot recovery (see ensureSlot).
     pub fn connect(self: *Self, connection_string: []const u8, want_snapshot: bool) PostgresSourceError!void {
+        self.conninfo = self.allocator.dupe(u8, connection_string) catch return PostgresSourceError.OutOfMemory;
+
         self.protocol.connect(connection_string) catch |err| {
             std.log.warn("Failed to connect with replication protocol: {}", .{err});
             return PostgresSourceError.ConnectionFailed;
@@ -161,11 +180,92 @@ pub const PostgresSource = struct {
         self.protocol.createSlot() catch return PostgresSourceError.ConnectionFailed;
     }
 
-    /// Drop the snapshot marker once the initial snapshot is flushed, returning
-    /// steady state to a single publication. Idempotent, so it is safe to call even
-    /// when this run ran no snapshot.
+    /// Open an initial-snapshot session over `resources` and report whether one is
+    /// running. False means this run has nothing to bootstrap, so the caller goes
+    /// straight to streaming: either the slot already existed (no exported snapshot)
+    /// or no resource was asked for. The `resources` slice is copied; the names in it
+    /// are borrowed and must outlive the snapshot.
+    pub fn openSnapshot(self: *Self, io: std.Io, resources: []const []const u8) PostgresSourceError!bool {
+        const snapshot_name = self.protocol.snapshotName() orelse return false;
+        if (resources.len == 0) return false;
+
+        const conninfo = self.conninfo orelse return PostgresSourceError.ConnectionFailed;
+
+        const owned_resources = self.allocator.dupe([]const u8, resources) catch return PostgresSourceError.OutOfMemory;
+        errdefer self.allocator.free(owned_resources);
+
+        // Every READ row is stamped with the snapshot's wall-clock start and the slot's
+        // start LSN, so a snapshot row and the first streamed change share the dedup
+        // boundary.
+        var session = SnapshotSession.init(
+            self.allocator,
+            snapshot_name,
+            self.protocol.startLsn() orelse "0/0",
+            std.Io.Timestamp.now(io, .real).toSeconds(),
+            owned_resources,
+        );
+        session.connect(conninfo) catch |err| {
+            std.log.warn("Failed to open the snapshot session: {}", .{err});
+            return PostgresSourceError.ConnectionFailed;
+        };
+
+        self.snapshot_resources = owned_resources;
+        self.snapshot = session;
+        return true;
+    }
+
+    /// Receive a batch of snapshot rows as READ changes, shaped like receiveBatch. An
+    /// empty batch means every resource has been read out, so the caller can finish the
+    /// snapshot and move on to streaming. Call only while openSnapshot reported a
+    /// running session.
+    pub fn receiveSnapshotBatch(self: *Self, allocator: std.mem.Allocator, limit: usize) PostgresSourceError!Batch {
+        const session = if (self.snapshot) |*s| s else return PostgresSourceError.ConnectionFailed;
+
+        const changes = session.next(allocator, limit) catch |err| switch (err) {
+            error.OutOfMemory => return PostgresSourceError.OutOfMemory,
+            else => {
+                std.log.warn("Failed to read the initial snapshot: {}", .{err});
+                return PostgresSourceError.ConnectionFailed;
+            },
+        };
+
+        // A snapshot batch carries no WAL position: the slot advances only once the
+        // stream is confirmed, so last_lsn stays 0 and lag/keepalive do not apply.
+        return .{
+            .changes = changes,
+            .last_lsn = 0,
+            .replication_lag_seconds = 0,
+            .received_keepalive = false,
+            .allocator = allocator,
+        };
+    }
+
+    /// Close the snapshot session and drop the marker, returning steady state to a
+    /// single publication. Idempotent, so it is safe to call even when this run ran no
+    /// snapshot.
     pub fn finishSnapshot(self: *Self) PostgresSourceError!void {
+        self.closeSnapshot();
         self.protocol.dropSnapshotMarker() catch return PostgresSourceError.ConnectionFailed;
+    }
+
+    fn closeSnapshot(self: *Self) void {
+        if (self.snapshot) |*session| {
+            session.deinit();
+            self.snapshot = null;
+        }
+        if (self.snapshot_resources) |resources| {
+            self.allocator.free(resources);
+            self.snapshot_resources = null;
+        }
+    }
+
+    /// Finish the bootstrap and start streaming changes: close any snapshot session,
+    /// drop the marker, then replicate from the slot's start LSN (or from its confirmed
+    /// position when the slot already existed). Call only once the snapshot is flushed,
+    /// since starting the stream invalidates the exported snapshot.
+    pub fn startStreaming(self: *Self) PostgresSourceError!void {
+        try self.finishSnapshot();
+        try self.startReplication(self.protocol.startLsn() orelse "0/0");
     }
 
     /// Start logical replication from start_lsn. Call after connect.


### PR DESCRIPTION
Closes the #49 series (PR3 of 3): drives the snapshot reader from #145 at startup and makes an interrupted snapshot safe.

## Problem

Streaming only emits changes made after the slot was created, so a new consumer never sees pre-existing rows. The reader and the READ event landed in #145 but nothing called them.

## Solution

Wiring:
- The snapshot is part of the source interface, not the processor: `needsBootstrap` / `openSnapshot` / `receiveSnapshotBatch` / `startStreaming`. Snapshot rows come back as the same `Batch` the stream returns, and an empty batch ends the phase, so the processor drains it with the streaming loop's shape and never sees slots, cursors, or LSNs.
- Gate: the snapshot runs only when the slot is created this run and at least one stream lists `read`. Only the distinct read-opted resources are snapshotted.
- READ events go through the same match/serialize/partition/produce path as streamed changes (factored into `produceEvent`) and carry the slot's start LSN, so snapshot and stream share one boundary. `pending_lsn` stays 0, so the slot advances only once the stream is confirmed.
- Order matters: `START_REPLICATION` invalidates the slot's exported snapshot, so the reads happen first, on a second regular connection bound to that snapshot.

Interrupted-snapshot recovery:
- The streaming publication stays before the slot, so changes made during the snapshot still decode: pgoutput resolves the publication by name in the historical catalog per change, so a change that predates the publication cannot be decoded (verified on PG17).
- A transient marker publication `<slot>_snapshotting` flags an in-progress snapshot: created before the slot, dropped once the snapshot is flushed. On restart a slot with the marker present is dropped and the whole bootstrap is redone from a fresh consistent point; a slot without it resumes. It is named after the slot because it guards that slot's bootstrap and several pipelines can share one publication. The marker is never passed to `START_REPLICATION`, so steady state keeps a single publication.
- A signal-interrupted snapshot leaves the marker in place and exits before streaming, so the next start redoes it. No rows are missed, because the redo re-reads current state. Consumers must treat `READ` as an upsert.

## Tests

- Unit: `needsInitialSnapshot`, `Stream.hasReadOperation`.
- Integration: `SnapshotSession` over one and several resources, plus reconciliation (an interrupted snapshot recreates the slot from a fresh LSN with the marker still present; a completed one resumes and leaves one publication).
- E2E: seed rows before slot creation, run the snapshot, insert a live row after streaming starts, and assert READ (with the start LSN) for the seeded rows and INSERT for the live one, with no gap or overlap.

## Follow-ups

Filed rather than fixed here: #148 (marker name truncation past 63 bytes), #149 (observability endpoints stay down during the snapshot).